### PR TITLE
Fix Unicode encoding error in Windows console logging

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -13,6 +13,7 @@ Architecture:
 """
 
 import os
+import sys
 import json
 import time
 import base64
@@ -65,8 +66,8 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
-        logging.FileHandler("misty_controller.log"),
-        logging.StreamHandler(),
+        logging.FileHandler("misty_controller.log", encoding="utf-8"),
+        logging.StreamHandler(open(sys.stdout.fileno(), mode="w", encoding="utf-8", closefd=False)),
     ],
 )
 logger = logging.getLogger("misty_controller")

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -6,6 +6,7 @@ Serves OpenAI-compatible endpoints for Misty skill integration.
 
 import os
 import re
+import sys
 import json
 import logging
 import subprocess
@@ -24,8 +25,8 @@ logging.basicConfig(
     level=logging.DEBUG,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('orchestration.log'),
-        logging.StreamHandler()
+        logging.FileHandler('orchestration.log', encoding='utf-8'),
+        logging.StreamHandler(open(sys.stdout.fileno(), mode='w', encoding='utf-8', closefd=False))
     ]
 )
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Configures UTF-8 encoding for both FileHandler and StreamHandler in both services. Prevents UnicodeEncodeError when logging messages contain Unicode characters (→, —, ⚠️, ❌) on Windows cp1252 console.

Fixes #23