### PR TITLE
Fix watchdog false positive during idle periods

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -48,8 +48,8 @@ WS_RECONNECT_MAX_S = 30.0
 HEALTH_CHECK_INTERVAL_S = 10.0  # reduced from 30s for watchdog responsiveness
 
 # Keyphrase watchdog — detects silent failures and auto-recovers
-WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", "60"))  # 1 min after rearm with no wake event
-WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", "60"))  # 1 min after recovery attempt
+WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", "300"))  # 5 min after rearm with no wake event
+WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", "120"))  # 2 min after recovery attempt
 
 # Battery thresholds (as fractions 0.0–1.0)
 BATTERY_LOW_WARN = 0.20       # yellow LED warning


### PR DESCRIPTION
## Problem
The watchdog timeout of 60s was too aggressive. Between automated test cycles (10-min intervals), the watchdog would fire because no wake events occurred — even though keyphrase was working fine and nobody was talking to Misty.

This caused:
1. Unnecessary soft reset at 60s
2. Sensory reboot at 120s (level 1 → 2 escalation)
3. Misty disconnection during sensory reboot
4. Risk of mic degradation from repeated sensory reboots (#28)

## Fix
- Increased \\WATCHDOG_IDLE_TIMEOUT_S\\ from 60s → 300s (5 min)
- Increased \\WATCHDOG_ESCALATE_TIMEOUT_S\\ from 60s → 120s (2 min)

Both are still configurable via environment variables.

## Why 300s?
- Automated test cycles run every 10 min
- Human conversation gaps are typically <2 min
- 5 min gives ample buffer for both patterns
- Still catches genuine keyphrase failures (just takes longer)

Addresses: #22, #30