### PR TITLE
fix: increase recording to 6s and tighten watchdog to 90s

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -39,11 +39,11 @@ MISTY_IP = os.getenv("MISTY_IP", "10.0.0.44")
 MISTY_BASE = f"http://{MISTY_IP}"
 MISTY_WS = f"ws://{MISTY_IP}/pubsub"
 ORCHESTRATION_URL = os.getenv("ORCHESTRATION_URL", "http://10.0.0.58:5000")
-RECORDING_DURATION_S = float(os.getenv("RECORDING_DURATION_S", "4"))
+RECORDING_DURATION_S = float(os.getenv("RECORDING_DURATION_S", "6"))
 RECORDING_FILENAME = "foundry_input.wav"
 RESPONSE_FILENAME = "foundry_response.wav"
 REARM_DELAY_S = 3.0  # delay after playback before re-arming wake word (increased from 1.0 for reliability)
-FOLLOWUP_LISTEN_S = float(os.getenv("FOLLOWUP_LISTEN_S", "4"))  # seconds to listen for follow-up
+FOLLOWUP_LISTEN_S = float(os.getenv("FOLLOWUP_LISTEN_S", "5"))  # seconds to listen for follow-up
 FOLLOWUP_TIMEOUT_S = float(os.getenv("FOLLOWUP_TIMEOUT_S", "60"))  # max follow-up window
 FOLLOWUP_SILENCE_THRESHOLD = 1000  # audio bytes below this = silence (no speech)
 WS_RECONNECT_BASE_S = 2.0
@@ -51,8 +51,8 @@ WS_RECONNECT_MAX_S = 30.0
 HEALTH_CHECK_INTERVAL_S = 10.0  # reduced from 30s for watchdog responsiveness
 
 # Keyphrase watchdog — detects silent failures and auto-recovers
-WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", "300"))  # 5 min after rearm with no wake event
-WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", "120"))  # 2 min after recovery attempt
+WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", "90"))  # 90s after rearm with no wake event
+WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", "60"))  # 60s after recovery attempt
 
 # Battery thresholds (as fractions 0.0–1.0)
 BATTERY_LOW_WARN = 0.20       # yellow LED warning


### PR DESCRIPTION
## Problems
1. **Users cut off mid-sentence** (issue #20): Fixed 4s recording too short for natural questions. STT shows truncated input ('Do you know what the biggest?' instead of full question).
2. **Keyphrase silent failures take too long to recover** (issue #22): 300s watchdog means user waits 5 minutes before auto-recovery.

## Changes
| Setting | Before | After | Rationale |
|---------|--------|-------|-----------|
| Recording duration | 4s | 6s | Captures full questions; STT VAD trims silence |
| Follow-up listen | 4s | 5s | Longer follow-up responses |
| Watchdog idle timeout | 300s | 90s | Faster keyphrase recovery |
| Watchdog escalation | 120s | 60s | Quicker escalation steps |

## Evidence
From live testing (7 follow-up turns):
- 'Do you know what the biggest?' — clearly cut off at 4s
- 'What is the margins making this year?' — garbled due to truncation

STT VAD already removes trailing silence, so 6s recording doesn't increase pipeline time for short utterances.