### PR TITLE
feat: add drive/locomotion primitives to misty_controller (#48)

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -218,6 +218,108 @@ class MistyController:
             body["RightArmPosition"] = right
         self.misty_post("/api/arms", body)
 
+    # --- Drive / Locomotion (#48) ---
+
+    # Safety bounds — enforced on all drive commands
+    DRIVE_MAX_LINEAR_PCT = 30      # max linear velocity percent
+    DRIVE_MAX_ANGULAR_PCT = 30     # max angular velocity percent
+    DRIVE_MAX_DURATION_MS = 5000   # max single drive command duration (5s)
+
+    def drive(self, linear_velocity: float, angular_velocity: float):
+        """Drive Misty continuously until stop() or halt() is called.
+
+        Args:
+            linear_velocity: -100 (full backward) to 100 (full forward).
+            angular_velocity: -100 (clockwise) to 100 (counter-clockwise).
+        """
+        linear_velocity = max(-self.DRIVE_MAX_LINEAR_PCT, min(self.DRIVE_MAX_LINEAR_PCT, linear_velocity))
+        angular_velocity = max(-self.DRIVE_MAX_ANGULAR_PCT, min(self.DRIVE_MAX_ANGULAR_PCT, angular_velocity))
+        logger.info(f"Drive: linear={linear_velocity:.0f}%, angular={angular_velocity:.0f}%")
+        return self.misty_post("/api/drive", {
+            "LinearVelocity": linear_velocity,
+            "AngularVelocity": angular_velocity,
+        })
+
+    def drive_time(self, linear_velocity: float, angular_velocity: float, time_ms: int):
+        """Drive Misty for a specified duration then stop automatically.
+
+        Args:
+            linear_velocity: -100 (full backward) to 100 (full forward).
+            angular_velocity: -100 (clockwise) to 100 (counter-clockwise).
+            time_ms: Duration in milliseconds (min 100, max DRIVE_MAX_DURATION_MS).
+        """
+        linear_velocity = max(-self.DRIVE_MAX_LINEAR_PCT, min(self.DRIVE_MAX_LINEAR_PCT, linear_velocity))
+        angular_velocity = max(-self.DRIVE_MAX_ANGULAR_PCT, min(self.DRIVE_MAX_ANGULAR_PCT, angular_velocity))
+        time_ms = max(100, min(self.DRIVE_MAX_DURATION_MS, int(time_ms)))
+        logger.info(f"DriveTime: linear={linear_velocity:.0f}%, angular={angular_velocity:.0f}%, duration={time_ms}ms")
+        return self.misty_post("/api/drive/time", {
+            "LinearVelocity": linear_velocity,
+            "AngularVelocity": angular_velocity,
+            "TimeMs": time_ms,
+        })
+
+    def drive_track(self, left_speed: float, right_speed: float):
+        """Drive Misty using individual track speeds.
+
+        Args:
+            left_speed: -100 (full backward) to 100 (full forward).
+            right_speed: -100 (full backward) to 100 (full forward).
+        """
+        left_speed = max(-self.DRIVE_MAX_LINEAR_PCT, min(self.DRIVE_MAX_LINEAR_PCT, left_speed))
+        right_speed = max(-self.DRIVE_MAX_LINEAR_PCT, min(self.DRIVE_MAX_LINEAR_PCT, right_speed))
+        logger.info(f"DriveTrack: left={left_speed:.0f}%, right={right_speed:.0f}%")
+        return self.misty_post("/api/drive/track", {
+            "LeftTrackSpeed": left_speed,
+            "RightTrackSpeed": right_speed,
+        })
+
+    def halt(self):
+        """Emergency stop — halts ALL motors (drive, head, arms). Use for safety stops."""
+        logger.warning("HALT: stopping all motors")
+        return self.misty_post("/api/halt")
+
+    def stop_driving(self):
+        """Stop drive motors only (head/arms unaffected)."""
+        logger.info("Stop driving")
+        return self.misty_post("/api/drive/stop")
+
+    def drive_arc(self, heading: float, radius: float, time_ms: int, reverse: bool = False):
+        """Drive in an arc to reach an absolute heading.
+
+        Args:
+            heading: Target absolute heading (0-360 or -180 to 180).
+            radius: Arc radius in meters.
+            time_ms: Duration in milliseconds.
+            reverse: If True, drive in reverse.
+        """
+        time_ms = max(100, min(self.DRIVE_MAX_DURATION_MS, int(time_ms)))
+        logger.info(f"DriveArc: heading={heading:.0f}°, radius={radius:.2f}m, duration={time_ms}ms")
+        return self.misty_post("/api/drive/arc", {
+            "Heading": heading,
+            "Radius": radius,
+            "TimeMs": time_ms,
+            "Reverse": reverse,
+        })
+
+    def drive_heading(self, heading: float, distance: float, time_ms: int, reverse: bool = False):
+        """Drive in a straight line maintaining an absolute heading.
+
+        Args:
+            heading: Absolute heading to maintain (0-360 or -180 to 180).
+            distance: Distance in meters (max 1.0m per command for safety).
+            time_ms: Duration in milliseconds.
+            reverse: If True, drive in reverse.
+        """
+        distance = max(0.01, min(1.0, distance))
+        time_ms = max(100, min(self.DRIVE_MAX_DURATION_MS, int(time_ms)))
+        logger.info(f"DriveHeading: heading={heading:.0f}°, distance={distance:.2f}m, duration={time_ms}ms")
+        return self.misty_post("/api/drive/hdt", {
+            "Heading": heading,
+            "Distance": distance,
+            "TimeMs": time_ms,
+            "Reverse": reverse,
+        })
+
     def start_keyphrase(self, force_restart=False):
         if force_restart:
             self.misty_post("/api/audio/keyphrase/stop")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -569,5 +569,162 @@ class TestPromptLimiting(unittest.TestCase):
                           "Brevity reminder should be suppressed in summary mode")
 
 
