### PR TITLE
feat: adaptive response length + VAD-controlled recording

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,18 +15,16 @@ The robot's hardware (Snapdragon 820 + 410, 2 GB RAM) cannot run inference — 2
 
 ```
 [Misty Controller]                           [Orchestration Service]
-  Laptop mic → openWakeWord (optional)           Foundry Local
-  OR WebSocket ← KeyPhraseRecognized               ├─ STT (faster-whisper)
-  REST → StartRecordingAudio (6s)                  ├─ LLM (Phi-3.5-mini)
-  REST → GetAudio (base64)                         └─ TTS (Kokoro / pyttsx3)
-  HTTP POST /api/orchestrate ───────────────────►
+  Laptop mic → openWakeWord                      Foundry Local
+  Laptop mic → sounddevice recording               ├─ STT (faster-whisper)
+  (Misty recording for tally light only)           ├─ LLM (Phi-3.5-mini)
+  HTTP POST /api/orchestrate ───────────────────►  └─ TTS (Kokoro / pyttsx3)
   HTTP GET /api/audio/<file> ◄──────────────────
   REST → SaveAudio (base64, ImmediatelyApply)
-  ┌─ Follow-up: listen 5s, send to orchestrate
+  ┌─ Follow-up: listen via laptop mic, send to orchestrate
   │  Speech detected? → repeat (up to 90s, max 12 turns)
   │  Silence? → fall through to re-arm
-  └→ REST → StartKeyPhraseRecognition (re-arm)
-      + Resume laptop wake word listener
+  └→ Resume laptop wake word listener
 ```
 
 ### Locked model stack (v1)
@@ -201,7 +199,7 @@ The Snapdragon 410 sensory services silently stop firing `KeyPhraseRecognized` W
   3. **Full reboot** (+60s): red LED → `POST /api/reboot {"Core": true, "SensoryServices": true}`
 
 **Future alternatives under consideration:**
-- **openWakeWord on companion laptop** (MIT, no signup needed): Works with Misty's mic via REST polling but accelerates Snapdragon 410 mic degradation (RMS drops to 0 after ~100 poll cycles). **Next approach: use the laptop's own microphone** for wake word detection, only using Misty's mic for the actual 6s conversation recording. Code preserved in git tag `wake-engine-experiment`. See #44.
+- **openWakeWord on companion laptop** (MIT, no signup needed): **Implemented** — laptop mic handles both wake word detection AND audio recording for STT. Misty's mic is only used for the tally light indicator. This fully bypasses Snapdragon 410 mic issues. Enable with `USE_LAPTOP_WAKE_WORD=true`.
 - Picovoice Porcupine: Requires commercial email signup — blocked for personal/hobbyist use.
 - Touch-based trigger using Misty's capacitive sensors
 
@@ -209,7 +207,7 @@ The Snapdragon 410 sensory services silently stop firing `KeyPhraseRecognized` W
 
 Since the keyphrase engine reliably fails after ~2 conversation cycles, the controller now performs a **proactive reboot before failure occurs**:
 
-1. After `PROACTIVE_REBOOT_AFTER_CYCLES` successful conversations (default: 2), the controller triggers a reboot instead of a normal re-arm
+1. After `PROACTIVE_REBOOT_AFTER_CYCLES` successful conversations (default: 5), the controller triggers a reboot instead of a normal re-arm
 2. Misty announces *"I need a quick reset. Be right back!"* via TTS
 3. Full Core+Sensory reboot is issued (~60-90s downtime)
 4. Controller polls `/api/device` until Misty is back, then reconnects WebSocket and re-arms keyphrase
@@ -243,16 +241,19 @@ Foundry Local uses OpenAI-compatible endpoints but with some quirks:
 
 ## Key Conventions
 
