### PR TITLE
fix: graceful shutdown to prevent mic lock on process kill

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -19,6 +19,8 @@ import time
 import base64
 import wave
 import struct
+import signal
+import atexit
 import logging
 import threading
 import requests
@@ -507,7 +509,9 @@ class MistyController:
     # --- Shutdown ---
 
     def _shutdown(self):
-        """Centralized cleanup on exit."""
+        """Centralized cleanup on exit. Stops keyphrase to release mic lock."""
+        if not self.running:
+            return  # Already shut down
         logger.info("Shutting down...")
         self.running = False
         # Log final battery state
@@ -1068,6 +1072,16 @@ class ControllerAPIHandler(BaseHTTPRequestHandler):
 if __name__ == "__main__":
     controller = MistyController()
     controller._start_time = time.time()
+
+    # Graceful shutdown on SIGTERM/SIGINT — stops keyphrase to prevent mic lock
+    def _signal_handler(signum, frame):
+        logger.info(f"Received signal {signum}, shutting down gracefully...")
+        controller._shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _signal_handler)
+    signal.signal(signal.SIGINT, _signal_handler)
+    atexit.register(controller._shutdown)
 
     # Start test API server in background thread
     ControllerAPIHandler.controller = controller


### PR DESCRIPTION
## Problem
Killing the controller process (e.g., \Stop-Process\, task manager, or service restart) while keyphrase recognition is active leaves the Snapdragon 410 audio subsystem locked. All subsequent recordings return 44 bytes (empty WAV header). Only a full Core+Sensory reboot recovers the mic.

## Root Cause
\_shutdown()\ (which stops keyphrase) was only called on \KeyboardInterrupt\. Process kills via SIGTERM or forced termination bypass this, leaving the keyphrase engine holding the mic lock.

## Fix
- Register \signal.SIGTERM\ and \signal.SIGINT\ handlers that call \_shutdown()\
- Register \texit\ handler as safety net for normal process exit
- Add double-shutdown guard to prevent duplicate cleanup

## Evidence (today's timeline)
| Time | Event | Mic Status |
|------|-------|------------|
| 18:35-18:43 | Old controller running, 7 conversation turns | ✅ 380-414KB |
| 18:44:55 | \Stop-Process -Force\ killed controller | ❌ Mic locked |
| 18:44:56 | New controller started, keyphrase 'active' | ❌ No wake events |
| 18:48:50 | Direct mic test without controller | ❌ 44 bytes |
| 18:49:30 | Full Core+Sensory reboot | ✅ 414KB recovered |

Related: #33