+class TestDrivePrimitives(unittest.TestCase):
+    """Unit tests for drive/locomotion methods (#48).
+
+    These tests mock HTTP calls — no live robot required.
+    """
+
+    _ctrl = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            _ctrl_path = os.path.normpath(
+                os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+            )
+            if _ctrl_path not in sys.path:
+                sys.path.insert(0, _ctrl_path)
+            from misty_controller import MistyController
+            cls._MistyController = MistyController
+        except Exception as exc:
+            cls._MistyController = None
+            print(f"[TestDrivePrimitives] Could not import misty_controller: {exc}")
+
+    def setUp(self):
+        if self._MistyController is None:
+            self.skipTest("misty_controller could not be imported")
+        self.ctrl = self._MistyController()
+        # Mock misty_post to capture calls without network
+        self._post_calls = []
+        self.ctrl.misty_post = lambda endpoint, body=None, timeout=5.0: (
+            self._post_calls.append((endpoint, body)) or {"status": "Success", "result": True}
+        )
+
+    # --- Parameter clamping tests ---
+
+    def test_drive_clamps_linear_velocity(self):
+        """Linear velocity should be clamped to ±DRIVE_MAX_LINEAR_PCT."""
+        self.ctrl.drive(200, 0)
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive")
+        self.assertEqual(body["LinearVelocity"], self.ctrl.DRIVE_MAX_LINEAR_PCT)
+
+    def test_drive_clamps_negative_linear_velocity(self):
+        """Negative linear velocity should be clamped."""
+        self.ctrl.drive(-200, 0)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["LinearVelocity"], -self.ctrl.DRIVE_MAX_LINEAR_PCT)
+
+    def test_drive_clamps_angular_velocity(self):
+        """Angular velocity should be clamped to ±DRIVE_MAX_ANGULAR_PCT."""
+        self.ctrl.drive(0, 150)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["AngularVelocity"], self.ctrl.DRIVE_MAX_ANGULAR_PCT)
+
+    def test_drive_passes_valid_values_unchanged(self):
+        """Values within bounds pass through unchanged."""
+        self.ctrl.drive(15, -10)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["LinearVelocity"], 15)
+        self.assertEqual(body["AngularVelocity"], -10)
+
+    # --- DriveTime tests ---
+
+    def test_drive_time_clamps_duration(self):
+        """Duration should be clamped to DRIVE_MAX_DURATION_MS."""
+        self.ctrl.drive_time(10, 0, 99999)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["TimeMs"], self.ctrl.DRIVE_MAX_DURATION_MS)
+
+    def test_drive_time_enforces_minimum_duration(self):
+        """Duration below 100ms should be raised to 100."""
+        self.ctrl.drive_time(10, 0, 50)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["TimeMs"], 100)
+
+    def test_drive_time_valid_params(self):
+        """Valid parameters pass through correctly."""
+        self.ctrl.drive_time(20, -15, 2000)
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive/time")
+        self.assertEqual(body["LinearVelocity"], 20)
+        self.assertEqual(body["AngularVelocity"], -15)
+        self.assertEqual(body["TimeMs"], 2000)
+
+    # --- DriveTrack tests ---
+
+    def test_drive_track_clamps_speeds(self):
+        """Track speeds should be clamped to ±DRIVE_MAX_LINEAR_PCT."""
+        self.ctrl.drive_track(100, -100)
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive/track")
+        self.assertEqual(body["LeftTrackSpeed"], self.ctrl.DRIVE_MAX_LINEAR_PCT)
+        self.assertEqual(body["RightTrackSpeed"], -self.ctrl.DRIVE_MAX_LINEAR_PCT)
+
+    def test_drive_track_valid_params(self):
+        """Valid track speeds pass through."""
+        self.ctrl.drive_track(20, 25)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["LeftTrackSpeed"], 20)
+        self.assertEqual(body["RightTrackSpeed"], 25)
+
+    # --- Halt / Stop tests ---
+
+    def test_halt_calls_correct_endpoint(self):
+        """halt() should call POST /api/halt."""
+        self.ctrl.halt()
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/halt")
+
+    def test_stop_driving_calls_correct_endpoint(self):
+        """stop_driving() should call POST /api/drive/stop."""
+        self.ctrl.stop_driving()
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive/stop")
+
+    # --- DriveArc tests ---
+
+    def test_drive_arc_clamps_duration(self):
+        """DriveArc duration should be clamped."""
+        self.ctrl.drive_arc(90, 0.5, 99999)
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive/arc")
+        self.assertEqual(body["TimeMs"], self.ctrl.DRIVE_MAX_DURATION_MS)
+        self.assertEqual(body["Heading"], 90)
+        self.assertEqual(body["Radius"], 0.5)
+        self.assertFalse(body["Reverse"])
+
+    def test_drive_arc_reverse(self):
+        """DriveArc with reverse=True."""
+        self.ctrl.drive_arc(180, 1.0, 3000, reverse=True)
+        _, body = self._post_calls[-1]
+        self.assertTrue(body["Reverse"])
+
+    # --- DriveHeading tests ---
+
+    def test_drive_heading_clamps_distance(self):
+        """Distance should be clamped to max 1.0m."""
+        self.ctrl.drive_heading(0, 5.0, 3000)
+        endpoint, body = self._post_calls[-1]
+        self.assertEqual(endpoint, "/api/drive/hdt")
+        self.assertEqual(body["Distance"], 1.0)
+
+    def test_drive_heading_clamps_min_distance(self):
+        """Distance below 0.01m should be raised."""
+        self.ctrl.drive_heading(0, 0.001, 1000)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["Distance"], 0.01)
+
+    def test_drive_heading_valid_params(self):
+        """Valid heading parameters pass through."""
+        self.ctrl.drive_heading(45, 0.5, 2000, reverse=True)
+        _, body = self._post_calls[-1]
+        self.assertEqual(body["Heading"], 45)
+        self.assertEqual(body["Distance"], 0.5)
+        self.assertEqual(body["TimeMs"], 2000)
+        self.assertTrue(body["Reverse"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds 7 drive methods to misty_controller.py with safety bounds enforcement for Phase 1 navigation.

Closes #48

## Methods Added
| Method | Endpoint | Purpose |
|--------|----------|---------|
| drive(linear, angular) | POST /api/drive | Continuous drive |
| drive_time(linear, angular, time_ms) | POST /api/drive/time | Timed drive |
| drive_track(left, right) | POST /api/drive/track | Individual track control |
| halt() | POST /api/halt | Emergency stop ALL motors |
| stop_driving() | POST /api/drive/stop | Stop drive only |
| drive_arc(heading, radius, time_ms) | POST /api/drive/arc | Arc movement |
| drive_heading(heading, distance, time_ms) | POST /api/drive/hdt | Heading-locked drive |

## Safety Bounds (enforced in code)
- Linear velocity: clamped to +/-30%
- Angular velocity: clamped to +/-30%  
- Duration: 100ms min, 5000ms max
- Distance: 0.01m min, 1.0m max

## Tests
16 new unit tests in TestDrivePrimitives — all pass. No live robot required (HTTP mocked).

## Phase
Phase 1: Manual Teleop + Hazard Monitoring (first of 6 Phase 1 issues)