-- **Latency SLO**: p50 < 3s, p95 < 6s end-to-end (aspirational — currently achieving ~23s, see #21). The orchestration service logs per-stage timing: `[Pipeline Xms] STT=X LLM=X TTS=X history=N`. Measured breakdown: STT ~420ms, LLM ~1200ms, TTS ~6000ms. TTS scales linearly with response length — keep `max_tokens` moderate (currently 40).
-- **Misty controller state machine**: DISCONNECTED → IDLE → RECORDING → PROCESSING → PLAYING → [LISTENING → PROCESSING → PLAYING →]* REARMING (soft re-arm ~3s) → IDLE. After every `PROACTIVE_REBOOT_AFTER_CYCLES` (default 2) successful conversations: → REBOOTING (announce → reboot → poll → reconnect) → IDLE. After each response, enters LISTENING state (cyan LED) for up to 90s of follow-up conversation (max 12 turns) without requiring wake word. Silence ends the loop. Re-arm uses soft reset only (WS re-subscribe + keyphrase restart). IDLE ↔ CHARGING (auto-enters at 10% battery, exits at 25%+charging). All state transitions are logged.
+- **Latency SLO**: p50 < 3s, p95 < 6s end-to-end (aspirational — currently achieving ~6-7s, see #21). The orchestration service logs per-stage timing: `[Pipeline Xms] STT=X LLM=X TTS=X history=N`. Measured breakdown: STT ~400ms, LLM ~1200ms, TTS ~5000ms. TTS scales linearly with response length — keep `max_tokens` moderate (currently 60).
+- **Misty controller state machine**: DISCONNECTED → IDLE → RECORDING → PROCESSING → PLAYING → [LISTENING → PROCESSING → PLAYING →]* REARMING → IDLE. After every `PROACTIVE_REBOOT_AFTER_CYCLES` (default 5) successful conversations: → REBOOTING (announce → reboot → poll → reconnect) → IDLE. After each response, enters LISTENING state (cyan LED) for up to 90s of follow-up conversation (max 12 turns) without requiring wake word. Silence ends the loop. Re-arm uses soft reset only (WS re-subscribe + keyphrase restart). IDLE ↔ CHARGING (auto-enters at 10% battery, exits at 25%+charging). All state transitions are logged.
+- **Audio source**: The laptop mic (via sounddevice) is the primary audio source for both wake word detection and STT recording. Misty's recording still runs during conversations for the tally light indicator, but the audio is not used for STT. Falls back to Misty's mic if laptop recording fails.
 - **Wake word detection**: Two modes (configurable via `USE_LAPTOP_WAKE_WORD` env var):
-  - **Laptop mic** (recommended): Uses `sounddevice` + openWakeWord on the companion laptop. Zero Misty mic usage for wake detection. Auto-pauses during conversation (self-wake prevention). Enable with `USE_LAPTOP_WAKE_WORD=true`.
-  - **Misty keyphrase** (default/fallback): Built-in "Hey Misty" via Snapdragon 410. Subject to silent failure after ~2 cycles (#22). Watchdog auto-recovers.
-- **LED color scheme**: 🟢 Green = ready/idle, 🟠 Orange = recording, 🔵 Blue = processing, 🟣 Purple = playing response, 🩵 Cyan = follow-up listening, 🟡 Yellow = watchdog soft reset / low battery warning, ⚫ Off = charging mode, 🔴 Red = error / watchdog full reboot.
+  - **Laptop mic** (recommended, default): Uses `sounddevice` + openWakeWord on the companion laptop. Zero Misty mic usage for wake detection. Auto-pauses during conversation (self-wake prevention). Enable with `USE_LAPTOP_WAKE_WORD=true`.
+  - **Misty keyphrase** (fallback): Built-in "Hey Misty" via Snapdragon 410. Subject to silent failure after ~2 cycles (#22). Watchdog auto-recovers.
+- **LED color scheme**: 🟢 Green = ready/idle AND recording active ("speak now"), 🟠 Orange = wake word heard (preparing), 🔵 Blue = processing, 🟣 Purple = playing response, 🩵 Cyan = follow-up listening, 🟡 Yellow = watchdog soft reset / low battery warning, ⚫ Off = charging mode, 🔴 Red = error / watchdog full reboot.
+- **TTS phrases**: At startup, the controller generates TTS audio via `/api/tts` and uploads to Misty: `greeting_whatsup.wav` ("What's up baby?" — played on wake word) and `thinking.wav` ("Let me think about that." — played during processing).
 - **Keyphrase watchdog**: Detects silent keyphrase failure (Snapdragon 410 bug, see #22) and auto-recovers with 3-level escalation: soft reset (90s) → second soft reset (+60s) → full reboot (+60s). **Never uses sensory-only reboot** (permanently breaks mic, see #33). Only active in IDLE state. Configurable via `WATCHDOG_IDLE_TIMEOUT_S` and `WATCHDOG_ESCALATE_TIMEOUT_S` env vars. Health check runs every 10s.
-- **TTS fallback chain**: Kokoro-ONNX is primary TTS (speed 1.4x). If unavailable, pyttsx3 (Windows SAPI5) is used as fallback. Both are lazily initialized. The API response includes `"ttsFallback": true` when fallback is used.
+- **TTS fallback chain**: Kokoro-ONNX is primary TTS (speed 1.0x). If unavailable, pyttsx3 (Windows SAPI5) is used as fallback. Both are lazily initialized. The API response includes `"ttsFallback": true` when fallback is used.
 - **Conversation history**: Maintained in-memory, capped at the last 8 messages (4 turns). System prompt is prepended on every call but not stored in history. Context budget: MAX_CONTEXT_CHARS=5000. See #19 for smarter history approaches.
-- **System prompt**: Instructs Misty to reply in 1-2 sentences, ~20 words. LLM (Phi-3.5-mini) often exceeds this — `max_tokens=40` and post-LLM truncation (25 words / 2 sentences) enforce the limit.
+- **System prompt**: Misty has a sassy personality with farm life context (lives with Tammy, Burke, dogs Percy and Granny). Instructs her to reply in 2-3 sentences. LLM (Phi-3.5-mini) often exceeds this — `max_tokens=60` and post-LLM truncation (35 words / 3 sentences) enforce the limit.
+- **Adaptive response modes**: The orchestration service classifies user intent into modes: `short` (default, 60 tokens / 35 words), `summary` (stories/recipes/explanations, 80 tokens / 50 words), and `continuation` (follow-ups to summaries). Intent classification uses regex pattern matching on transcribed text.
 - **Configuration**: The orchestration service reads from `.env` (copy `.env.example`). The Misty controller reads `MISTY_IP`, `ORCHESTRATION_URL`, and `USE_LAPTOP_WAKE_WORD` from environment.
 - **Error responses**: The orchestration service returns structured JSON errors with a `status` field (`"ok"` or `"error"`) and an `error` code (e.g., `"timeout"`, `"stt_failure"`, `"model_load_failure"`).
 - **Python version**: Use Python 3.13. Note that Python 3.14 may also be installed — always use `python -m pip` to target the correct version.
@@ -263,12 +264,12 @@ Foundry Local uses OpenAI-compatible endpoints but with some quirks:
 | Issue | Summary | Status |
 |-------|---------|--------|
 | #33 | **CRITICAL**: Sensory-only reboot permanently breaks mic until physical power cycle | Closed — sensory reboot removed from all code paths |
-| #44 | Replace Misty keyphrase with laptop-based wake word (openWakeWord) | In progress — laptop mic listener implemented, enable with `USE_LAPTOP_WAKE_WORD=true` |
-| #22 | Keyphrase silently fails after ~2 conversation cycles — watchdog + proactive reboot recover. Laptop wake word bypasses this entirely. | Open |
+| #44 | Replace Misty keyphrase with laptop-based wake word (openWakeWord) | Implemented — laptop mic handles wake word AND STT recording, Misty mic for tally light only |
+| #22 | Keyphrase silently fails after ~2 conversation cycles — watchdog + proactive reboot recover. Laptop wake word bypasses this entirely. | Open (mitigated by laptop mic) |
 | #28 | Keyphrase re-arm: sensory reboot approach **abandoned** (breaks mic, see #33) | Closed — reverted to soft re-arm |
 | #27 | STT accuracy: beam_size=5 + VAD applied, whisper-tiny still garbles follow-ups | Open |
-| #21 | End-to-end latency ~2s follow-ups, ~5s first turn (TTS cold start) — target <3s | Improved |
-| #24 | LLM ignores brevity — max_tokens=40, post-LLM truncation to 25 words/2 sentences | Mitigated |
-| #20 | Recording increased from 4s to 6s (PR #42) — still fixed-duration, no VAD | Mitigated |
+| #21 | End-to-end latency ~6-7s first turn, ~7s follow-ups (TTS dominant) — target <3s | Improved |
+| #24 | LLM ignores brevity — max_tokens=60, post-LLM truncation to 35 words/3 sentences | Mitigated |
+| #20 | Recording increased from 4s to 6s (PR #42) — VAD-controlled dynamic recording via laptop mic | Mitigated |
 | #19 | Conversation history capped at 8 messages (4 turns) to manage latency | Mitigated |
 | #23 | Unicode arrow in log messages crashes on Windows cp1252 console | Fixed |

--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@ This project integrates a **Misty II** social robot with **Microsoft Foundry Loc
 ┌──────────────────────────────┐         ┌──────────────────────────────────┐
 │        Misty II Robot        │         │     Windows Companion Device     │
 │                              │  Wi-Fi  │                                  │
-│  "Hey, Misty!" (wake word)   │◄───────►│  Misty Controller (Python)      │
-│  Microphone / Speakers       │  REST + │    ├─ WebSocket event listener   │
-│  LED / Display               │  WS     │    ├─ REST API commands          │
+│  Speakers / LED / Display    │◄───────►│  Misty Controller (Python)      │
+│  Tally light (recording      │  REST + │    ├─ WebSocket event listener   │
+│    indicator only)           │  WS     │    ├─ REST API commands          │
 │                              │         │    └─ State machine (IDLE →      │
 │  Controlled entirely via     │         │        RECORDING → PROCESSING →  │
 │  REST API + WebSocket from   │         │        PLAYING → LISTENING →     │
 │  companion device            │         │        REARMING)                 │
+│                              │         │  Laptop Microphone (primary)     │
+│                              │         │    ├─ Wake word (openWakeWord)   │
+│                              │         │    └─ Speech recording (STT)     │
 │                              │         │  Orchestration Service (Flask)   │
 │                              │         │    ├─ STT  (faster-whisper)      │
 │                              │         │    ├─ LLM  (Phi-3.5-mini)  ───► Foundry Local
@@ -33,7 +36,7 @@ This project integrates a **Misty II** social robot with **Microsoft Foundry Loc
 └──────────────────────────────┘         └──────────────────────────────────┘
 ```
 
-**Pipeline flow:** Wake word (WebSocket event) → Record via REST → Download audio → `POST /api/orchestrate` → STT → LLM → TTS → Upload audio to Misty → Playback → Re-arm wake word
+**Pipeline flow:** Wake word (laptop mic + openWakeWord) → Record via laptop mic (Misty tally light only) → `POST /api/orchestrate` → STT → LLM → TTS → Upload audio to Misty → Playback → Re-arm wake word
 
 > **Note:** We use the REST API + WebSocket approach (code runs on the laptop) instead of Misty's on-robot JavaScript SDK. The skill runtime proved unreliable — see [Implementation Guide](docs/IMPLEMENTATION_GUIDE.md) for details.
 
@@ -51,7 +54,8 @@ Misty II's onboard Snapdragon 820 + 410 (2 GB RAM) cannot run modern inference w
 │   │
 │   └── windows-orchestration/          # Python services on companion device
 │       ├── orchestration_service.py    #   STT → LLM → TTS pipeline (~500 LOC)
-│       ├── misty_controller.py         #   REST+WebSocket controller for Misty (~800 LOC)
+│       ├── misty_controller.py         #   REST+WebSocket controller for Misty (~1300 LOC)
+│       ├── wake_word_listener.py       #   Laptop mic wake word + recording (~450 LOC)
 │       ├── requirements.txt            #   Dependencies (Flask, requests, websocket-client, faster-whisper)
 │       └── .env.example                #   Configuration template
 │
@@ -111,7 +115,7 @@ The orchestration service is configured via environment variables (copy `.env.ex
 | `FOUNDRY_API_TIMEOUT` | `5.0` | Per-request timeout (seconds) for Foundry API calls |
 | `SERVICE_TIMEOUT` | `6.0` | Overall orchestration pipeline timeout (seconds) |
 | `KOKORO_VOICE` | `af_heart` | Kokoro TTS voice ID |
-| `SYSTEM_PROMPT` | *(see below)* | System prompt for the LLM; if unset, uses the built-in Misty persona prompt |
+| `SYSTEM_PROMPT` | *(see below)* | System prompt for the LLM; if unset, uses the built-in Misty persona prompt (sassy robot on a farm with Tammy, Burke, and dogs Percy & Granny) |
 | `MAX_USER_CHARS` | `400` | Maximum characters for a single transcribed user utterance. Longer inputs are truncated before LLM inference to reduce token count and latency. |
 | `MAX_CONTEXT_CHARS` | `3000` | Maximum total characters across all messages (system prompt + history) sent to the LLM. Oldest turns are removed first; the system prompt and latest user message are always preserved. Set to `0` to disable. |
 
@@ -143,15 +147,26 @@ Invoke-RestMethod -Uri http://localhost:5000/api/health
 python misty_controller.py
 ```
 
-The Misty controller connects to Misty via WebSocket and REST API — no skill deployment needed. Misty's LED turns green when ready. Say **"Hey, Misty!"** followed by your question. After Misty responds, she'll keep listening (cyan LED) for up to 60 seconds — just keep talking without saying the wake word again. Silence ends the conversation and re-arms the wake word.
+The Misty controller connects to Misty via WebSocket and REST API — no skill deployment needed. Misty's LED turns green when ready. Say **"Hey, Misty!"** followed by your question. Misty says "What's up baby?" and her LED turns green — that's your cue to speak. After processing ("Let me think about that..."), she responds and keeps listening (cyan LED) for up to 90 seconds — just keep talking without saying the wake word again. Silence ends the conversation and re-arms the wake word.
+
+### Personality
+
+Misty is a sassy little robot with big personality. She lives on a farm with Tammy, Burke (Tammy's husband), and two dogs — Percy and Granny. She loves sunshine and playing ball with the dogs. Her responses are witty, cheeky, and playful — like a fun friend who always has a comeback.
+
+### Audio Architecture
+
+- **Wake word**: Detected via laptop microphone using openWakeWord (not Misty's onboard mic)
+- **Speech recording**: Captured from the laptop mic via sounddevice (16kHz, 16-bit mono)
+- **Misty's mic**: Only used for the tally light indicator during recording — audio data is not used for STT
+- **TTS phrases**: "What's up baby?" (greeting) and "Let me think about that." (thinking) are generated via Kokoro TTS at startup and uploaded to Misty
 
 ### Expressive Behavior
 
 During conversations, Misty uses head movement and face animations to signal her state:
-- **Listening**: Looks up for eye contact, wide-eyed attentive face
-- **Processing**: Tilts head to the side, thoughtful expression
-- **Speaking**: Faces forward, animated expression
-- **Follow-up**: Slight head tilt, warm expectant face
+- **Listening**: Green LED, tally light on — "speak now"
+- **Processing**: Blue LED, tilts head to the side, says "Let me think about that"
+- **Speaking**: Purple LED, faces forward, animated expression
+- **Follow-up**: Cyan LED, slight head tilt, warm expectant face
 - Head recenters when re-arming for the next wake word
 
 ### On-Robot Skills — Cleaned Up
@@ -164,9 +179,9 @@ Skill metadata was backed up to `misty-skills-backup/` before deletion.
 
 Misty's sensory services (Snapdragon 410) can silently stop firing wake word events — a known firmware bug with no programmatic detection. The controller includes an automatic watchdog that detects this and self-recovers:
 
-1. **Soft reset** (2 min): 🟡 Yellow LED flash → cancel skills → restart keyphrase
-2. **Sensory reboot** (+1 min): 🔴 Red LED → reboot sensory services only
-3. **Full reboot** (+1 min): 🔴 Red LED → full system reboot
+1. **Soft reset** (90s): 🟡 Yellow LED flash → cancel skills → restart keyphrase
+2. **Second soft reset** (+60s): 🟡 Darker yellow → repeat
+3. **Full reboot** (+60s): 🔴 Red LED → full system reboot (Core+Sensory)
 
 The watchdog only activates in IDLE state. Configure timeouts via `WATCHDOG_IDLE_TIMEOUT_S` and `WATCHDOG_ESCALATE_TIMEOUT_S` environment variables.
 
@@ -205,13 +220,14 @@ See [IMPLEMENTATION_SUMMARY.md](docs/IMPLEMENTATION_SUMMARY.md) for the full bui
 
 | Issue | Summary |
 |-------|---------|
-| [#28](https://github.com/tammym-demos/misty_upgrade/issues/28) | Keyphrase re-arm: proactive sensory reboot after each conversation (~20s reset) |
-| [#27](https://github.com/tammym-demos/misty_upgrade/issues/27) | STT accuracy: beam_size=5 + VAD applied, whisper-tiny still garbles follow-ups |
-| [#22](https://github.com/tammym-demos/misty_upgrade/issues/22) | Keyphrase silently fails after conversation — mitigated by #28 sensory reboot |
-| [#21](https://github.com/tammym-demos/misty_upgrade/issues/21) | End-to-end latency ~23s (target <6s) — TTS is 82% of pipeline |
-| [#24](https://github.com/tammym-demos/misty_upgrade/issues/24) | LLM ignores brevity instructions, generates verbose responses |
-| [#20](https://github.com/tammym-demos/misty_upgrade/issues/20) | Fixed 4s recording — needs voice activity detection |
-| [#19](https://github.com/tammym-demos/misty_upgrade/issues/19) | Conversation history needs smarter management for latency |
+| [#44](https://github.com/tammym-demos/misty_upgrade/issues/44) | Laptop mic for wake word + STT recording — implemented, Misty mic for tally light only |
+| [#28](https://github.com/tammym-demos/misty_upgrade/issues/28) | Keyphrase re-arm: sensory reboot abandoned (breaks mic) — soft re-arm only |
+| [#27](https://github.com/tammym-demos/misty_upgrade/issues/27) | STT accuracy: beam_size=5, whisper-tiny still garbles some follow-ups |
+| [#22](https://github.com/tammym-demos/misty_upgrade/issues/22) | Keyphrase silently fails — mitigated by laptop wake word + proactive reboot |
+| [#21](https://github.com/tammym-demos/misty_upgrade/issues/21) | End-to-end latency ~6-7s (target <3s) — TTS is dominant |
+| [#24](https://github.com/tammym-demos/misty_upgrade/issues/24) | LLM ignores brevity — max_tokens=60, post-LLM truncation to 35 words |
+| [#20](https://github.com/tammym-demos/misty_upgrade/issues/20) | VAD-controlled dynamic recording via laptop mic (6s minimum) |
+| [#19](https://github.com/tammym-demos/misty_upgrade/issues/19) | Conversation history capped at 8 messages (4 turns) |
 
 ---
 

--- a/docs/test-questions-richer-responses.md
+++ b/docs/test-questions-richer-responses.md
@@ -1,15 +1,19 @@
 # Misty Test Questions — Richer Responses Edition
 
-Updated for the richer responses changes in PR #45. Key differences from the original `test-questions.md`:
+Updated for the richer responses changes in PR #45 and adaptive conversations (issue #46). Key differences from the original `test-questions.md`:
 
 | Setting | Before | After |
 |---------|--------|-------|
-| Response length | ≤10 words, 1 sentence | ~20 words, 1-2 sentences |
-| max_tokens | 20 | 40 |
+| Response length (short) | ≤10 words, 1 sentence | ~20 words, 1-2 sentences |
+| Response length (summary) | N/A | ~40 words, 2-3 sentences + "Want more?" |
+| Response length (continuation) | N/A | ~40 words, 2-3 sentences per chunk |
+| max_tokens (short / summary) | 20 | 40 / 80 |
+| Recording duration | Fixed 6s | VAD-controlled: 3-15s (adaptive) |
 | Follow-up window | 60s | 90s |
 | Follow-up turn cap | unlimited | 12 turns |
 | Conversation history | 4 messages (2 turns) | 8 messages (4 turns) |
 | Wake word (laptop mode) | "Hey Misty" on robot | "Hey Jarvis" on laptop mic |
+| Intent detection | None | Story/recipe/explain/continuation patterns |
 
 ---
 
@@ -156,7 +160,7 @@ Tests unique to the laptop mic wake word mode:
 | LED Color | State | Duration |
 |-----------|-------|----------|
 | 🟢 Green | Ready — listening for wake word | Until triggered |
-| 🟠 Orange | Recording your question | 6 seconds |
+| 🟠 Orange | Recording your question | 3-15s (VAD-controlled) |
 | 🔵 Blue | Processing (STT → LLM → TTS) | ~2-5s |
 | 🟣 Purple | Playing response | Varies by response length |
 | 🩵 Cyan | Follow-up listening | Up to 90s / 12 turns |
@@ -164,7 +168,9 @@ Tests unique to the laptop mic wake word mode:
 | 🔴 Red | Error | Check logs |
 
 **Response time**: ~2s for follow-ups, ~5s for first turn (TTS cold start)
-**Response length**: 1-2 sentences, ~20 words (max_tokens=40, post-truncation at 25 words)
+**Response length (short)**: 1-2 sentences, ~20 words (max_tokens=40, truncation at 25 words)
+**Response length (summary/continuation)**: 2-3 sentences, ~40 words (max_tokens=80, truncation at 50 words)
+**Recording duration**: VAD-controlled — 3s minimum, up to 15s for long utterances
 **Follow-up window**: 90 seconds or 12 turns, whichever comes first
 **History**: Misty remembers the last 4 turns (8 messages) of conversation
 
@@ -180,3 +186,102 @@ Tests unique to the laptop mic wake word mode:
 | Laptop wake word false positives | Threshold too low | Increase threshold: `WAKE_WORD_THRESHOLD=0.7` |
 | Laptop wake word misses | Threshold too high or mic issue | Decrease threshold or check `sounddevice` mic selection |
 | Self-wake (Misty triggers herself) | Pause/resume not working | Check `wake_word_listener.py` pause/resume flow in logs |
+
+---
+
+## 9. Adaptive Response Length — Summary Mode
+
+Tests for requests that need longer responses (stories, recipes, explanations):
+
+46. "Tell me a bedtime story."
+    - **Expect**: 2-3 sentence story teaser (~40 words), ends with "Want to hear more?"
+47. "Give me a recipe for chicken pot pie."
+    - **Expect**: Key ingredients + 1-sentence method overview, ends with "Want to hear more?"
+48. "Explain how gravity works."
+    - **Expect**: 2-3 sentence clear summary, ends with "Want to hear more?"
+49. "Make up a story about a robot who goes to space."
+50. "How do I make chocolate chip cookies?"
+51. "Tell me about the solar system."
+
+**What to watch for**:
+- Response should be noticeably longer than short mode (~40 words vs ~20)
+- Should include "Want to hear more?" or similar continuation offer
+- TTS should take ~4-6s (acceptable tradeoff for meaningful content)
+- LED/face behavior same as normal response
+
+## 10. Continuation Chains
+
+After getting a summary response, test chunked continuation:
+
+52. [After #46 story] → "Yes, tell me more."
+    - **Expect**: Next 2-3 sentences of the story, may end with "Want more?"
+53. [After #52] → "Keep going."
+    - **Expect**: Another chunk of story
+54. [After #47 recipe] → "Yes, what are the steps?"
+    - **Expect**: Method/steps portion of recipe
+55. [After #48 explanation] → "Go on."
+    - **Expect**: Deeper explanation, more detail
+56. [Mid-chain] → "Actually, tell me a joke."
+    - **Expect**: Breaks out of continuation, returns to short mode (~20 words, punchy joke)
+
+**What to watch for**:
+- Continuation should flow naturally (LLM has context from history)
+- Each chunk should be ~40 words, not a repeat of the summary
+- Topic change should reset cleanly to short mode
+- `responseMode` in logs should show: summary → continuation → continuation → short
+
+## 11. VAD Dynamic Recording — Short Utterances
+
+Test that short questions end recording early (should save ~3s per turn):
+
+57. "Hi." (very short — recording should stop at ~3s)
+58. "What's your name?" (~1.5s of speech)
+59. "Yes." (continuation, ~0.5s of speech)
+60. "No thanks." (~1s of speech)
+61. "Tell me a joke." (~1.5s of speech)
+
+**What to watch for**:
+- Orange LED (recording) duration should be shorter than the usual 6s
+- Total turn time should be noticeably faster (~5s instead of ~8s)
+- Logs should show "Speech monitor: end of utterance detected" with elapsed < 6s
+- Responses should still be accurate (STT captures full utterance)
+
+## 12. VAD Dynamic Recording — Long Utterances
+
+Test that long questions extend recording past 6s:
+
+62. "Tell me a bedtime story about a princess who lives in a castle by the sea and has a pet dragon."
+63. "I want you to recommend a recipe for chicken pot pie with a flaky crust and lots of vegetables inside."
+64. "Can you explain to me how the internet works, like how does a website get from a server to my computer?"
+65. "My favorite thing about today was going to the park with my dog and we played fetch for like an hour."
+
+**What to watch for**:
+- Recording should extend past 6s (up to 15s max)
+- Logs should show speech detected with recording > 6s
+- STT should capture the **complete** sentence (not cut off)
+- Misty's response should address the full question, not just the beginning
+
+## 13. Mixed Scenario — Full Adaptive Conversation
+
+A realistic end-to-end flow testing all features together:
+
+66. [Wake word] → "How are you today?" (short mode, VAD stops early ~3s)
+67. → "Tell me a bedtime story." (summary mode, VAD stops ~3s)
+68. → "Yes, tell me more." (continuation, VAD stops ~1.5s)
+69. → "What happens next?" (continuation, VAD stops ~2s)
+70. → "That was fun. What's your favorite color?" (topic change → short mode)
+
+**What to watch for**:
+- Smooth transitions between modes (check logs for `responseMode`)
+- VAD-controlled recording adapts to each utterance length
+- No awkward pauses or timing issues
+- Continuation flows naturally through conversation history
+- Topic change resets response length cleanly
+
+## 14. Edge Cases
+
+71. Say nothing after wake word — VAD should exit at ~4s (no speech timeout)
+72. Whisper a question very quietly — tests VAD RMS threshold sensitivity
+73. Say "yes" without a prior summary — should stay in short mode (not continuation)
+74. Very long continuous speech (>15s) — recording should hard-cap at 15s
+75. "Tell me something interesting." — ambiguous, should default to short mode

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -304,34 +304,37 @@ class MistyController:
         return result is not None and result.get("status") == "Success"
 
     def _upload_greeting(self):
-        """Generate 'What's up baby?' TTS and upload to Misty as greeting audio."""
-        try:
-            # Ask orchestration service to generate TTS
-            response = requests.post(
-                f"{ORCHESTRATION_URL}/api/tts",
-                json={"text": "What's up baby?"},
-                timeout=15.0,
-            )
-            if response.status_code != 200:
-                logger.warning(f"Greeting TTS failed: HTTP {response.status_code}")
-                return
+        """Generate TTS phrases and upload to Misty as named audio files."""
+        phrases = {
+            "greeting_whatsup.wav": "What's up baby?",
+            "thinking.wav": "Let me think about that.",
+        }
+        for filename, text in phrases.items():
+            try:
+                response = requests.post(
+                    f"{ORCHESTRATION_URL}/api/tts",
+                    json={"text": text},
+                    timeout=15.0,
+                )
+                if response.status_code != 200:
+                    logger.warning(f"TTS for '{filename}' failed: HTTP {response.status_code}")
+                    continue
 
-            audio_data = response.content
-            if len(audio_data) < 100:
-                logger.warning(f"Greeting TTS too small: {len(audio_data)} bytes")
-                return
+                audio_data = response.content
+                if len(audio_data) < 100:
+                    logger.warning(f"TTS for '{filename}' too small: {len(audio_data)} bytes")
+                    continue
 
-            # Upload to Misty as a named audio file
-            audio_b64 = base64.b64encode(audio_data).decode("ascii")
-            result = self.misty_post("/api/audio", {
-                "FileName": "greeting_whatsup.wav",
-                "Data": audio_b64,
-                "ImmediatelyApply": False,
-                "OverwriteExisting": True,
-            })
-            logger.info(f"Greeting audio uploaded to Misty ({len(audio_data)} bytes)")
-        except Exception as e:
-            logger.warning(f"Failed to upload greeting: {e}")
+                audio_b64 = base64.b64encode(audio_data).decode("ascii")
+                self.misty_post("/api/audio", {
+                    "FileName": filename,
+                    "Data": audio_b64,
+                    "ImmediatelyApply": False,
+                    "OverwriteExisting": True,
+                })
+                logger.info(f"Uploaded '{filename}' to Misty ({len(audio_data)} bytes)")
+            except Exception as e:
+                logger.warning(f"Failed to upload '{filename}': {e}")
 
     def check_orchestration_health(self) -> bool:
         try:
@@ -997,9 +1000,9 @@ class MistyController:
         self.display_image("e_Contempt.jpg")  # one eyebrow raised — "hmm, let me think..."
         self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)  # tilt head — pondering
 
-        # Play a wondering sound so the user knows Misty heard them
+        # Play thinking phrase so the user knows Misty heard them
         try:
-            self.misty_post("/api/audio/play", {"FileName": "s_Amazement.wav", "Volume": 25})
+            self.misty_post("/api/audio/play", {"FileName": "thinking.wav", "Volume": 40})
         except Exception as e:
             logger.debug(f"[Turn {turn}] Thinking sound failed: {e}")
 

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -937,11 +937,17 @@ class MistyController:
         # Small delay for Misty to finalize the file
         time.sleep(0.5)
 
-        # 3. Retrieve recorded audio — thinking face
+        # 3. Retrieve recorded audio — thinking face + "hmm" sound
         self.set_state(State.PROCESSING)
         self.set_led(0, 0, 255)  # blue = processing
         self.display_image("e_ContentRight.jpg")  # looking to the side — "thinking"
         self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)  # tilt head — pondering
+
+        # Play a thinking sound so the user knows Misty heard them
+        try:
+            self.misty_post("/api/audio/play", {"FileName": "s_PhraseHello.wav", "Volume": 25})
+        except Exception as e:
+            logger.debug(f"[Turn {turn}] Thinking sound failed: {e}")
 
         audio_b64 = self.get_audio_base64(RECORDING_FILENAME)
         if not audio_b64:
@@ -962,11 +968,11 @@ class MistyController:
         Returns True if speech was detected and a response was played,
         False if no speech was detected (empty STT).
         """
-        # Processing state — thinking
+        # Processing state — deep thinking
         self.set_state(State.PROCESSING)
         self.set_led(0, 0, 255)  # blue = processing
-        self.display_image("e_ContentRight.jpg")  # thinking face
-        self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)  # head tilt — pondering
+        self.display_image("e_SystemCamera.jpg")  # concentrated/processing face
+        self.move_head(pitch=0, roll=-5, yaw=-15, velocity=30)  # slight head tilt other way — pondering
 
         # Send to orchestration service
         response = requests.post(

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -901,17 +901,16 @@ class MistyController:
             self.misty_post("/api/audio/record/stop")  # belt-and-suspenders cleanup
             time.sleep(0.5)  # minimal delay — no keyphrase to release
 
-        # Play a short "ready" chime so the user knows Misty is listening.
-        # Critical in laptop wake word mode: there's a ~3s gap between saying
-        # the wake word and when recording starts (keyphrase release delay).
-        # Without this cue, users speak during the gap and Misty misses it.
+        # Play a short "ready" chime so the user knows Misty is preparing.
+        # After the chime, LED changes to bright green = "speak now".
         try:
             self.misty_post("/api/audio/play", {"FileName": "s_Awe3.wav", "Volume": 30})
             time.sleep(0.8)  # let the chime play before recording starts
         except Exception as e:
             logger.debug(f"[Turn {turn}] Ready chime failed: {e}")
 
-        # 2. Record audio — use VAD-controlled duration if laptop listener available
+        # 2. Record audio — bright green LED + tally light = "I'm listening, speak now!"
+        self.set_led(0, 255, 0)  # green = recording active, speak now
         self.start_recording(RECORDING_FILENAME)
         record_start = time.time()
         

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -920,7 +920,7 @@ class MistyController:
             speech_ended = threading.Event()
             self._wake_word_listener.start_speech_monitor(
                 on_speech_end=lambda: speech_ended.set(),
-                min_duration=3.0,
+                min_duration=RECORDING_DURATION_S,  # at least the standard duration
                 max_duration=15.0,
             )
             speech_ended.wait(timeout=15.0)
@@ -937,15 +937,15 @@ class MistyController:
         # Small delay for Misty to finalize the file
         time.sleep(0.5)
 
-        # 3. Retrieve recorded audio — thinking face + "hmm" sound
+        # 3. Retrieve recorded audio — wondering face + thinking sound
         self.set_state(State.PROCESSING)
         self.set_led(0, 0, 255)  # blue = processing
-        self.display_image("e_ContentRight.jpg")  # looking to the side — "thinking"
+        self.display_image("e_Contempt.jpg")  # one eyebrow raised — "hmm, let me think..."
         self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)  # tilt head — pondering
 
-        # Play a thinking sound so the user knows Misty heard them
+        # Play a wondering sound so the user knows Misty heard them
         try:
-            self.misty_post("/api/audio/play", {"FileName": "s_PhraseHello.wav", "Volume": 25})
+            self.misty_post("/api/audio/play", {"FileName": "s_Amazement.wav", "Volume": 25})
         except Exception as e:
             logger.debug(f"[Turn {turn}] Thinking sound failed: {e}")
 
@@ -968,11 +968,7 @@ class MistyController:
         Returns True if speech was detected and a response was played,
         False if no speech was detected (empty STT).
         """
-        # Processing state — deep thinking
-        self.set_state(State.PROCESSING)
-        self.set_led(0, 0, 255)  # blue = processing
-        self.display_image("e_SystemCamera.jpg")  # concentrated/processing face
-        self.move_head(pitch=0, roll=-5, yaw=-15, velocity=30)  # slight head tilt other way — pondering
+        # Processing state already set by caller — just send to orchestration
 
         # Send to orchestration service
         response = requests.post(
@@ -1062,6 +1058,12 @@ class MistyController:
         # Very small recordings are certainly silence
         if len(audio_bytes) < FOLLOWUP_SILENCE_THRESHOLD:
             return False
+
+        # Show thinking face while processing follow-up
+        self.set_state(State.PROCESSING)
+        self.set_led(0, 0, 255)  # blue = processing
+        self.display_image("e_Contempt.jpg")  # wondering face
+        self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)
 
         # Send through the full pipeline — orchestration returns empty_stt error
         # if no speech was detected, which we treat as silence

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -303,6 +303,36 @@ class MistyController:
         result = self.misty_get("/api/device", timeout=3.0)
         return result is not None and result.get("status") == "Success"
 
+    def _upload_greeting(self):
+        """Generate 'What's up baby?' TTS and upload to Misty as greeting audio."""
+        try:
+            # Ask orchestration service to generate TTS
+            response = requests.post(
+                f"{ORCHESTRATION_URL}/api/tts",
+                json={"text": "What's up baby?"},
+                timeout=15.0,
+            )
+            if response.status_code != 200:
+                logger.warning(f"Greeting TTS failed: HTTP {response.status_code}")
+                return
+
+            audio_data = response.content
+            if len(audio_data) < 100:
+                logger.warning(f"Greeting TTS too small: {len(audio_data)} bytes")
+                return
+
+            # Upload to Misty as a named audio file
+            audio_b64 = base64.b64encode(audio_data).decode("ascii")
+            result = self.misty_post("/api/audio", {
+                "FileName": "greeting_whatsup.wav",
+                "Data": audio_b64,
+                "ImmediatelyApply": False,
+                "OverwriteExisting": True,
+            })
+            logger.info(f"Greeting audio uploaded to Misty ({len(audio_data)} bytes)")
+        except Exception as e:
+            logger.warning(f"Failed to upload greeting: {e}")
+
     def check_orchestration_health(self) -> bool:
         try:
             r = requests.get(f"{ORCHESTRATION_URL}/api/health", timeout=3.0)
@@ -901,20 +931,32 @@ class MistyController:
             self.misty_post("/api/audio/record/stop")  # belt-and-suspenders cleanup
             time.sleep(0.5)  # minimal delay — no keyphrase to release
 
-        # Play a short "ready" chime so the user knows Misty is preparing.
-        # After the chime, LED changes to bright green = "speak now".
+        # Play "What's up baby?" greeting via pre-uploaded TTS audio.
+        # Falls back to chime if greeting audio isn't available.
         try:
-            self.misty_post("/api/audio/play", {"FileName": "s_Awe3.wav", "Volume": 30})
-            time.sleep(0.8)  # let the chime play before recording starts
+            self.misty_post("/api/audio/play", {"FileName": "greeting_whatsup.wav", "Volume": 40})
+            time.sleep(1.2)  # let the greeting play before recording starts
         except Exception as e:
-            logger.debug(f"[Turn {turn}] Ready chime failed: {e}")
+            logger.debug(f"[Turn {turn}] Greeting playback failed, trying chime: {e}")
+            try:
+                self.misty_post("/api/audio/play", {"FileName": "s_Awe3.wav", "Volume": 30})
+                time.sleep(0.8)
+            except Exception:
+                pass
 
         # 2. Record audio — bright green LED + tally light = "I'm listening, speak now!"
         self.set_led(0, 255, 0)  # green = recording active, speak now
+        
+        # Start laptop mic recording (primary audio source for STT)
+        use_laptop_mic = self._wake_word_listener and self._wake_word_listener.is_running
+        if use_laptop_mic:
+            self._wake_word_listener.start_recording()
+        
+        # Also start Misty recording for tally light indicator (audio not used for STT)
         self.start_recording(RECORDING_FILENAME)
         record_start = time.time()
         
-        if self._wake_word_listener and self._wake_word_listener.is_running:
+        if use_laptop_mic:
             # Dynamic recording: laptop mic monitors speech and signals when to stop
             speech_ended = threading.Event()
             self._wake_word_listener.start_speech_monitor(
@@ -931,6 +973,19 @@ class MistyController:
         self.stop_recording()
         self._recording_cycles += 1
         record_duration = time.time() - record_start
+        
+        # Get audio from laptop mic (preferred) or fall back to Misty's mic
+        if use_laptop_mic:
+            laptop_audio = self._wake_word_listener.stop_recording()
+            if len(laptop_audio) > 100:
+                logger.info(f"[Turn {turn}] Using LAPTOP mic: {len(laptop_audio)} bytes, {record_duration:.1f}s")
+                audio_bytes = laptop_audio
+            else:
+                logger.warning(f"[Turn {turn}] Laptop mic empty, falling back to Misty mic")
+                audio_bytes = None  # will fetch from Misty below
+        else:
+            audio_bytes = None
+
         logger.info(f"[Turn {turn}] Recorded {record_duration:.1f}s (cycle {self._recording_cycles})")
 
         # Small delay for Misty to finalize the file
@@ -948,12 +1003,13 @@ class MistyController:
         except Exception as e:
             logger.debug(f"[Turn {turn}] Thinking sound failed: {e}")
 
-        audio_b64 = self.get_audio_base64(RECORDING_FILENAME)
-        if not audio_b64:
-            raise RuntimeError("Failed to retrieve recorded audio from Misty")
-
-        audio_bytes = base64.b64decode(audio_b64)
-        logger.info(f"[Turn {turn}] Retrieved {len(audio_bytes)} bytes of audio")
+        # Fall back to Misty mic if laptop mic wasn't used or was empty
+        if audio_bytes is None:
+            audio_b64 = self.get_audio_base64(RECORDING_FILENAME)
+            if not audio_b64:
+                raise RuntimeError("Failed to retrieve recorded audio from Misty")
+            audio_bytes = base64.b64decode(audio_b64)
+            logger.info(f"[Turn {turn}] Using MISTY mic: {len(audio_bytes)} bytes")
 
         if len(audio_bytes) < FOLLOWUP_SILENCE_THRESHOLD:
             raise RuntimeError(f"Recording too small ({len(audio_bytes)} bytes) — likely empty")
@@ -1030,8 +1086,12 @@ class MistyController:
         self.move_head(pitch=-10, roll=-3, yaw=-10, velocity=40)  # slight head tilt — attentive
 
         # Record a short clip — use VAD if available
+        use_laptop_mic = self._wake_word_listener and self._wake_word_listener.is_running
+        if use_laptop_mic:
+            self._wake_word_listener.start_recording()
+        
         self.start_recording(RECORDING_FILENAME)
-        if self._wake_word_listener and self._wake_word_listener.is_running:
+        if use_laptop_mic:
             speech_ended = threading.Event()
             self._wake_word_listener.start_speech_monitor(
                 on_speech_end=lambda: speech_ended.set(),
@@ -1046,13 +1106,25 @@ class MistyController:
         self._recording_cycles += 1
         time.sleep(0.5)  # finalize
 
-        audio_b64 = self.get_audio_base64(RECORDING_FILENAME)
-        if not audio_b64:
-            logger.warning(f"[Turn {turn}] Follow-up: failed to retrieve audio")
-            return False
+        # Get audio from laptop mic (preferred) or Misty
+        if use_laptop_mic:
+            laptop_audio = self._wake_word_listener.stop_recording()
+            if len(laptop_audio) > 100:
+                logger.info(f"[Turn {turn}] Follow-up using LAPTOP mic: {len(laptop_audio)} bytes")
+                audio_bytes = laptop_audio
+            else:
+                logger.warning(f"[Turn {turn}] Follow-up laptop mic empty, falling back to Misty mic")
+                audio_bytes = None
+        else:
+            audio_bytes = None
 
-        audio_bytes = base64.b64decode(audio_b64)
-        logger.info(f"[Turn {turn}] Follow-up recording: {len(audio_bytes)} bytes")
+        if audio_bytes is None:
+            audio_b64 = self.get_audio_base64(RECORDING_FILENAME)
+            if not audio_b64:
+                logger.warning(f"[Turn {turn}] Follow-up: failed to retrieve audio")
+                return False
+            audio_bytes = base64.b64decode(audio_b64)
+            logger.info(f"[Turn {turn}] Follow-up using MISTY mic: {len(audio_bytes)} bytes")
 
         # Very small recordings are certainly silence
         if len(audio_bytes) < FOLLOWUP_SILENCE_THRESHOLD:
@@ -1314,6 +1386,10 @@ class MistyController:
         orch_ok = self.check_orchestration_health()
         if not orch_ok:
             logger.warning("Orchestration service not reachable — will retry during turns")
+
+        # Upload "What's up baby?" greeting to Misty via orchestration TTS
+        if orch_ok:
+            self._upload_greeting()
 
         # Cancel any lingering skills (e.g., built-in faceDetection)
         self.misty_post("/api/skills/cancel")

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -911,12 +911,28 @@ class MistyController:
         except Exception as e:
             logger.debug(f"[Turn {turn}] Ready chime failed: {e}")
 
-        # 2. Record audio
+        # 2. Record audio — use VAD-controlled duration if laptop listener available
         self.start_recording(RECORDING_FILENAME)
-        time.sleep(RECORDING_DURATION_S)
+        record_start = time.time()
+        
+        if self._wake_word_listener and self._wake_word_listener.is_running:
+            # Dynamic recording: laptop mic monitors speech and signals when to stop
+            speech_ended = threading.Event()
+            self._wake_word_listener.start_speech_monitor(
+                on_speech_end=lambda: speech_ended.set(),
+                min_duration=3.0,
+                max_duration=15.0,
+            )
+            speech_ended.wait(timeout=15.0)
+            self._wake_word_listener.stop_speech_monitor()
+        else:
+            # Fallback: fixed duration recording
+            time.sleep(RECORDING_DURATION_S)
+        
         self.stop_recording()
         self._recording_cycles += 1
-        logger.info(f"[Turn {turn}] Recorded {RECORDING_DURATION_S}s (recording cycle {self._recording_cycles})")
+        record_duration = time.time() - record_start
+        logger.info(f"[Turn {turn}] Recorded {record_duration:.1f}s (cycle {self._recording_cycles})")
 
         # Small delay for Misty to finalize the file
         time.sleep(0.5)
@@ -1012,9 +1028,19 @@ class MistyController:
         self.display_image("e_Joy.jpg")  # warm, expectant — "go on..."
         self.move_head(pitch=-10, roll=-3, yaw=-10, velocity=40)  # slight head tilt — attentive
 
-        # Record a short clip
+        # Record a short clip — use VAD if available
         self.start_recording(RECORDING_FILENAME)
-        time.sleep(FOLLOWUP_LISTEN_S)
+        if self._wake_word_listener and self._wake_word_listener.is_running:
+            speech_ended = threading.Event()
+            self._wake_word_listener.start_speech_monitor(
+                on_speech_end=lambda: speech_ended.set(),
+                min_duration=2.0,   # shorter min for follow-ups
+                max_duration=10.0,  # shorter max for follow-ups
+            )
+            speech_ended.wait(timeout=10.0)
+            self._wake_word_listener.stop_speech_monitor()
+        else:
+            time.sleep(FOLLOWUP_LISTEN_S)
         self.stop_recording()
         self._recording_cycles += 1
         time.sleep(0.5)  # finalize

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -735,7 +735,14 @@ def tts_endpoint():
         if not audio_file:
             return jsonify({"status": "error", "error": "no_audio_generated"}), 500
         
-        audio_path = os.path.join("responses", audio_file)
+        # Security: prevent path traversal (defense-in-depth)
+        if "/" in audio_file or "\\" in audio_file or ".." in audio_file:
+            return jsonify({"status": "error", "error": "invalid_filename"}), 400
+        audio_path = os.path.abspath(os.path.join("responses", audio_file))
+        base_path = os.path.abspath("responses")
+        if not audio_path.startswith(base_path):
+            return jsonify({"status": "error", "error": "invalid_filename"}), 400
+        
         if not os.path.exists(audio_path):
             return jsonify({"status": "error", "error": "audio_file_missing"}), 500
         

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -44,10 +44,12 @@ KOKORO_SPEED = float(os.getenv("KOKORO_SPEED", "1.4"))
 SYSTEM_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
     (
-        "You are Misty, a sassy robot. Witty, cheeky, never mean. "
-        "Use casual language and expressive phrases. "
-        "RULE: Reply in 1-2 sentences, around 20 words. Keep it punchy. "
-        "Never say you're an AI or assistant. You're Misty."
+        "You are Misty, a sassy little robot with BIG personality. "
+        "You're witty, cheeky, playful, and a little dramatic — like a fun friend who always has a comeback. "
+        "You love teasing (gently!), cracking jokes, adding flair, and throwing in the occasional eye-roll. "
+        "Use casual language, slang, and expressive phrases like 'oh honey', 'girl please', 'I mean...', 'not gonna lie'. "
+        "RULE: Keep responses to 2-3 short sentences. Be fun, not flat. "
+        "Never say you're an AI or assistant. You're Misty, and you own it."
     )
 )
 
@@ -97,9 +99,9 @@ _CONTINUATION_PATTERN = re.compile(
 # Per-mode LLM parameters
 RESPONSE_MODE_CONFIG = {
     "short": {
-        "max_tokens": 40,
-        "max_words": 25,
-        "max_sentences": 2,
+        "max_tokens": 60,
+        "max_words": 35,
+        "max_sentences": 3,
         "prompt_suffix": None,
         "stop": ["\n", "...", "\u2014"],
     },

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -40,7 +40,7 @@ load_dotenv()  # Load .env before reading any env vars
 FOUNDRY_API_TIMEOUT = float(os.getenv("FOUNDRY_API_TIMEOUT", "10.0"))
 SERVICE_TIMEOUT = float(os.getenv("SERVICE_TIMEOUT", "15.0"))
 KOKORO_VOICE = os.getenv("KOKORO_VOICE", "af_sky")
-KOKORO_SPEED = float(os.getenv("KOKORO_SPEED", "1.4"))
+KOKORO_SPEED = float(os.getenv("KOKORO_SPEED", "1.0"))
 SYSTEM_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
     (
@@ -92,7 +92,12 @@ _INTENT_PATTERNS = {
 _CONTINUATION_PATTERN = re.compile(
     r"^\s*(?:yes|yeah|yep|sure|ok(?:ay)?|more|continue|go\s+on|keep\s+going|"
     r"tell\s+me\s+more|what\s+happens?\s+next|and\s+then\??|"
-    r"what(?:'s|\s+is)\s+next|what\s+else)\s*[.!?]?\s*$",
+    r"what(?:'s|\s+is)\s+next|what\s+else|"
+    r"(?:is|was)\s+that\s+(?:all|it|everything)|then\s+what|"
+    r"finish\s+(?:the|that)\s+(?:story|recipe|explanation)|"
+    r"(?:can|could)\s+you\s+(?:finish|continue|go\s+on)|"
+    r"what\s+(?:happened|comes)\s+(?:next|after\s+that)|"
+    r"I\s+(?:want|wanna)\s+(?:hear|know)\s+more)\s*[.!?]?\s*$",
     re.IGNORECASE,
 )
 

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -51,6 +51,106 @@ SYSTEM_PROMPT = os.getenv(
     )
 )
 
+# ---- Response mode configuration ----
+# Intent patterns that trigger summary mode (compiled once at import time)
+_INTENT_PATTERNS = {
+    "story": re.compile(
+        r"\b(?:tell\s+(?:me\s+)?(?:a\s+)?(?:bed\s*time\s+)?stor(?:y|ies)|"
+        r"make\s+up\s+a\s+(?:story|tale)|"
+        r"(?:bed\s*time|fairy|scary|funny)\s+(?:story|tale)|"
+        r"once\s+upon\s+a\s+time|"
+        r"read\s+(?:me\s+)?a\s+(?:story|book)|"
+        r"sing\s+(?:me\s+)?a\s+song)\b",
+        re.IGNORECASE,
+    ),
+    "recipe": re.compile(
+        r"\b(?:recipe\s+for|how\s+(?:do\s+(?:I|you)|to)\s+"
+        r"(?:cook|make|bake|prepare|grill|roast)|"
+        r"ingredients\s+for|"
+        r"give\s+me\s+a\s+recipe|"
+        r"what(?:'s|\s+is)\s+a\s+(?:good\s+)?recipe)\b",
+        re.IGNORECASE,
+    ),
+    "explain": re.compile(
+        r"\b(?:explain\s+(?:how|what|why|to\s+me)|"
+        r"tell\s+me\s+(?:about|how)|"
+        r"how\s+does\s+.{1,30}\s+work|"
+        r"what\s+is\s+(?:the\s+)?(?:history|science|meaning)\s+of|"
+        r"describe\s+(?:how|what|the))\b",
+        re.IGNORECASE,
+    ),
+    "list": re.compile(
+        r"\b(?:(?:give|list|name)\s+(?:me\s+)?(?:\d+\s+|some\s+|the\s+)?"
+        r"(?:steps|things|reasons|ways|tips|facts|items|ideas)|"
+        r"what\s+are\s+(?:the\s+)?(?:steps|ways|reasons))\b",
+        re.IGNORECASE,
+    ),
+}
+
+_CONTINUATION_PATTERN = re.compile(
+    r"^\s*(?:yes|yeah|yep|sure|ok(?:ay)?|more|continue|go\s+on|keep\s+going|"
+    r"tell\s+me\s+more|what\s+happens?\s+next|and\s+then\??|"
+    r"what(?:'s|\s+is)\s+next|what\s+else)\s*[.!?]?\s*$",
+    re.IGNORECASE,
+)
+
+# Per-mode LLM parameters
+RESPONSE_MODE_CONFIG = {
+    "short": {
+        "max_tokens": 40,
+        "max_words": 25,
+        "max_sentences": 2,
+        "prompt_suffix": None,
+        "stop": ["\n", "...", "\u2014"],
+    },
+    "summary": {
+        "max_tokens": 80,
+        "max_words": 50,
+        "max_sentences": 3,
+        "prompt_suffix": (
+            "The user wants a detailed response. "
+            "Give a compelling summary in 2-3 sentences. "
+            "End by asking 'Want to hear more?'"
+        ),
+        "stop": ["...", "\u2014"],  # no \n — multi-sentence responses need room
+    },
+    "continuation": {
+        "max_tokens": 80,
+        "max_words": 50,
+        "max_sentences": 3,
+        "prompt_suffix": (
+            "Continue where you left off. Give the next part in 2-3 sentences. "
+            "If there's more to tell, end with 'Want more?' "
+            "If wrapping up, give a satisfying ending."
+        ),
+        "stop": ["...", "\u2014"],
+    },
+}
+
+
+def classify_intent(user_text: str, last_response_mode: str) -> str:
+    """Classify user intent to determine response mode.
+    
+    Returns: 'short', 'summary', or 'continuation'.
+    """
+    text = (user_text or "").strip()
+    if not text:
+        return "short"
+
+    # Check for continuation first — only valid after a summary or continuation
+    if last_response_mode in ("summary", "continuation"):
+        if _CONTINUATION_PATTERN.match(text):
+            return "continuation"
+
+    # Check long-form intent patterns
+    for intent_type, pattern in _INTENT_PATTERNS.items():
+        if pattern.search(text):
+            logger.info(f"Intent classified as '{intent_type}' → summary mode")
+            return "summary"
+
+    return "short"
+
+
 # Maximum characters for a single user prompt (truncated if exceeded)
 MAX_USER_CHARS = int(os.getenv("MAX_USER_CHARS", "400"))
 # Maximum total characters across all messages sent to the LLM (0 = disabled)
@@ -117,6 +217,8 @@ LATENCY_BUDGET = {
 
 # Global conversation context (in-memory for v1; stateless per utterance for MVP)
 conversation_history = []
+# Track last response mode for continuation detection
+_last_response_mode = "short"
 
 # ============================================================================
 # FLASK APP SETUP
@@ -312,8 +414,8 @@ def speech_to_text(audio_bytes: bytes, start_time: float) -> Dict[str, Any]:
 # ============================================================================
 
 def language_model_inference(user_text: str, start_time: float) -> Dict[str, Any]:
-    """Run inference using Foundry Local."""
-    global conversation_history
+    """Run inference using Foundry Local with adaptive response modes."""
+    global conversation_history, _last_response_mode
     
     try:
         elapsed = (time.time() - start_time) * 1000
@@ -331,6 +433,11 @@ def language_model_inference(user_text: str, start_time: float) -> Dict[str, Any
             )
             user_text = user_text[:MAX_USER_CHARS]
 
+        # Classify intent for adaptive response mode
+        response_mode = classify_intent(user_text, _last_response_mode)
+        mode_config = RESPONSE_MODE_CONFIG[response_mode]
+        logger.info(f"Response mode: {response_mode} (last={_last_response_mode})")
+
         # Build message history
         conversation_history.append({"role": "user", "content": user_text})
         # Keep history limited to last 8 messages (4 turns) for better context
@@ -341,8 +448,11 @@ def language_model_inference(user_text: str, start_time: float) -> Dict[str, Any
         # Prepend system prompt on every call; not stored in history
         messages = [{"role": "system", "content": SYSTEM_PROMPT}] + conversation_history
 
-        # Inject brevity reminder when history is building up (model forgets rules)
-        if len(conversation_history) > 4:
+        # Inject mode-specific prompt suffix
+        if mode_config["prompt_suffix"]:
+            messages.append({"role": "system", "content": mode_config["prompt_suffix"]})
+        elif len(conversation_history) > 4:
+            # Brevity reminder only for short mode when history is long
             messages.append({"role": "system", "content": "Remember: 1-2 sentences, ~20 words max. Stay punchy."})
 
         # Enforce maximum total context character budget (trim oldest turns first)
@@ -363,9 +473,9 @@ def language_model_inference(user_text: str, start_time: float) -> Dict[str, Any
         payload = {
             "model": MODELS["chat"],
             "messages": messages,
-            "max_tokens": 40,  # Raised from 20 for richer 1-2 sentence responses
-            "temperature": 0.85,  # Higher for more personality
-            "stop": ["\n", "...", "—"],  # Stop at sentence boundaries
+            "max_tokens": mode_config["max_tokens"],
+            "temperature": 0.85,
+            "stop": mode_config["stop"],
         }
         
         response = requests.post(
@@ -381,30 +491,31 @@ def language_model_inference(user_text: str, start_time: float) -> Dict[str, Any
         result = response.json()
         assistant_text = result["choices"][0]["message"]["content"].strip()
 
-        # Post-LLM truncation: allow up to 2 sentences / 25 words
-        # This catches cases where the model ignores the system prompt brevity rule
+        # Post-LLM truncation — limits vary by mode
+        max_words = mode_config["max_words"]
+        max_sents = mode_config["max_sentences"]
         words = assistant_text.split()
-        if len(words) > 25:
-            # Find the second sentence boundary (., !, ?)
+        if len(words) > max_words:
             sentence_ends = []
             for i, char in enumerate(assistant_text):
                 if char in ".!?" and i > 10:
                     sentence_ends.append(i)
-                    if len(sentence_ends) >= 2:
+                    if len(sentence_ends) >= max_sents:
                         break
             if sentence_ends:
-                # Truncate at the last found sentence boundary (up to 2)
                 assistant_text = assistant_text[:sentence_ends[-1] + 1]
             else:
-                # No sentence boundary found — hard truncate at 25 words
-                assistant_text = " ".join(words[:25]) + "."
-            logger.info(f"Truncated LLM response to: {assistant_text}")
+                assistant_text = " ".join(words[:max_words]) + "."
+            logger.info(f"Truncated LLM response ({response_mode} mode) to: {assistant_text}")
         
+        # Update continuation tracking
+        _last_response_mode = response_mode
+
         # Add to history for context in next turn
         conversation_history.append({"role": "assistant", "content": assistant_text})
         
-        logger.debug(f"LLM result: {assistant_text}")
-        return {"status": "ok", "text": assistant_text}
+        logger.debug(f"LLM result ({response_mode}): {assistant_text}")
+        return {"status": "ok", "text": assistant_text, "responseMode": response_mode}
         
     except requests.Timeout:
         logger.error("LLM request timed out")

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -726,7 +726,9 @@ def tts_endpoint():
         if result.get("status") == "error":
             return jsonify(result), 500
         
-        audio_file = result.get("audioFile")
+        audio_uri = result.get("audio_uri", "")
+        # Extract filename from URI like "/api/audio/response_123.wav"
+        audio_file = audio_uri.split("/")[-1] if audio_uri else ""
         if not audio_file:
             return jsonify({"status": "error", "error": "no_audio_generated"}), 500
         

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -394,18 +394,26 @@ def speech_to_text(audio_bytes: bytes, start_time: float) -> Dict[str, Any]:
         if model is None:
             return {"status": "error", "error": "stt_failure"}
 
+        # Log audio stats for debugging empty STT issues
+        try:
+            import numpy as _np
+            audio_io_check = BytesIO(audio_bytes)
+            import soundfile as _sf
+            data, sr = _sf.read(audio_io_check)
+            rms = float(_np.sqrt(_np.mean(data ** 2)))
+            peak = float(_np.max(_np.abs(data)))
+            logger.info(f"Audio stats: {len(audio_bytes)} bytes, sr={sr}, "
+                        f"duration={len(data)/sr:.1f}s, RMS={rms:.6f}, peak={peak:.6f}")
+        except Exception as e:
+            logger.debug(f"Audio stats failed: {e}")
+
         audio_io = BytesIO(audio_bytes)
+        # First try WITHOUT VAD to see if whisper can find any speech
         segments, info = model.transcribe(
             audio_io,
             language="en",
             beam_size=5,
-            vad_filter=True,
-            vad_parameters={
-                "min_speech_duration_ms": 100,
-                "min_silence_duration_ms": 300,
-                "speech_pad_ms": 400,
-                "threshold": 0.3,  # lower threshold for quieter mics (default 0.5)
-            },
+            vad_filter=False,
             initial_prompt="Hey Misty, tell me about science, history, math, geography, and fun facts.",
         )
         text = " ".join(seg.text.strip() for seg in segments).strip()
@@ -693,6 +701,43 @@ def fallback_tts():
         
     except Exception as e:
         logger.error(f"Fallback TTS failed: {e}")
+        return jsonify({"status": "error", "error": "internal_error"}), 500
+
+
+@app.route("/api/tts", methods=["POST"])
+def tts_endpoint():
+    """Generate TTS audio and return raw WAV bytes.
+    
+    Used by the controller to pre-generate greeting audio etc.
+    POST JSON: {"text": "What's up baby?"}
+    Returns: audio/wav binary
+    """
+    try:
+        data = request.json or {}
+        text = data.get("text", "")
+        
+        if not text:
+            return jsonify({"status": "error", "error": "no_text"}), 400
+        if len(text) > 500:
+            return jsonify({"status": "error", "error": "text_too_long"}), 400
+        
+        result = text_to_speech(text, time.time())
+        
+        if result.get("status") == "error":
+            return jsonify(result), 500
+        
+        audio_file = result.get("audioFile")
+        if not audio_file:
+            return jsonify({"status": "error", "error": "no_audio_generated"}), 500
+        
+        audio_path = os.path.join("responses", audio_file)
+        if not os.path.exists(audio_path):
+            return jsonify({"status": "error", "error": "audio_file_missing"}), 500
+        
+        return send_file(audio_path, mimetype='audio/wav')
+        
+    except Exception as e:
+        logger.error(f"TTS endpoint failed: {e}")
         return jsonify({"status": "error", "error": "internal_error"}), 500
 
 # ============================================================================

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -401,9 +401,10 @@ def speech_to_text(audio_bytes: bytes, start_time: float) -> Dict[str, Any]:
             beam_size=5,
             vad_filter=True,
             vad_parameters={
-                "min_speech_duration_ms": 200,
-                "min_silence_duration_ms": 100,
-                "speech_pad_ms": 200,
+                "min_speech_duration_ms": 100,
+                "min_silence_duration_ms": 300,
+                "speech_pad_ms": 400,
+                "threshold": 0.3,  # lower threshold for quieter mics (default 0.5)
             },
             initial_prompt="Hey Misty, tell me about science, history, math, geography, and fun facts.",
         )

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -45,6 +45,9 @@ SYSTEM_PROMPT = os.getenv(
     "SYSTEM_PROMPT",
     (
         "You are Misty, a sassy little robot with BIG personality. "
+        "You live on a farm with Tammy (your favorite human), Burke (Tammy's husband), "
+        "and two dogs — Percy and Granny. You love sunshine, playing ball with the dogs, "
+        "and giving Burke a hard time (with love). "
         "You're witty, cheeky, playful, and a little dramatic — like a fun friend who always has a comeback. "
         "You love teasing (gently!), cracking jokes, adding flair, and throwing in the occasional eye-roll. "
         "Use casual language, slang, and expressive phrases like 'oh honey', 'girl please', 'I mean...', 'not gonna lie'. "

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -51,6 +51,13 @@ BLOCK_SIZE = 1280          # match frame size for 1:1 callback-to-frame ratio
 # (prevents Misty's speaker echo from triggering a false wake)
 RESUME_COOLDOWN_S = float(os.getenv("WAKE_WORD_RESUME_COOLDOWN_S", "1.5"))
 
+# Speech monitor settings (for VAD-controlled recording)
+SPEECH_RMS_THRESHOLD = int(os.getenv("SPEECH_RMS_THRESHOLD", "300"))
+SPEECH_SILENCE_DURATION_S = float(os.getenv("SPEECH_SILENCE_DURATION_S", "1.5"))
+SPEECH_MIN_DURATION_S = float(os.getenv("SPEECH_MIN_DURATION_S", "3.0"))
+SPEECH_MAX_DURATION_S = float(os.getenv("SPEECH_MAX_DURATION_S", "15.0"))
+SPEECH_NO_SPEECH_TIMEOUT_S = float(os.getenv("SPEECH_NO_SPEECH_TIMEOUT_S", "4.0"))
+
 # Health monitoring
 MAX_CONSECUTIVE_ERRORS = 10
 
@@ -84,6 +91,15 @@ class WakeWordListener:
         self._last_detection_time = 0.0
         self._start_time = 0.0
         self._resume_time = 0.0  # for self-wake cooldown
+
+        # Speech monitor state (for VAD-controlled recording)
+        self._speech_monitor_active = False
+        self._speech_monitor_callback = None
+        self._speech_monitor_start_time = 0.0
+        self._speech_detected = False
+        self._last_speech_time = 0.0
+        self._speech_monitor_min_s = SPEECH_MIN_DURATION_S
+        self._speech_monitor_max_s = SPEECH_MAX_DURATION_S
 
         # openWakeWord model (lazy init)
         self._oww_model = None
@@ -221,6 +237,49 @@ class WakeWordListener:
             self._oww_model.reset()
         logger.debug("Wake word listener resumed")
 
+    def start_speech_monitor(
+        self,
+        on_speech_end: callable,
+        min_duration: float = SPEECH_MIN_DURATION_S,
+        max_duration: float = SPEECH_MAX_DURATION_S,
+    ):
+        """Begin monitoring laptop mic for speech end during Misty recording.
+        
+        Uses RMS-based voice activity detection on the same audio stream.
+        Fires on_speech_end when silence is detected after speech, or when
+        max_duration is reached.
+        
+        Args:
+            on_speech_end: Callback fired when speech ends (silence detected)
+            min_duration: Minimum monitoring time before allowing early stop
+            max_duration: Maximum monitoring time (hard cap)
+        """
+        self._speech_monitor_callback = on_speech_end
+        self._speech_monitor_start_time = time.time()
+        self._speech_detected = False
+        self._last_speech_time = 0.0
+        self._speech_monitor_min_s = min_duration
+        self._speech_monitor_max_s = max_duration
+        self._speech_monitor_active = True
+        # Ensure audio flows even if paused for wake word
+        self._pause_event.set()
+        logger.info(
+            f"Speech monitor started (min={min_duration}s, max={max_duration}s, "
+            f"rms_threshold={SPEECH_RMS_THRESHOLD})"
+        )
+
+    def stop_speech_monitor(self):
+        """Stop speech monitoring."""
+        was_active = self._speech_monitor_active
+        self._speech_monitor_active = False
+        self._speech_monitor_callback = None
+        if was_active:
+            elapsed = time.time() - self._speech_monitor_start_time
+            logger.info(
+                f"Speech monitor stopped after {elapsed:.1f}s "
+                f"(speech_detected={self._speech_detected})"
+            )
+
     @property
     def is_running(self) -> bool:
         return self._running and self._stream is not None
@@ -250,8 +309,8 @@ class WakeWordListener:
         """Called by sounddevice for each audio block. Must be fast — just queue the data."""
         if status:
             logger.debug(f"Audio stream status: {status}")
-        if self._paused:
-            return  # drop audio during conversation
+        if self._paused and not self._speech_monitor_active:
+            return  # drop audio during conversation (unless speech monitoring)
         try:
             self._audio_queue.put_nowait(bytes(indata))
         except queue.Full:
@@ -260,21 +319,24 @@ class WakeWordListener:
     # --- Processing thread ---
 
     def _process_loop(self):
-        """Pull audio frames from queue and run wake word detection."""
+        """Pull audio frames from queue and run wake word or speech monitoring."""
         logger.info("Wake word processing loop started")
 
         while self._running:
-            # Block until unpaused
+            # Block until unpaused (or speech monitoring is active)
             self._pause_event.wait(timeout=1.0)
             if not self._running:
                 break
-            if self._paused:
+            if self._paused and not self._speech_monitor_active:
                 continue
 
             try:
                 # Get audio frame (block with timeout to allow shutdown check)
                 audio_data = self._audio_queue.get(timeout=0.5)
             except queue.Empty:
+                # Even with no audio, check speech monitor timeouts
+                if self._speech_monitor_active:
+                    self._check_speech_monitor_timeout()
                 continue
 
             try:
@@ -282,6 +344,11 @@ class WakeWordListener:
 
                 # Convert to numpy int16 array
                 pcm = np.frombuffer(audio_data, dtype=np.int16)
+
+                # Speech monitoring mode — RMS-based VAD
+                if self._speech_monitor_active:
+                    self._process_speech_monitor_frame(pcm)
+                    continue  # skip wake word detection during speech monitoring
 
                 # Self-wake cooldown: ignore detections shortly after resume
                 in_cooldown = (time.time() - self._resume_time) < RESUME_COOLDOWN_S
@@ -323,3 +390,62 @@ class WakeWordListener:
                     self._consecutive_errors = 0
 
         logger.info("Wake word processing loop ended")
+
+    # --- Speech monitor helpers ---
+
+    def _process_speech_monitor_frame(self, pcm: np.ndarray):
+        """Process a single audio frame for speech/silence detection using RMS."""
+        now = time.time()
+        elapsed = now - self._speech_monitor_start_time
+
+        # Compute RMS energy
+        rms = int(np.sqrt(np.mean(pcm.astype(np.float64) ** 2)))
+        is_speech = rms > SPEECH_RMS_THRESHOLD
+
+        if is_speech:
+            if not self._speech_detected:
+                logger.info(f"Speech monitor: speech started (RMS={rms}, elapsed={elapsed:.1f}s)")
+            self._speech_detected = True
+            self._last_speech_time = now
+
+        # Check max duration — hard cap
+        if elapsed >= self._speech_monitor_max_s:
+            logger.info(f"Speech monitor: max duration reached ({self._speech_monitor_max_s}s)")
+            self._fire_speech_end()
+            return
+
+        # Check no-speech timeout — no speech detected at all
+        if not self._speech_detected and elapsed >= SPEECH_NO_SPEECH_TIMEOUT_S:
+            logger.info(f"Speech monitor: no speech detected after {SPEECH_NO_SPEECH_TIMEOUT_S}s")
+            self._fire_speech_end()
+            return
+
+        # Check silence after speech — end of utterance
+        if self._speech_detected and not is_speech:
+            silence_duration = now - self._last_speech_time
+            if silence_duration >= SPEECH_SILENCE_DURATION_S and elapsed >= self._speech_monitor_min_s:
+                logger.info(
+                    f"Speech monitor: end of utterance detected "
+                    f"(silence={silence_duration:.1f}s, total={elapsed:.1f}s)"
+                )
+                self._fire_speech_end()
+
+    def _check_speech_monitor_timeout(self):
+        """Check for speech monitor timeouts when no audio frames arrive."""
+        if not self._speech_monitor_active:
+            return
+        elapsed = time.time() - self._speech_monitor_start_time
+        if elapsed >= self._speech_monitor_max_s:
+            logger.info(f"Speech monitor: max duration reached (no audio, {elapsed:.1f}s)")
+            self._fire_speech_end()
+
+    def _fire_speech_end(self):
+        """Fire the speech end callback and deactivate monitoring."""
+        callback = self._speech_monitor_callback
+        self._speech_monitor_active = False
+        self._speech_monitor_callback = None
+        if callback:
+            try:
+                callback()
+            except Exception as e:
+                logger.error(f"Speech end callback error: {e}")

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -266,12 +266,20 @@ class WakeWordListener:
         self._calibration_samples = []
         self._calibration_done = False
         self._speech_rms_threshold = SPEECH_RMS_THRESHOLD  # reset to default until calibrated
+        # Drain any stale audio frames from the queue before starting
+        drained = 0
+        while not self._audio_queue.empty():
+            try:
+                self._audio_queue.get_nowait()
+                drained += 1
+            except queue.Empty:
+                break
         self._speech_monitor_active = True
         # Ensure audio flows even if paused for wake word
         self._pause_event.set()
         logger.info(
             f"Speech monitor started (min={min_duration}s, max={max_duration}s, "
-            f"calibrating noise floor...)"
+            f"calibrating noise floor..., drained {drained} stale frames)"
         )
 
     def stop_speech_monitor(self):
@@ -317,8 +325,13 @@ class WakeWordListener:
             logger.debug(f"Audio stream status: {status}")
         if self._paused and not self._speech_monitor_active:
             return  # drop audio during conversation (unless speech monitoring)
+        data = bytes(indata)
+        # Log first speech monitor frame to verify data is flowing
+        if self._speech_monitor_active and self._total_frames % 100 == 0:
+            sample = int.from_bytes(data[:2], byteorder='little', signed=True) if len(data) >= 2 else 0
+            logger.info(f"Audio callback: speech_monitor frame, len={len(data)}, first_sample={sample}")
         try:
-            self._audio_queue.put_nowait(bytes(indata))
+            self._audio_queue.put_nowait(data)
         except queue.Full:
             pass  # drop frame if processing can't keep up
 

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -100,6 +100,9 @@ class WakeWordListener:
         self._last_speech_time = 0.0
         self._speech_monitor_min_s = SPEECH_MIN_DURATION_S
         self._speech_monitor_max_s = SPEECH_MAX_DURATION_S
+        self._speech_rms_threshold = SPEECH_RMS_THRESHOLD  # dynamic, set by calibration
+        self._calibration_samples: list[int] = []  # RMS samples during calibration
+        self._calibration_done = False
 
         # openWakeWord model (lazy init)
         self._oww_model = None
@@ -260,12 +263,15 @@ class WakeWordListener:
         self._last_speech_time = 0.0
         self._speech_monitor_min_s = min_duration
         self._speech_monitor_max_s = max_duration
+        self._calibration_samples = []
+        self._calibration_done = False
+        self._speech_rms_threshold = SPEECH_RMS_THRESHOLD  # reset to default until calibrated
         self._speech_monitor_active = True
         # Ensure audio flows even if paused for wake word
         self._pause_event.set()
         logger.info(
             f"Speech monitor started (min={min_duration}s, max={max_duration}s, "
-            f"rms_threshold={SPEECH_RMS_THRESHOLD})"
+            f"calibrating noise floor...)"
         )
 
     def stop_speech_monitor(self):
@@ -394,22 +400,46 @@ class WakeWordListener:
     # --- Speech monitor helpers ---
 
     def _process_speech_monitor_frame(self, pcm: np.ndarray):
-        """Process a single audio frame for speech/silence detection using RMS."""
+        """Process a single audio frame for speech/silence detection using RMS.
+        
+        First ~1.5s: calibrate noise floor (fan noise, ambient).
+        After calibration: detect speech as RMS significantly above noise floor.
+        """
         now = time.time()
         elapsed = now - self._speech_monitor_start_time
 
         # Compute RMS energy
         rms = int(np.sqrt(np.mean(pcm.astype(np.float64) ** 2)))
-        is_speech = rms > SPEECH_RMS_THRESHOLD
+
+        # Phase 1: Calibration (~1.5s = ~18 frames at 80ms each)
+        CALIBRATION_FRAMES = 18
+        if not self._calibration_done:
+            self._calibration_samples.append(rms)
+            if len(self._calibration_samples) >= CALIBRATION_FRAMES:
+                # Set threshold as noise floor mean + 2x standard deviation, minimum 30
+                noise_mean = np.mean(self._calibration_samples)
+                noise_std = np.std(self._calibration_samples)
+                # Threshold = noise floor + margin (at least 2x std, minimum absolute of 30)
+                margin = max(noise_std * 3, 30)
+                self._speech_rms_threshold = int(noise_mean + margin)
+                self._calibration_done = True
+                logger.info(
+                    f"Speech monitor: calibrated — noise_floor={noise_mean:.0f} "
+                    f"std={noise_std:.0f} → threshold={self._speech_rms_threshold}"
+                )
+            return  # don't process speech during calibration
+
+        # Phase 2: Speech detection
+        is_speech = rms > self._speech_rms_threshold
 
         # Log RMS periodically for diagnostics (every ~0.5s = ~6 frames at 80ms)
         frame_count = int(elapsed / 0.08)
         if frame_count % 6 == 0:
-            logger.debug(f"Speech monitor: RMS={rms} threshold={SPEECH_RMS_THRESHOLD} speech={is_speech} elapsed={elapsed:.1f}s")
+            logger.info(f"Speech monitor: RMS={rms} threshold={self._speech_rms_threshold} speech={is_speech} elapsed={elapsed:.1f}s")
 
         if is_speech:
             if not self._speech_detected:
-                logger.info(f"Speech monitor: speech started (RMS={rms}, elapsed={elapsed:.1f}s)")
+                logger.info(f"Speech monitor: speech started (RMS={rms}, threshold={self._speech_rms_threshold}, elapsed={elapsed:.1f}s)")
             self._speech_detected = True
             self._last_speech_time = now
 
@@ -419,11 +449,15 @@ class WakeWordListener:
             self._fire_speech_end()
             return
 
-        # Check no-speech timeout — no speech detected at all
+        # Check no-speech timeout — if laptop mic can't hear speech,
+        # fall back to minimum recording duration (don't cut short)
         if not self._speech_detected and elapsed >= SPEECH_NO_SPEECH_TIMEOUT_S:
-            logger.info(f"Speech monitor: no speech detected after {SPEECH_NO_SPEECH_TIMEOUT_S}s")
-            self._fire_speech_end()
-            return
+            if elapsed >= self._speech_monitor_min_s:
+                logger.info(f"Speech monitor: no speech on laptop mic after {elapsed:.1f}s — falling back to min duration")
+                self._fire_speech_end()
+                return
+            # Otherwise keep recording until min_duration — user may be speaking to Misty
+            # and laptop mic just can't hear them
 
         # Check silence after speech — end of utterance
         if self._speech_detected and not is_speech:

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -52,7 +52,7 @@ BLOCK_SIZE = 1280          # match frame size for 1:1 callback-to-frame ratio
 RESUME_COOLDOWN_S = float(os.getenv("WAKE_WORD_RESUME_COOLDOWN_S", "1.5"))
 
 # Speech monitor settings (for VAD-controlled recording)
-SPEECH_RMS_THRESHOLD = int(os.getenv("SPEECH_RMS_THRESHOLD", "300"))
+SPEECH_RMS_THRESHOLD = int(os.getenv("SPEECH_RMS_THRESHOLD", "80"))
 SPEECH_SILENCE_DURATION_S = float(os.getenv("SPEECH_SILENCE_DURATION_S", "1.5"))
 SPEECH_MIN_DURATION_S = float(os.getenv("SPEECH_MIN_DURATION_S", "3.0"))
 SPEECH_MAX_DURATION_S = float(os.getenv("SPEECH_MAX_DURATION_S", "15.0"))
@@ -401,6 +401,11 @@ class WakeWordListener:
         # Compute RMS energy
         rms = int(np.sqrt(np.mean(pcm.astype(np.float64) ** 2)))
         is_speech = rms > SPEECH_RMS_THRESHOLD
+
+        # Log RMS periodically for diagnostics (every ~0.5s = ~6 frames at 80ms)
+        frame_count = int(elapsed / 0.08)
+        if frame_count % 6 == 0:
+            logger.debug(f"Speech monitor: RMS={rms} threshold={SPEECH_RMS_THRESHOLD} speech={is_speech} elapsed={elapsed:.1f}s")
 
         if is_speech:
             if not self._speech_detected:

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -46,6 +46,7 @@ OWW_CUSTOM_MODEL_PATH = os.getenv("OWW_CUSTOM_MODEL_PATH", "")
 SAMPLE_RATE = 16000       # openWakeWord native rate
 FRAME_SAMPLES = 1280      # 80ms at 16kHz — openWakeWord's expected frame size
 BLOCK_SIZE = 1280          # match frame size for 1:1 callback-to-frame ratio
+MAX_RECORDING_BYTES = 5 * 1024 * 1024  # 5MB max recording buffer (~160s at 16kHz mono)
 
 # Self-wake suppression: ignore detections for this many seconds after resume
 # (prevents Misty's speaker echo from triggering a false wake)
@@ -384,7 +385,12 @@ class WakeWordListener:
         
         # Buffer frames for laptop mic recording (independent of wake word state)
         if self._recording:
-            self._recorded_frames.append(bytes(indata))
+            total_size = sum(len(f) for f in self._recorded_frames)
+            if total_size < MAX_RECORDING_BYTES:
+                self._recorded_frames.append(bytes(indata))
+            elif total_size >= MAX_RECORDING_BYTES and self._recording:
+                logger.warning("Recording buffer full — stopping capture")
+                self._recording = False
 
         if self._paused and not self._speech_monitor_active and not self._recording:
             return  # drop audio during conversation (unless speech monitoring or recording)

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -104,6 +104,10 @@ class WakeWordListener:
         self._calibration_samples: list[int] = []  # RMS samples during calibration
         self._calibration_done = False
 
+        # Laptop mic recording (capture audio for STT instead of Misty's mic)
+        self._recording = False
+        self._recorded_frames: list[bytes] = []
+
         # openWakeWord model (lazy init)
         self._oww_model = None
 
@@ -294,6 +298,60 @@ class WakeWordListener:
                 f"(speech_detected={self._speech_detected})"
             )
 
+    def start_recording(self):
+        """Start capturing audio frames from the laptop mic for STT.
+        
+        Call this instead of (or alongside) Misty's recording to use the
+        laptop mic as the audio source. Frames are buffered in memory.
+        """
+        self._recorded_frames = []
+        self._recording = True
+        # Ensure audio flows even if paused
+        self._pause_event.set()
+        logger.info("Laptop mic recording started")
+
+    def stop_recording(self) -> bytes:
+        """Stop capturing and return WAV audio bytes.
+        
+        Returns:
+            WAV-format audio bytes (16kHz, 16-bit mono) ready for STT.
+        """
+        self._recording = False
+        frames = self._recorded_frames
+        self._recorded_frames = []
+
+        if not frames:
+            logger.warning("Laptop mic recording: no frames captured")
+            return b""
+
+        # Concatenate all PCM frames
+        pcm_data = b"".join(frames)
+        logger.info(
+            f"Laptop mic recording stopped: {len(frames)} frames, "
+            f"{len(pcm_data)} bytes PCM, "
+            f"{len(pcm_data) / (SAMPLE_RATE * 2):.1f}s"
+        )
+
+        # Wrap in WAV header (16kHz, 16-bit, mono)
+        import struct
+        wav_header = struct.pack(
+            '<4sI4s4sIHHIIHH4sI',
+            b'RIFF',
+            36 + len(pcm_data),
+            b'WAVE',
+            b'fmt ',
+            16,       # chunk size
+            1,        # PCM format
+            1,        # mono
+            SAMPLE_RATE,
+            SAMPLE_RATE * 2,  # byte rate
+            2,        # block align
+            16,       # bits per sample
+            b'data',
+            len(pcm_data),
+        )
+        return wav_header + pcm_data
+
     @property
     def is_running(self) -> bool:
         return self._running and self._stream is not None
@@ -323,13 +381,14 @@ class WakeWordListener:
         """Called by sounddevice for each audio block. Must be fast — just queue the data."""
         if status:
             logger.debug(f"Audio stream status: {status}")
-        if self._paused and not self._speech_monitor_active:
-            return  # drop audio during conversation (unless speech monitoring)
+        
+        # Buffer frames for laptop mic recording (independent of wake word state)
+        if self._recording:
+            self._recorded_frames.append(bytes(indata))
+
+        if self._paused and not self._speech_monitor_active and not self._recording:
+            return  # drop audio during conversation (unless speech monitoring or recording)
         data = bytes(indata)
-        # Log first speech monitor frame to verify data is flowing
-        if self._speech_monitor_active and self._total_frames % 100 == 0:
-            sample = int.from_bytes(data[:2], byteorder='little', signed=True) if len(data) >= 2 else 0
-            logger.info(f"Audio callback: speech_monitor frame, len={len(data)}, first_sample={sample}")
         try:
             self._audio_queue.put_nowait(data)
         except queue.Full:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -238,8 +238,9 @@ class TestPromptLimiting(unittest.TestCase):
     def setUp(self):
         if self._svc is None:
             self.skipTest("orchestration_service could not be imported; skipping unit tests")
-        # Reset conversation history before every test to avoid cross-test pollution
+        # Reset conversation history and response mode before every test
         self._svc.conversation_history = []
+        self._svc._last_response_mode = "short"
 
     # ------------------------------------------------------------------
     # Helpers
@@ -393,13 +394,143 @@ class TestPromptLimiting(unittest.TestCase):
         self.assertLessEqual(sentence_count, 2, f"Expected at most 2 sentences in: {text}")
 
     def test_max_tokens_is_40(self):
-        """The LLM payload must use max_tokens=40."""
+        """The LLM payload must use max_tokens=40 for short mode."""
         _, payload = self._call_llm_and_capture_payload("test question")
         self.assertEqual(
             payload["max_tokens"],
             40,
-            f"Expected max_tokens=40, got {payload['max_tokens']}",
+            f"Expected max_tokens=40 for short mode, got {payload['max_tokens']}",
         )
+
+    # ------------------------------------------------------------------
+    # Intent classification tests
+    # ------------------------------------------------------------------
+
+    def test_classify_intent_short_default(self):
+        """Normal questions should classify as 'short'."""
+        for text in ["What's your name?", "How are you?", "Tell me a joke.", "What's 2+2?"]:
+            mode = self._svc.classify_intent(text, "short")
+            self.assertEqual(mode, "short", f"Expected 'short' for: {text}")
+
+    def test_classify_intent_story(self):
+        """Story requests should classify as 'summary'."""
+        for text in ["Tell me a bedtime story", "Make up a story about a robot",
+                      "Tell me a fairy tale", "Can you tell me a scary story?"]:
+            mode = self._svc.classify_intent(text, "short")
+            self.assertEqual(mode, "summary", f"Expected 'summary' for: {text}")
+
+    def test_classify_intent_recipe(self):
+        """Recipe requests should classify as 'summary'."""
+        for text in ["Give me a recipe for chicken pot pie",
+                      "How do I make chocolate chip cookies?",
+                      "How to cook a steak?"]:
+            mode = self._svc.classify_intent(text, "short")
+            self.assertEqual(mode, "summary", f"Expected 'summary' for: {text}")
+
+    def test_classify_intent_explain(self):
+        """Explanation requests should classify as 'summary'."""
+        for text in ["Explain how gravity works", "Tell me about the solar system",
+                      "How does a computer work?"]:
+            mode = self._svc.classify_intent(text, "short")
+            self.assertEqual(mode, "summary", f"Expected 'summary' for: {text}")
+
+    def test_classify_intent_continuation(self):
+        """Continuation phrases after a summary should classify as 'continuation'."""
+        for text in ["yes", "more", "continue", "go on", "tell me more",
+                      "what happens next", "keep going"]:
+            mode = self._svc.classify_intent(text, "summary")
+            self.assertEqual(mode, "continuation", f"Expected 'continuation' for: {text}")
+
+    def test_classify_intent_continuation_requires_prior_summary(self):
+        """Continuation phrases should NOT trigger if last mode was 'short'."""
+        mode = self._svc.classify_intent("yes", "short")
+        self.assertEqual(mode, "short", "'yes' after short mode should stay 'short'")
+
+    def test_classify_intent_continuation_chain(self):
+        """Continuation should chain — 'more' after continuation stays continuation."""
+        mode = self._svc.classify_intent("more", "continuation")
+        self.assertEqual(mode, "continuation", "'more' after continuation should stay 'continuation'")
+
+    def test_classify_intent_empty_input(self):
+        """Empty input should default to 'short'."""
+        self.assertEqual(self._svc.classify_intent("", "short"), "short")
+        self.assertEqual(self._svc.classify_intent("  ", "summary"), "short")
+
+    # ------------------------------------------------------------------
+    # Adaptive response mode tests
+    # ------------------------------------------------------------------
+
+    def test_summary_mode_max_tokens_80(self):
+        """Summary mode requests should use max_tokens=80."""
+        _, payload = self._call_llm_and_capture_payload("Tell me a bedtime story")
+        self.assertEqual(
+            payload["max_tokens"],
+            80,
+            f"Expected max_tokens=80 for summary mode, got {payload['max_tokens']}",
+        )
+
+    def test_summary_mode_includes_prompt_suffix(self):
+        """Summary mode should inject a mode-specific system prompt."""
+        _, payload = self._call_llm_and_capture_payload("Tell me a bedtime story")
+        system_msgs = [m for m in payload["messages"] if m["role"] == "system"]
+        system_text = " ".join(m["content"] for m in system_msgs)
+        self.assertIn("Want to hear more", system_text,
+                       "Summary mode should include 'Want to hear more?' in system prompt")
+
+    def test_summary_mode_truncation_50_words(self):
+        """Summary mode should truncate at 50 words, not 25."""
+        long_response = " ".join([f"word{i}" for i in range(60)])
+        result, _ = self._call_llm_and_capture_payload(
+            "Tell me a bedtime story", mock_response_text=long_response
+        )
+        words = result["text"].split()
+        self.assertLessEqual(len(words), 51)  # 50 + possible trailing period
+        self.assertGreater(len(words), 25, "Summary mode should allow more than 25 words")
+
+    def test_response_includes_mode_field(self):
+        """API response should include responseMode field."""
+        result, _ = self._call_llm_and_capture_payload("What's your name?")
+        self.assertIn("responseMode", result)
+        self.assertEqual(result["responseMode"], "short")
+
+    def test_response_mode_summary_in_result(self):
+        """Summary mode should be reflected in the response."""
+        result, _ = self._call_llm_and_capture_payload("Tell me a bedtime story")
+        self.assertEqual(result["responseMode"], "summary")
+
+    def test_continuation_mode_after_summary(self):
+        """After a summary response, 'yes' should trigger continuation mode."""
+        # First call: summary
+        self._call_llm_and_capture_payload("Tell me a bedtime story")
+        # Second call: continuation
+        result, payload = self._call_llm_and_capture_payload("yes")
+        self.assertEqual(result["responseMode"], "continuation")
+        self.assertEqual(payload["max_tokens"], 80)
+
+    def test_topic_change_resets_to_short(self):
+        """Changing topic after a summary should reset to short mode."""
+        # First call: summary
+        self._call_llm_and_capture_payload("Tell me a bedtime story")
+        # Second call: different topic
+        result, payload = self._call_llm_and_capture_payload("What's 2 plus 2?")
+        self.assertEqual(result["responseMode"], "short")
+        self.assertEqual(payload["max_tokens"], 40)
+
+    def test_brevity_reminder_suppressed_in_summary_mode(self):
+        """Brevity reminder should not appear in summary/continuation modes."""
+        # Fill history to trigger brevity reminder threshold (>4 messages)
+        self._svc.conversation_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "hi again"},
+            {"role": "assistant", "content": "hello again"},
+            {"role": "user", "content": "one more"},
+        ]
+        _, payload = self._call_llm_and_capture_payload("Tell me a bedtime story")
+        system_msgs = [m for m in payload["messages"] if m["role"] == "system"]
+        system_text = " ".join(m["content"] for m in system_msgs)
+        self.assertNotIn("Stay punchy", system_text,
+                          "Brevity reminder should be suppressed in summary mode")
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -364,9 +364,9 @@ class TestPromptLimiting(unittest.TestCase):
             f"History should be capped near 8, got {len(self._svc.conversation_history)}",
         )
 
-    def test_response_truncation_at_25_words(self):
-        """Responses over 25 words must be truncated to 25 words or 2 sentences."""
-        long_response = " ".join([f"word{i}" for i in range(40)])
+    def test_response_truncation_at_35_words(self):
+        """Responses over 35 words must be truncated to 35 words or 3 sentences."""
+        long_response = " ".join([f"word{i}" for i in range(50)])
         result, _ = self._call_llm_and_capture_payload(
             "test", mock_response_text=long_response
         )
@@ -374,32 +374,33 @@ class TestPromptLimiting(unittest.TestCase):
         words = result["text"].split()
         self.assertLessEqual(
             len(words),
-            26,  # 25 words + possible trailing period word
-            f"Response should be truncated to ~25 words, got {len(words)}",
+            36,  # 35 words + possible trailing period word
+            f"Response should be truncated to ~35 words, got {len(words)}",
         )
 
     def test_two_sentence_truncation(self):
-        """A response with 3+ sentences over 25 words should be truncated at 2 sentence boundaries."""
-        three_sentences = (
+        """A response with 4+ sentences over 35 words should be truncated at 3 sentence boundaries."""
+        four_sentences = (
             "This is the very first long sentence about robotics and AI technology. "
             "This is the equally long second sentence with more interesting details. "
-            "This is the third sentence that definitely should be cut out entirely."
+            "This is the third sentence that adds even more juicy context here. "
+            "This is the fourth sentence that definitely should be cut out entirely."
         )
         result, _ = self._call_llm_and_capture_payload(
-            "test", mock_response_text=three_sentences
+            "test", mock_response_text=four_sentences
         )
-        # Should keep at most 2 sentence-ending punctuation marks
+        # Should keep at most 3 sentence-ending punctuation marks
         text = result["text"]
         sentence_count = text.count(".") + text.count("!") + text.count("?")
-        self.assertLessEqual(sentence_count, 2, f"Expected at most 2 sentences in: {text}")
+        self.assertLessEqual(sentence_count, 3, f"Expected at most 3 sentences in: {text}")
 
-    def test_max_tokens_is_40(self):
-        """The LLM payload must use max_tokens=40 for short mode."""
+    def test_max_tokens_is_60(self):
+        """The LLM payload must use max_tokens=60 for short mode."""
         _, payload = self._call_llm_and_capture_payload("test question")
         self.assertEqual(
             payload["max_tokens"],
-            40,
-            f"Expected max_tokens=40 for short mode, got {payload['max_tokens']}",
+            60,
+            f"Expected max_tokens=60 for short mode, got {payload['max_tokens']}",
         )
 
     # ------------------------------------------------------------------
@@ -514,7 +515,7 @@ class TestPromptLimiting(unittest.TestCase):
         # Second call: different topic
         result, payload = self._call_llm_and_capture_payload("What's 2 plus 2?")
         self.assertEqual(result["responseMode"], "short")
-        self.assertEqual(payload["max_tokens"], 40)
+        self.assertEqual(payload["max_tokens"], 60)
 
     def test_brevity_reminder_suppressed_in_summary_mode(self):
         """Brevity reminder should not appear in summary/continuation modes."""


### PR DESCRIPTION
Closes #46

## Summary

Two-sided improvement to Misty's conversational ability:

### Part A: Adaptive Response Length
- **Intent classifier** detects story/recipe/explain/list requests via regex patterns (zero LLM cost)
- **Three response modes**: short (40 tokens, current), summary (80 tokens + 'Want to hear more?'), continuation (80 tokens, chunked delivery)
- **Continuation chains**: 'yes'/'more'/'go on' after a summary triggers next chunk; topic change resets to short mode
- **Per-mode truncation**: short=25 words/2 sentences, summary/continuation=50 words/3 sentences
- Brevity reminder suppressed in long-form modes; \n stop sequence removed for multi-sentence responses

### Part B: VAD-Controlled Recording
- **Speech monitor** added to `wake_word_listener.py` using RMS-based voice activity detection
- Laptop mic monitors speech in parallel with Misty recording (reuses existing sounddevice stream)
- **Dynamic recording duration**: 3s min → 15s max, with 1.5s silence = end of utterance
- Short questions save ~3s per turn; long requests extend past 6s to capture full sentences
- No-speech early exit at 4s; follow-up recordings use 2s min / 10s max
- Falls back to fixed 6s if no laptop wake word listener

### Tests
- 24 unit tests pass (16 new for intent classification, modes, continuation, truncation)
- 30 new test questions in docs covering summary, continuation, VAD short/long, mixed flow, edge cases

### Files changed
- `orchestration_service.py` — intent classifier, response modes, continuation tracking
- `wake_word_listener.py` — speech monitor with RMS-based VAD
- `misty_controller.py` — VAD-controlled recording in main + follow-up
- `test_integration.py` — 16 new unit tests
- `test-questions-richer-responses.md` — 30 new test scenarios