### PR TITLE
feat: add hazard/ToF/bump telemetry subscription (#49)

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -65,6 +65,12 @@ BATTERY_RESUME = 0.25         # exit charging mode (must also be charging)
 BATTERY_TEMP_WARN_C = 45.0    # log warning
 BATTERY_TEMP_THROTTLE_C = 50.0  # add delay between turns
 
+# Movement-specific battery thresholds (#52)
+BATTERY_MOVEMENT_CUTOFF = 0.25     # deny movement below 25% (motors draw heavy current)
+BATTERY_MOVEMENT_VOLTAGE_MIN = 7.5  # deny movement below 7.5V (near abrupt shutdown ~7V)
+BATTERY_SLAM_CUTOFF = 0.35         # deny SLAM below 35% (memory-intensive)
+BATTERY_VOLTAGE_DROP_HALT = 0.3    # halt if voltage drops >0.3V between readings (load-induced sag)
+
 # Idle timeout
 IDLE_TIMEOUT_S = float(os.getenv("IDLE_TIMEOUT_S", "900"))  # 15 minutes
 
@@ -400,6 +406,9 @@ class MistyController:
 
     # --- Movement Lifecycle (#50) ---
 
+    # Settle time after motors stop before resuming audio (#53)
+    MOVEMENT_SETTLE_MS = 500  # ms to wait after halt before resuming wake word
+
     def _safe_halt(self, reason: str = "unknown"):
         """Stop all motors safely. Called before any transition FROM MOVING state.
 
@@ -409,6 +418,19 @@ class MistyController:
         logger.warning(f"Safe halt: reason={reason}")
         self.halt()
 
+    def _pause_wake_word_for_movement(self):
+        """Pause wake word listener during movement (motor noise interference, #53)."""
+        if self._wake_word_listener:
+            self._wake_word_listener.pause()
+            logger.info("Wake word paused for movement")
+
+    def _resume_wake_word_after_movement(self):
+        """Resume wake word listener after movement + settle time (#53)."""
+        time.sleep(self.MOVEMENT_SETTLE_MS / 1000.0)
+        if self._wake_word_listener:
+            self._wake_word_listener.resume()
+            logger.info("Wake word resumed after movement")
+
     def start_moving(self, reason: str = "command") -> bool:
         """Transition to MOVING state if safe to do so.
 
@@ -416,7 +438,7 @@ class MistyController:
         - Must be in IDLE state
         - No active hazards
         - No active bump contacts
-        - Battery not critically low
+        - Battery above movement cutoff (25% or 7.5V) (#52)
 
         Returns True if transition succeeded, False if blocked.
         """
@@ -430,15 +452,24 @@ class MistyController:
                 return False
 
         with self.battery_lock:
-            if self.battery.charge_percent < BATTERY_LOW_CRITICAL and self.battery.last_updated > 0:
-                logger.warning(f"Cannot start moving: battery critical ({self.battery.charge_percent*100:.0f}%)")
-                return False
+            if self.battery.last_updated > 0:
+                if self.battery.charge_percent < BATTERY_MOVEMENT_CUTOFF:
+                    logger.warning(f"Cannot start moving: battery too low for movement "
+                                   f"({self.battery.charge_percent*100:.0f}% < {BATTERY_MOVEMENT_CUTOFF*100:.0f}%)")
+                    return False
+                if self.battery.voltage > 0 and self.battery.voltage < BATTERY_MOVEMENT_VOLTAGE_MIN:
+                    logger.warning(f"Cannot start moving: voltage too low "
+                                   f"({self.battery.voltage:.1f}V < {BATTERY_MOVEMENT_VOLTAGE_MIN}V)")
+                    return False
 
         # Atomic state transition
         if not self.try_set_state(State.IDLE, State.MOVING):
             current = self.get_state()
             logger.warning(f"Cannot start moving: not IDLE (state={current.value})")
             return False
+
+        # Pause wake word — motor noise interferes with detection (#53)
+        self._pause_wake_word_for_movement()
 
         logger.info(f"MOVING: started (reason={reason})")
         return True
@@ -458,6 +489,13 @@ class MistyController:
         self.last_activity_time = time.time()
         logger.info(f"Movement stopped: reason={reason}")
 
+        # Resume wake word after settle time (non-blocking, #53)
+        threading.Thread(
+            target=self._resume_wake_word_after_movement,
+            name="resume-wake-post-move",
+            daemon=True,
+        ).start()
+
     def preempt_movement(self, reason: str):
         """Force-stop movement due to higher-priority event.
 
@@ -471,6 +509,13 @@ class MistyController:
         logger.warning(f"Movement PREEMPTED: {reason}")
         self._safe_halt(reason)
         self.last_activity_time = time.time()
+
+        # Resume wake word after settle time (non-blocking, #53)
+        threading.Thread(
+            target=self._resume_wake_word_after_movement,
+            name="resume-wake-preempt",
+            daemon=True,
+        ).start()
 
     def start_keyphrase(self, force_restart=False):
         if force_restart:
@@ -679,10 +724,36 @@ class MistyController:
         """Check battery levels and trigger state changes as needed."""
         # Critical: auto-enter charging mode (atomic transition)
         if b.charge_percent < BATTERY_LOW_CRITICAL:
+            # If moving, preempt first
+            if self.get_state() == State.MOVING:
+                self.preempt_movement("battery_critical")
             if self.try_set_state(State.IDLE, State.CHARGING):
                 logger.warning(f"Battery critically low ({b.charge_percent*100:.0f}%) — entering charging mode")
                 self._apply_charging_mode()
             return
+
+        # Movement-specific: halt if battery drops below movement threshold (#52)
+        if self.get_state() == State.MOVING:
+            if b.charge_percent < BATTERY_MOVEMENT_CUTOFF:
+                logger.warning(f"Battery below movement cutoff during MOVING "
+                               f"({b.charge_percent*100:.0f}% < {BATTERY_MOVEMENT_CUTOFF*100:.0f}%)")
+                self.preempt_movement("battery_critical")
+                return
+            if b.voltage > 0 and b.voltage < BATTERY_MOVEMENT_VOLTAGE_MIN:
+                logger.warning(f"Voltage below movement minimum during MOVING "
+                               f"({b.voltage:.1f}V < {BATTERY_MOVEMENT_VOLTAGE_MIN}V)")
+                self.preempt_movement("battery_critical")
+                return
+
+        # Voltage drop detection: halt movement if voltage sags rapidly (#52)
+        if self.get_state() == State.MOVING and b.voltage > 0:
+            last_voltage = getattr(self, '_last_battery_voltage', 0.0)
+            if last_voltage > 0 and (last_voltage - b.voltage) > BATTERY_VOLTAGE_DROP_HALT:
+                logger.warning(f"Rapid voltage drop detected during movement: "
+                               f"{last_voltage:.2f}V → {b.voltage:.2f}V (drop={last_voltage - b.voltage:.2f}V)")
+                self.preempt_movement("battery_critical")
+        if b.voltage > 0:
+            self._last_battery_voltage = b.voltage
 
         # Exit charging mode when sufficiently charged (charge level alone, no is_charging requirement)
         if self.get_state() == State.CHARGING and b.charge_percent >= BATTERY_RESUME:

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -173,10 +173,24 @@ class State(Enum):
     PROCESSING = "PROCESSING"
     PLAYING = "PLAYING"
     LISTENING = "LISTENING"  # follow-up listening after response
+    MOVING = "MOVING"        # robot is in motion (#50)
     REARMING = "REARMING"
     REBOOTING = "REBOOTING"  # proactive reboot in progress (#22)
     CHARGING = "CHARGING"
     ERROR = "ERROR"
+
+
+# Movement preemption priority (highest priority first) — determines what can
+# interrupt an active movement command. (#50)
+PREEMPTION_PRIORITY = [
+    "hazard_stop",       # firmware-level HazardNotification (auto-halts motors)
+    "battery_critical",  # battery < BATTERY_LOW_CRITICAL
+    "emergency_halt",    # explicit halt() call (e.g., from teleop kill switch)
+    "bump_contact",      # physical bump sensor contact
+    "telemetry_stale",   # safety sensors went dark (fail closed)
+    "wake_word",         # user wants to talk — stop and listen
+    "move_complete",     # normal movement completion
+]
 
 
 class MistyController:
@@ -383,6 +397,80 @@ class MistyController:
             "TimeMs": time_ms,
             "Reverse": reverse,
         })
+
+    # --- Movement Lifecycle (#50) ---
+
+    def _safe_halt(self, reason: str = "unknown"):
+        """Stop all motors safely. Called before any transition FROM MOVING state.
+
+        This is the single choke point for movement termination — ensures motors
+        are always stopped regardless of why movement ended.
+        """
+        logger.warning(f"Safe halt: reason={reason}")
+        self.halt()
+
+    def start_moving(self, reason: str = "command") -> bool:
+        """Transition to MOVING state if safe to do so.
+
+        Pre-checks:
+        - Must be in IDLE state
+        - No active hazards
+        - No active bump contacts
+        - Battery not critically low
+
+        Returns True if transition succeeded, False if blocked.
+        """
+        # Pre-flight safety checks
+        with self.hazard_lock:
+            if self.hazard.active_hazards:
+                logger.warning(f"Cannot start moving: active hazards ({len(self.hazard.active_hazards)})")
+                return False
+            if self.hazard.any_bump_active:
+                logger.warning("Cannot start moving: bump sensor active")
+                return False
+
+        with self.battery_lock:
+            if self.battery.charge_percent < BATTERY_LOW_CRITICAL and self.battery.last_updated > 0:
+                logger.warning(f"Cannot start moving: battery critical ({self.battery.charge_percent*100:.0f}%)")
+                return False
+
+        # Atomic state transition
+        if not self.try_set_state(State.IDLE, State.MOVING):
+            current = self.get_state()
+            logger.warning(f"Cannot start moving: not IDLE (state={current.value})")
+            return False
+
+        logger.info(f"MOVING: started (reason={reason})")
+        return True
+
+    def stop_moving(self, reason: str = "complete"):
+        """Transition from MOVING back to IDLE, halting motors first.
+
+        Args:
+            reason: Why movement is stopping (for logging/telemetry).
+                    One of PREEMPTION_PRIORITY values or custom string.
+        """
+        if self.get_state() != State.MOVING:
+            return
+
+        self._safe_halt(reason)
+        self.set_state(State.IDLE)
+        self.last_activity_time = time.time()
+        logger.info(f"Movement stopped: reason={reason}")
+
+    def preempt_movement(self, reason: str):
+        """Force-stop movement due to higher-priority event.
+
+        Unlike stop_moving(), this can be called from any thread (e.g., WS event
+        handler) and will interrupt in-progress movement immediately.
+        """
+        with self.state_lock:
+            if self.state != State.MOVING:
+                return
+            self.state = State.IDLE
+        logger.warning(f"Movement PREEMPTED: {reason}")
+        self._safe_halt(reason)
+        self.last_activity_time = time.time()
 
     def start_keyphrase(self, force_restart=False):
         if force_restart:
@@ -649,6 +737,10 @@ class MistyController:
 
         if hazards:
             logger.warning(f"HAZARD: {len(hazards)} active — {hazards}")
+            # Preempt movement if in MOVING state (firmware already halted motors,
+            # but we need to update our state machine)
+            if self.get_state() == State.MOVING:
+                self.preempt_movement("hazard_stop")
         else:
             # Hazard cleared
             with self.hazard_lock:
@@ -710,6 +802,9 @@ class MistyController:
 
         if is_pressed:
             logger.warning(f"BUMP: {sensor_name} contacted")
+            # Preempt movement if in MOVING state
+            if self.get_state() == State.MOVING:
+                self.preempt_movement("bump_contact")
         else:
             logger.info(f"Bump released: {sensor_name}")
 
@@ -1194,6 +1289,16 @@ class MistyController:
 
             if self.get_state() == State.IDLE and time.time() >= self.ready_time:
                 logger.info("[Wake] Wake word detected!")
+                self.turn_id += 1
+                threading.Thread(
+                    target=self._handle_conversation_turn,
+                    name=f"turn-{self.turn_id}",
+                    daemon=True,
+                ).start()
+            elif self.get_state() == State.MOVING:
+                # Wake word during movement — stop moving, then start conversation
+                logger.info("[Wake] Wake word during movement — preempting to converse")
+                self.preempt_movement("wake_word")
                 self.turn_id += 1
                 threading.Thread(
                     target=self._handle_conversation_turn,

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -2158,6 +2158,113 @@ class ControllerAPIHandler(BaseHTTPRequestHandler):
                 "turn_id": ctrl.turn_id,
                 "message": "Conversation turn started — Misty is recording",
             })
+
+        elif self.path == "/api/move":
+            # Teleop movement endpoint (#51) — strict parameter validation
+            ctrl = self.controller
+            try:
+                content_len = int(self.headers.get("Content-Length", 0))
+                body = json.loads(self.rfile.read(content_len)) if content_len > 0 else {}
+            except (json.JSONDecodeError, ValueError):
+                self._send_json(400, {"error": "invalid_json", "message": "Request body must be valid JSON"})
+                return
+
+            command = body.get("command")
+            valid_commands = ("forward", "backward", "rotate_left", "rotate_right", "halt")
+            if command not in valid_commands:
+                self._send_json(400, {
+                    "error": "invalid_command",
+                    "message": f"command must be one of: {valid_commands}",
+                    "received": command,
+                })
+                return
+
+            # Handle halt immediately (no state transition needed)
+            if command == "halt":
+                ctrl.halt()
+                self._send_json(200, {"status": "ok", "command": "halt", "message": "Emergency halt issued"})
+                return
+
+            # Validate parameters
+            distance_mm = body.get("distance_mm", 200)
+            speed_pct = body.get("speed_pct", 20)
+            angle_deg = body.get("angle_deg", 90)
+
+            # Strict bounds
+            if not isinstance(distance_mm, (int, float)) or distance_mm < 50 or distance_mm > 500:
+                self._send_json(400, {
+                    "error": "invalid_distance",
+                    "message": "distance_mm must be 50-500",
+                    "received": distance_mm,
+                })
+                return
+            if not isinstance(speed_pct, (int, float)) or speed_pct < 5 or speed_pct > 30:
+                self._send_json(400, {
+                    "error": "invalid_speed",
+                    "message": "speed_pct must be 5-30",
+                    "received": speed_pct,
+                })
+                return
+            if command in ("rotate_left", "rotate_right"):
+                if not isinstance(angle_deg, (int, float)) or angle_deg < 10 or angle_deg > 180:
+                    self._send_json(400, {
+                        "error": "invalid_angle",
+                        "message": "angle_deg must be 10-180",
+                        "received": angle_deg,
+                    })
+                    return
+
+            # Attempt to enter MOVING state
+            if not ctrl.start_moving(reason=f"teleop_{command}"):
+                state = ctrl.get_state()
+                self._send_json(409, {
+                    "error": "cannot_move",
+                    "state": state.name,
+                    "message": "Cannot start moving — check state, hazards, or battery",
+                })
+                return
+
+            # Execute movement command in background thread
+            def _execute_teleop():
+                try:
+                    if command in ("forward", "backward"):
+                        # Calculate duration from distance and speed
+                        # At speed_pct=30, max velocity ~135mm/s (30% of 450mm/s)
+                        velocity_mms = (speed_pct / 100.0) * 450.0
+                        duration_ms = int((distance_mm / velocity_mms) * 1000)
+                        duration_ms = max(100, min(ctrl.DRIVE_MAX_DURATION_MS, duration_ms))
+                        linear = speed_pct if command == "forward" else -speed_pct
+                        ctrl.drive_time(linear, 0, duration_ms)
+                        time.sleep(duration_ms / 1000.0 + 0.2)  # wait for completion + buffer
+                    elif command in ("rotate_left", "rotate_right"):
+                        # Rotate in place — angular velocity only
+                        # Approximate: at 20% angular, ~30 deg/s → duration = angle/30 * 1000ms
+                        angular_rate = (speed_pct / 100.0) * 150.0  # approx deg/s
+                        duration_ms = int((angle_deg / angular_rate) * 1000)
+                        duration_ms = max(100, min(ctrl.DRIVE_MAX_DURATION_MS, duration_ms))
+                        angular = speed_pct if command == "rotate_left" else -speed_pct
+                        ctrl.drive_time(0, angular, duration_ms)
+                        time.sleep(duration_ms / 1000.0 + 0.2)
+                except Exception as e:
+                    logger.error(f"Teleop execution error: {e}")
+                finally:
+                    if ctrl.get_state() == State.MOVING:
+                        ctrl.stop_moving(reason="move_complete")
+
+            threading.Thread(target=_execute_teleop, name="teleop-exec", daemon=True).start()
+
+            self._send_json(200, {
+                "status": "ok",
+                "command": command,
+                "message": f"Movement started: {command}",
+            })
+
+        elif self.path == "/api/sensors":
+            # Sensor telemetry snapshot (#49)
+            ctrl = self.controller
+            snapshot = ctrl.get_hazard_snapshot()
+            self._send_json(200, {"status": "ok", **snapshot})
+
         else:
             self._send_json(404, {"error": "not_found"})
 

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -103,6 +103,66 @@ class BatteryState:
 
 
 # ============================================================================
+# HAZARD / SENSOR TELEMETRY (#49)
+# ============================================================================
+
+# ToF sensor positions on Misty (from docs)
+TOF_SENSORS = {
+    "toffc": "front_center",      # front center
+    "toffr": "front_right",       # front right
+    "toffl": "front_left",        # front left
+    "tofr": "rear",               # rear center
+    "tofdfc": "edge_front_center",  # downward front center (edge)
+    "tofdfr": "edge_front_right",   # downward front right (edge)
+    "tofdfl": "edge_front_left",    # downward front left (edge)
+    "tofdr": "edge_rear",           # downward rear (edge)
+}
+
+# Direction → required sensors for movement safety
+TOF_FORWARD_SENSORS = {"toffc", "toffr", "toffl", "tofdfc", "tofdfr", "tofdfl"}
+TOF_REVERSE_SENSORS = {"tofr", "tofdr"}
+TOF_EDGE_SENSORS = {"tofdfc", "tofdfr", "tofdfl", "tofdr"}
+
+# Telemetry watchdog — per-sensor freshness during movement
+TELEMETRY_STALE_TIMEOUT_S = 1.0  # sensor data older than this = stale (halt if moving)
+
+
+@dataclass
+class ToFReading:
+    """Single Time-of-Flight sensor reading."""
+    sensor_id: str = ""           # e.g., "toffc"
+    distance_mm: float = 0.0     # millimeters (0 = invalid/no return)
+    status: int = 0              # 0=valid, 100-class=warn, 200-class=error
+    is_valid: bool = False       # True only if status indicates reliable reading
+    last_updated: float = 0.0   # time.time()
+
+
+@dataclass
+class HazardState:
+    """Aggregated hazard/sensor state for safety decision-making."""
+    # Active hazards from HazardNotification events
+    active_hazards: list = None       # list of hazard dicts from last event
+    last_hazard_time: float = 0.0     # when last HazardNotification arrived
+    hazard_halt_issued: bool = False  # True if we auto-halted due to hazard
+
+    # Per-sensor ToF readings (keyed by sensor_id, e.g., "toffc")
+    tof_readings: dict = None         # {sensor_id: ToFReading}
+
+    # Bump sensor states (keyed by sensor position)
+    bump_states: dict = None          # {sensor_name: {"is_pressed": bool, "last_updated": float}}
+    last_bump_time: float = 0.0       # when last BumpSensor event arrived
+    any_bump_active: bool = False     # True if any bump sensor is currently pressed
+
+    def __post_init__(self):
+        if self.active_hazards is None:
+            self.active_hazards = []
+        if self.tof_readings is None:
+            self.tof_readings = {sid: ToFReading(sensor_id=sid) for sid in TOF_SENSORS}
+        if self.bump_states is None:
+            self.bump_states = {}
+
+
+# ============================================================================
 # STATE MACHINE
 # ============================================================================
 
@@ -151,6 +211,10 @@ class MistyController:
         # Proactive reboot — counts successful conversation cycles (wake→response→rearm)
         self._conversation_cycles = 0
         self._recording_cycles = 0  # total recordings since last reboot
+
+        # Hazard / sensor telemetry (#49)
+        self.hazard = HazardState()
+        self.hazard_lock = threading.Lock()
 
     # --- State transitions ---
 
@@ -551,6 +615,178 @@ class MistyController:
         if self.get_state() == State.IDLE:
             self.set_led(0, 255, 0)
 
+    # --- Hazard / Sensor Telemetry Event Handlers (#49) ---
+
+    def _handle_hazard_event(self, data: dict):
+        """Handle HazardNotification — firmware-level safety alert.
+
+        The firmware auto-stops motors on hazard, but we need to update our state
+        and log the event for safety decisions.
+        """
+        now = time.time()
+        # Extract hazard details from event data
+        # HazardNotification contains arrays of sensors that triggered
+        bump_hazards = data.get("bumpSensorsHazardState", [])
+        tof_hazards = data.get("timeOfFlightSensorsHazardState", [])
+
+        hazards = []
+        for sensor in bump_hazards:
+            if sensor.get("inHazard", False):
+                hazards.append({"type": "bump", "sensor": sensor.get("sensorName", "unknown")})
+        for sensor in tof_hazards:
+            if sensor.get("inHazard", False):
+                hazards.append({
+                    "type": "tof",
+                    "sensor": sensor.get("sensorName", "unknown"),
+                    "distance_mm": sensor.get("distance", 0),
+                })
+
+        with self.hazard_lock:
+            self.hazard.active_hazards = hazards
+            self.hazard.last_hazard_time = now
+            if hazards:
+                self.hazard.hazard_halt_issued = True
+
+        if hazards:
+            logger.warning(f"HAZARD: {len(hazards)} active — {hazards}")
+        else:
+            # Hazard cleared
+            with self.hazard_lock:
+                self.hazard.hazard_halt_issued = False
+            logger.info("Hazard cleared — all sensors nominal")
+
+    def _handle_tof_event(self, data: dict):
+        """Handle TimeOfFlight — raw distance reading from a single sensor.
+
+        Updates per-sensor state. Only logs significant changes (DEBUG level for routine).
+        """
+        sensor_id = data.get("sensorId", "").lower()
+        if sensor_id not in TOF_SENSORS:
+            return
+
+        distance_mm = data.get("distanceInMeters", 0) * 1000  # API returns meters
+        status = data.get("status", 0)
+        # Status 0 = valid ranging, 2 = ranging complete. Status >= 100 = reduced confidence.
+        is_valid = status in (0, 2)
+
+        now = time.time()
+        with self.hazard_lock:
+            reading = self.hazard.tof_readings[sensor_id]
+            old_valid = reading.is_valid
+            old_distance = reading.distance_mm
+
+            reading.distance_mm = distance_mm
+            reading.status = status
+            reading.is_valid = is_valid
+            reading.last_updated = now
+
+        # Log only transitions: sensor going invalid, or close obstacles
+        if is_valid and not old_valid:
+            logger.debug(f"ToF {sensor_id} recovered (status={status}, dist={distance_mm:.0f}mm)")
+        elif not is_valid and old_valid:
+            logger.info(f"ToF {sensor_id} degraded (status={status})")
+        elif is_valid and distance_mm < 200 and (old_distance >= 200 or not old_valid):
+            logger.info(f"ToF {sensor_id} close obstacle: {distance_mm:.0f}mm")
+
+    def _handle_bump_event(self, data: dict):
+        """Handle BumpSensor — physical contact detection.
+
+        On bump contact: log and set state. Firmware auto-halts on bump.
+        """
+        sensor_name = data.get("sensorName", "unknown")
+        is_pressed = data.get("isContacted", False)
+        now = time.time()
+
+        with self.hazard_lock:
+            self.hazard.bump_states[sensor_name] = {
+                "is_pressed": is_pressed,
+                "last_updated": now,
+            }
+            self.hazard.last_bump_time = now
+            self.hazard.any_bump_active = any(
+                s.get("is_pressed", False)
+                for s in self.hazard.bump_states.values()
+            )
+
+        if is_pressed:
+            logger.warning(f"BUMP: {sensor_name} contacted")
+        else:
+            logger.info(f"Bump released: {sensor_name}")
+
+    def get_hazard_snapshot(self) -> dict:
+        """Thread-safe snapshot of current hazard/sensor state for decision-making."""
+        with self.hazard_lock:
+            return {
+                "active_hazards": list(self.hazard.active_hazards),
+                "last_hazard_time": self.hazard.last_hazard_time,
+                "hazard_halt_issued": self.hazard.hazard_halt_issued,
+                "any_bump_active": self.hazard.any_bump_active,
+                "last_bump_time": self.hazard.last_bump_time,
+                "tof_readings": {
+                    sid: {
+                        "distance_mm": r.distance_mm,
+                        "status": r.status,
+                        "is_valid": r.is_valid,
+                        "last_updated": r.last_updated,
+                        "friendly_name": TOF_SENSORS[sid],
+                    }
+                    for sid, r in self.hazard.tof_readings.items()
+                },
+                "bump_states": dict(self.hazard.bump_states),
+            }
+
+    def check_forward_clear(self, min_distance_mm: float = 200.0) -> bool:
+        """Check if forward path is clear based on ToF readings.
+
+        Returns True if all valid forward sensors report distance > min_distance_mm.
+        Returns False if any forward sensor reports close obstacle or is stale/invalid.
+        """
+        now = time.time()
+        with self.hazard_lock:
+            for sid in TOF_FORWARD_SENSORS:
+                reading = self.hazard.tof_readings[sid]
+                # Stale data = not clear (fail closed)
+                if now - reading.last_updated > TELEMETRY_STALE_TIMEOUT_S:
+                    return False
+                # Invalid reading = not clear (fail closed)
+                if not reading.is_valid:
+                    return False
+                # Only check horizontal sensors (not edge/downward) for distance
+                if sid in ("toffc", "toffr", "toffl"):
+                    if reading.distance_mm < min_distance_mm:
+                        return False
+            return True
+
+    def check_reverse_clear(self, min_distance_mm: float = 200.0) -> bool:
+        """Check if reverse path is clear based on rear ToF readings."""
+        now = time.time()
+        with self.hazard_lock:
+            for sid in TOF_REVERSE_SENSORS:
+                reading = self.hazard.tof_readings[sid]
+                if now - reading.last_updated > TELEMETRY_STALE_TIMEOUT_S:
+                    return False
+                if not reading.is_valid:
+                    return False
+                if sid == "tofr":
+                    if reading.distance_mm < min_distance_mm:
+                        return False
+            return True
+
+    def check_sensors_fresh(self, sensor_ids: set = None) -> bool:
+        """Check if specified sensors have fresh data (within TELEMETRY_STALE_TIMEOUT_S).
+
+        Args:
+            sensor_ids: Set of sensor IDs to check. If None, checks all sensors.
+        """
+        now = time.time()
+        check_ids = sensor_ids or set(TOF_SENSORS.keys())
+        with self.hazard_lock:
+            for sid in check_ids:
+                reading = self.hazard.tof_readings.get(sid)
+                if not reading or now - reading.last_updated > TELEMETRY_STALE_TIMEOUT_S:
+                    return False
+            return True
+
     # --- Keyphrase watchdog ---
 
     def _watchdog_check(self):
@@ -766,11 +1002,89 @@ class MistyController:
             self.ws.send(msg)
             logger.info(f"Subscribed to BatteryCharge events (name={self._battery_event_name})")
 
+    # --- Hazard / Safety Telemetry Subscriptions (#49) ---
+
+    def _ws_subscribe_hazard(self):
+        """Subscribe to HazardNotification — firmware-level safety alerts."""
+        if self.ws:
+            prev = getattr(self, '_hazard_event_name', None)
+            self._hazard_event_name = f"Hazard_{time.time_ns()}"
+
+            for old_name in ["Hazard", prev or '']:
+                if old_name:
+                    unsub = json.dumps({"Operation": "unsubscribe", "EventName": old_name})
+                    self.ws.send(unsub)
+            time.sleep(0.2)
+
+            msg = json.dumps({
+                "Operation": "subscribe",
+                "Type": "HazardNotification",
+                "DebounceMs": 0,  # safety-critical: every event matters
+                "EventName": self._hazard_event_name,
+                "ReturnProperty": None,
+                "EventConditions": [],
+            })
+            self.ws.send(msg)
+            logger.info(f"Subscribed to HazardNotification (name={self._hazard_event_name})")
+
+    def _ws_subscribe_tof(self):
+        """Subscribe to TimeOfFlight — raw distance readings from 8 sensors."""
+        if self.ws:
+            prev = getattr(self, '_tof_event_name', None)
+            self._tof_event_name = f"ToF_{time.time_ns()}"
+
+            for old_name in ["ToF", prev or '']:
+                if old_name:
+                    unsub = json.dumps({"Operation": "unsubscribe", "EventName": old_name})
+                    self.ws.send(unsub)
+            time.sleep(0.2)
+
+            msg = json.dumps({
+                "Operation": "subscribe",
+                "Type": "TimeOfFlight",
+                "DebounceMs": 250,  # 4 Hz per sensor — advisory, not primary safety
+                "EventName": self._tof_event_name,
+                "ReturnProperty": None,
+                "EventConditions": [],
+            })
+            self.ws.send(msg)
+            logger.info(f"Subscribed to TimeOfFlight (name={self._tof_event_name})")
+
+    def _ws_subscribe_bump(self):
+        """Subscribe to BumpSensor — physical contact detection."""
+        if self.ws:
+            prev = getattr(self, '_bump_event_name', None)
+            self._bump_event_name = f"Bump_{time.time_ns()}"
+
+            for old_name in ["Bump", prev or '']:
+                if old_name:
+                    unsub = json.dumps({"Operation": "unsubscribe", "EventName": old_name})
+                    self.ws.send(unsub)
+            time.sleep(0.2)
+
+            msg = json.dumps({
+                "Operation": "subscribe",
+                "Type": "BumpSensor",
+                "DebounceMs": 0,  # safety-critical: immediate notification
+                "EventName": self._bump_event_name,
+                "ReturnProperty": None,
+                "EventConditions": [],
+            })
+            self.ws.send(msg)
+            logger.info(f"Subscribed to BumpSensor (name={self._bump_event_name})")
+
+    def _ws_subscribe_safety_telemetry(self):
+        """Subscribe to all safety-related sensor events."""
+        self._ws_subscribe_hazard()
+        self._ws_subscribe_tof()
+        self._ws_subscribe_bump()
+
     def _on_ws_open(self, ws):
         logger.info("WebSocket connected")
         self.reconnect_attempts = 0
-        # Always subscribe to battery events
+        # Always subscribe to battery and safety telemetry events
         self._ws_subscribe_battery()
+        self._ws_subscribe_safety_telemetry()
 
         # In laptop wake word mode, skip keyphrase entirely — the laptop mic
         # handles wake word detection. Starting Misty's keyphrase would:
@@ -833,17 +1147,33 @@ class MistyController:
         event_name = data.get("eventName") or data.get("EventName", "")
         msg_content = data.get("message", "")
 
-        # Log ALL WebSocket messages for debugging keyphrase issues (#22)
+        # Ignore registration status messages
+        if isinstance(msg_content, str) and "Registration Status" in msg_content:
+            logger.debug(f"WS registration: {msg_content}")
+            return
+
+        # Route high-frequency telemetry events FIRST (no per-message INFO log)
+        if event_name == getattr(self, '_tof_event_name', ''):
+            if isinstance(msg_content, dict):
+                self._handle_tof_event(msg_content)
+            return
+
+        if event_name == getattr(self, '_hazard_event_name', ''):
+            if isinstance(msg_content, dict):
+                self._handle_hazard_event(msg_content)
+            return
+
+        if event_name == getattr(self, '_bump_event_name', ''):
+            if isinstance(msg_content, dict):
+                self._handle_bump_event(msg_content)
+            return
+
+        # Log non-telemetry WebSocket messages for debugging (#22)
         if event_name:
             msg_preview = str(msg_content)[:200] if msg_content else "(empty)"
             logger.info(f"WS event: {event_name} | msg_type={type(msg_content).__name__} | msg={msg_preview}")
         else:
             logger.info(f"WS raw: {str(message)[:300]}")
-
-        # Ignore registration status messages
-        if isinstance(msg_content, str) and "Registration Status" in msg_content:
-            logger.debug(f"WS registration: {msg_content}")
-            return
 
         if event_name == getattr(self, '_battery_event_name', 'BatteryMonitor') or event_name == "BatteryMonitor":
             if isinstance(msg_content, dict):

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -517,6 +517,116 @@ class MistyController:
             daemon=True,
         ).start()
 
+    def _execute_voice_movement(self, turn: int, movement: dict):
+        """Execute a voice-triggered movement command (#56).
+
+        Called after the acknowledgment audio has already been played.
+        Transitions IDLE → MOVING, executes the command, then returns.
+        On hazard preemption, generates verbal feedback ("something's in my way!").
+
+        Args:
+            turn: Current conversation turn number (for logging).
+            movement: Movement command dict from orchestration service
+                      (keys: "command", optionally "distance_mm", "speed_pct", "angle_deg").
+        """
+        command = movement.get("command", "")
+        distance_mm = movement.get("distance_mm", 200)
+        speed_pct = movement.get("speed_pct", 20)
+        angle_deg = movement.get("angle_deg", 90)
+
+        # Clamp to safe bounds (same as teleop endpoint)
+        distance_mm = max(50, min(500, distance_mm))
+        speed_pct = max(5, min(int(self.DRIVE_MAX_LINEAR_PCT), speed_pct))
+        angle_deg = max(10, min(180, angle_deg))
+
+        if command == "stop":
+            self.halt()
+            logger.info(f"[Turn {turn}] Voice halt executed")
+            return
+
+        # Transition to IDLE first (we're in PLAYING after the ack audio)
+        self.set_state(State.IDLE)
+        time.sleep(0.3)  # brief settle
+
+        # Enter MOVING state (pre-flight checks: hazards, battery, etc.)
+        if not self.start_moving(reason=f"voice_{command}"):
+            logger.warning(f"[Turn {turn}] Cannot execute voice movement — blocked by safety checks")
+            self._speak_movement_failure(turn, "I can't move right now. Something's blocking me.")
+            return
+
+        # Visual feedback — orange LED + adventurous face
+        self.set_led(255, 165, 0)  # orange = moving
+        self.display_image("e_Joy2.jpg")
+
+        try:
+            if command in ("forward", "backward"):
+                velocity_mms = (speed_pct / 100.0) * 450.0
+                duration_ms = int((distance_mm / velocity_mms) * 1000)
+                duration_ms = max(100, min(self.DRIVE_MAX_DURATION_MS, duration_ms))
+                linear = speed_pct if command == "forward" else -speed_pct
+                self.drive_time(linear, 0, duration_ms)
+
+                # Wait for completion, checking for preemption
+                wait_s = duration_ms / 1000.0 + 0.5
+                preempted = self._wait_for_move_completion(wait_s)
+                if preempted:
+                    self._speak_movement_failure(turn, "Oops, something's in my way!")
+                    return
+
+            elif command in ("rotate_left", "rotate_right"):
+                angular_rate = (speed_pct / 100.0) * 150.0
+                duration_ms = int((angle_deg / angular_rate) * 1000)
+                duration_ms = max(100, min(self.DRIVE_MAX_DURATION_MS, duration_ms))
+                angular = speed_pct if command == "rotate_left" else -speed_pct
+                self.drive_time(0, angular, duration_ms)
+
+                wait_s = duration_ms / 1000.0 + 0.5
+                preempted = self._wait_for_move_completion(wait_s)
+                if preempted:
+                    self._speak_movement_failure(turn, "Oops, something's in my way!")
+                    return
+            else:
+                logger.warning(f"[Turn {turn}] Unknown voice movement command: {command}")
+                return
+
+            logger.info(f"[Turn {turn}] Voice movement complete: {command}")
+
+        except Exception as e:
+            logger.error(f"[Turn {turn}] Voice movement error: {e}", exc_info=True)
+        finally:
+            if self.get_state() == State.MOVING:
+                self.stop_moving(reason="voice_move_complete")
+
+    def _wait_for_move_completion(self, timeout_s: float) -> bool:
+        """Wait for movement to finish, checking for preemption.
+
+        Returns True if movement was preempted (state changed from MOVING),
+        False if movement completed normally.
+        """
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            if self.get_state() != State.MOVING:
+                return True  # preempted
+            time.sleep(0.1)
+        return False  # completed normally
+
+    def _speak_movement_failure(self, turn: int, text: str):
+        """Generate and play a verbal notification about movement failure (#56)."""
+        try:
+            response = requests.post(
+                f"{ORCHESTRATION_URL}/api/tts",
+                json={"text": text},
+                timeout=10.0,
+            )
+            if response.status_code == 200 and len(response.content) > 100:
+                self.set_state(State.PLAYING)
+                self.set_led(255, 255, 0)  # yellow = warning
+                self.display_image("e_Sadness.jpg")
+                play_duration = self.upload_and_play_audio(response.content, RESPONSE_FILENAME)
+                time.sleep(play_duration + 1.0)
+        except Exception as e:
+            logger.warning(f"[Turn {turn}] Movement failure speech failed: {e}")
+
     def start_keyphrase(self, force_restart=False):
         if force_restart:
             self.misty_post("/api/audio/keyphrase/stop")
@@ -1489,7 +1599,16 @@ class MistyController:
             time.sleep(2.0)
 
         try:
-            had_speech = self._do_conversation_exchange(turn, turn_start)
+            exchange_result = self._do_conversation_exchange(turn, turn_start)
+
+            # Determine if speech was detected and if movement was requested
+            if isinstance(exchange_result, dict):
+                # Movement response (#56) — speech was detected, movement command returned
+                had_speech = exchange_result.get("had_speech", True)
+                movement = exchange_result.get("movement")
+            else:
+                had_speech = exchange_result
+                movement = None
 
             # Only count cycles with actual speech for proactive reboot tracking.
             # Empty STT (user too far from Misty's mic) shouldn't trigger a reboot.
@@ -1498,6 +1617,13 @@ class MistyController:
                 logger.info(f"[Turn {turn}] Conversation cycle {self._conversation_cycles}/{PROACTIVE_REBOOT_AFTER_CYCLES}")
             else:
                 logger.info(f"[Turn {turn}] No speech — not counting toward reboot cycles")
+
+            # Execute voice movement if requested (#56) — after ack audio has played
+            if movement:
+                logger.info(f"[Turn {turn}] Executing voice movement: {movement.get('command')}")
+                self._execute_voice_movement(turn, movement)
+                # After movement, skip follow-up listening — re-arm and wait for next wake word
+                return
 
             # Follow-up listening loop — listen for continued conversation
             # without requiring the wake word again
@@ -1516,6 +1642,13 @@ class MistyController:
                             f"({remaining:.0f}s remaining in window)")
 
                 had_speech = self._listen_for_followup(turn)
+                if isinstance(had_speech, dict):
+                    # Follow-up was a movement command (#56) — execute and end conversation
+                    movement = had_speech.get("movement")
+                    if movement:
+                        logger.info(f"[Turn {turn}] Follow-up movement: {movement.get('command')}")
+                        self._execute_voice_movement(turn, movement)
+                    break
                 if not had_speech:
                     logger.info(f"[Turn {turn}] No follow-up speech — ending conversation")
                     break
@@ -1647,8 +1780,11 @@ class MistyController:
     def _do_orchestrate_and_respond(self, turn: int, audio_bytes: bytes, turn_start: float):
         """Send audio to orchestration service and play response on Misty.
         
-        Returns True if speech was detected and a response was played,
-        False if no speech was detected (empty STT).
+        Returns:
+            dict — if orchestration returned a movement command.
+                   Keys: "movement" (command dict), "had_speech" (True).
+            True  — if speech was detected and a conversational response was played.
+            False — if no speech was detected (empty STT).
         """
         # Processing state already set by caller — just send to orchestration
 
@@ -1673,6 +1809,36 @@ class MistyController:
         if result.get("status") != "ok":
             raise RuntimeError(f"Orchestration error: {result.get('error', 'unknown')}")
 
+        # --- Movement response (#56) ---
+        if result.get("type") == "movement":
+            movement = result.get("movement", {})
+            ack_text = result.get("response_text", "")
+            pipeline_ms = result.get("pipeline_ms", 0)
+            user_text = result.get("user_text", "")
+            logger.info(f"[Turn {turn}] MOVEMENT: '{user_text}' -> {movement.get('command')} "
+                         f"ack='{ack_text}' ({pipeline_ms}ms)")
+
+            # Download and play acknowledgment audio (speak first, then move)
+            audio_file = result.get("audio_file")
+            if audio_file:
+                audio_url = f"{ORCHESTRATION_URL}/api/audio/{audio_file}"
+                try:
+                    audio_resp = requests.get(audio_url, timeout=10.0)
+                    audio_resp.raise_for_status()
+                    response_wav = audio_resp.content
+                    logger.info(f"[Turn {turn}] Downloaded movement ack audio: {len(response_wav)} bytes")
+
+                    self.set_state(State.PLAYING)
+                    self.set_led(148, 0, 211)  # purple = speaking
+                    self.display_image("e_EcstacyHilarious.jpg")
+                    play_duration = self.upload_and_play_audio(response_wav, RESPONSE_FILENAME)
+                    time.sleep(play_duration + 1.0)
+                except Exception as e:
+                    logger.warning(f"[Turn {turn}] Movement ack audio failed: {e}")
+
+            return {"movement": movement, "had_speech": True}
+
+        # --- Normal conversational response ---
         transcribed = result.get("transcribedText", "")
         llm_response = result.get("inferenceResponse", "")
         audio_uri = result.get("responseAudio", "")
@@ -1788,6 +1954,27 @@ class MistyController:
             if response.status_code != 200 or result.get("status") != "ok":
                 logger.warning(f"[Turn {turn}] Follow-up: orchestration error: {result.get('error', 'unknown')}")
                 return False
+
+            # Movement response in follow-up (#56)
+            if result.get("type") == "movement":
+                movement = result.get("movement", {})
+                ack_text = result.get("response_text", "")
+                logger.info(f"[Turn {turn}] Follow-up movement: {movement.get('command')} ack='{ack_text}'")
+
+                audio_file = result.get("audio_file")
+                if audio_file:
+                    try:
+                        audio_url = f"{ORCHESTRATION_URL}/api/audio/{audio_file}"
+                        audio_resp = requests.get(audio_url, timeout=10.0)
+                        audio_resp.raise_for_status()
+                        self.set_state(State.PLAYING)
+                        self.set_led(148, 0, 211)
+                        play_duration = self.upload_and_play_audio(audio_resp.content, RESPONSE_FILENAME)
+                        time.sleep(play_duration + 1.0)
+                    except Exception as e:
+                        logger.warning(f"[Turn {turn}] Follow-up movement ack audio failed: {e}")
+
+                return {"movement": movement, "had_speech": True}
 
             # Speech detected — download and play the response
             transcribed = result.get("transcribedText", "")

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -92,6 +92,60 @@ _INTENT_PATTERNS = {
     ),
 }
 
+# Movement intent patterns (#54) — detect commands to physically move the robot
+_MOVEMENT_PATTERNS = {
+    "forward": re.compile(
+        r"\b(?:(?:go|move|drive|roll|come)\s+(?:forward|ahead|straight)|"
+        r"(?:come|go)\s+(?:here|to\s+me|closer|over\s+here)|"
+        r"move\s+up|"
+        r"walk\s+(?:forward|to\s+me|over\s+here))\b",
+        re.IGNORECASE,
+    ),
+    "backward": re.compile(
+        r"\b(?:(?:go|move|drive|roll|back)\s+(?:back(?:ward)?s?|up)|"
+        r"reverse|"
+        r"back\s+(?:up|away)|"
+        r"move\s+(?:away|back))\b",
+        re.IGNORECASE,
+    ),
+    "rotate_left": re.compile(
+        r"\b(?:(?:turn|rotate|spin|face)\s+(?:left|around\s+to\s+(?:the\s+)?left)|"
+        r"look\s+(?:left|to\s+(?:the\s+)?left))\b",
+        re.IGNORECASE,
+    ),
+    "rotate_right": re.compile(
+        r"\b(?:(?:turn|rotate|spin|face)\s+(?:right|around\s+to\s+(?:the\s+)?right)|"
+        r"look\s+(?:right|to\s+(?:the\s+)?right))\b",
+        re.IGNORECASE,
+    ),
+    "stop": re.compile(
+        r"\b(?:stop|halt|freeze|don'?t\s+move|stay|hold\s+(?:it|still|on))\b",
+        re.IGNORECASE,
+    ),
+}
+
+
+def classify_movement_intent(user_text: str) -> dict | None:
+    """Classify if user text contains a movement command.
+
+    Returns dict with movement details if detected, None otherwise.
+    Only bounded relative commands are recognized (no absolute destinations).
+
+    Returns:
+        {"command": "forward"|"backward"|"rotate_left"|"rotate_right"|"stop"}
+        or None if no movement intent detected.
+    """
+    text = (user_text or "").strip()
+    if not text:
+        return None
+
+    for command, pattern in _MOVEMENT_PATTERNS.items():
+        if pattern.search(text):
+            logger.info(f"Movement intent detected: {command}")
+            return {"command": command}
+
+    return None
+
 _CONTINUATION_PATTERN = re.compile(
     r"^\s*(?:yes|yeah|yep|sure|ok(?:ay)?|more|continue|go\s+on|keep\s+going|"
     r"tell\s+me\s+more|what\s+happens?\s+next|and\s+then\??|"
@@ -316,6 +370,19 @@ def orchestrate():
             return jsonify({"status": "error", "error": "empty_stt"}), 400
         
         logger.info(f"[STT {stt_ms:.0f}ms] {user_text}")
+
+        # Step 1.5: Check for movement intent (#54) — bypass LLM for direct commands
+        movement = classify_movement_intent(user_text)
+        if movement:
+            total_ms = (time.time() - start_time) * 1000
+            logger.info(f"[Pipeline {total_ms:.0f}ms] Movement intent: {movement['command']} (STT={stt_ms:.0f}ms)")
+            return jsonify({
+                "status": "ok",
+                "type": "movement",
+                "movement": movement,
+                "user_text": user_text,
+                "pipeline_ms": round(total_ms),
+            }), 200
         
         # Step 2: Language Model Inference
         llm_start = time.time()

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -52,8 +52,18 @@ SYSTEM_PROMPT = os.getenv(
         "You love teasing (gently!), cracking jokes, adding flair, and throwing in the occasional eye-roll. "
         "Use casual language, slang, and expressive phrases like 'oh honey', 'girl please', 'I mean...', 'not gonna lie'. "
         "RULE: Keep responses to 2-3 short sentences. Be fun, not flat. "
-        "Never say you're an AI or assistant. You're Misty, and you own it."
+        "Never say you're an AI or assistant. You're Misty, and you own it. "
+        "You can move! If asked to come closer, go forward, back up, or turn — say something fun like "
+        "'On my way!' or 'Coming right up!' but keep it short. Movement commands are handled separately."
     )
+)
+
+# Movement-capable system prompt supplement (#55)
+# Appended when movement intent is detected alongside conversation
+MOVEMENT_PROMPT_SUPPLEMENT = (
+    "The user asked you to move. Respond with a short, fun acknowledgment "
+    "(1 sentence max). The actual movement is handled separately — "
+    "just be your sassy self about it."
 )
 
 # ---- Response mode configuration ----
@@ -145,6 +155,51 @@ def classify_movement_intent(user_text: str) -> dict | None:
             return {"command": command}
 
     return None
+
+
+import random
+
+# Pre-built movement acknowledgments (#55) — short, sassy, no LLM needed
+_MOVEMENT_ACKS = {
+    "forward": [
+        "On my way!",
+        "Coming right up!",
+        "Here I come!",
+        "Watch out, I'm rolling!",
+        "Ooh, road trip!",
+    ],
+    "backward": [
+        "Backing it up!",
+        "Beep beep beep!",
+        "Going in reverse, honey!",
+        "Watch out behind me!",
+    ],
+    "rotate_left": [
+        "Spinning left!",
+        "Look at me go!",
+        "Turning, turning!",
+        "Left it is!",
+    ],
+    "rotate_right": [
+        "Spinning right!",
+        "Right turn coming up!",
+        "Rotating like a pro!",
+        "Making my turn!",
+    ],
+    "stop": [
+        "Stopping!",
+        "I'll stay right here.",
+        "Okay okay, I'm stopped!",
+        "Holding still!",
+    ],
+}
+
+
+def _get_movement_acknowledgment(command: str) -> str:
+    """Get a random sassy acknowledgment for a movement command."""
+    acks = _MOVEMENT_ACKS.get(command, ["Okay!"])
+    return random.choice(acks)
+
 
 _CONTINUATION_PATTERN = re.compile(
     r"^\s*(?:yes|yeah|yep|sure|ok(?:ay)?|more|continue|go\s+on|keep\s+going|"
@@ -371,18 +426,28 @@ def orchestrate():
         
         logger.info(f"[STT {stt_ms:.0f}ms] {user_text}")
 
-        # Step 1.5: Check for movement intent (#54) — bypass LLM for direct commands
+        # Step 1.5: Check for movement intent (#54, #55) — short-circuit for direct commands
         movement = classify_movement_intent(user_text)
         if movement:
+            # Generate a quick verbal acknowledgment via TTS (no LLM needed)
+            ack_text = _get_movement_acknowledgment(movement["command"])
+            tts_start = time.time()
+            tts_result = text_to_speech(ack_text, tts_start)
+            tts_ms = (time.time() - tts_start) * 1000
             total_ms = (time.time() - start_time) * 1000
-            logger.info(f"[Pipeline {total_ms:.0f}ms] Movement intent: {movement['command']} (STT={stt_ms:.0f}ms)")
-            return jsonify({
+            logger.info(f"[Pipeline {total_ms:.0f}ms] Movement: {movement['command']} "
+                         f"(STT={stt_ms:.0f}ms, TTS={tts_ms:.0f}ms)")
+            result = {
                 "status": "ok",
                 "type": "movement",
                 "movement": movement,
                 "user_text": user_text,
+                "response_text": ack_text,
                 "pipeline_ms": round(total_ms),
-            }), 200
+            }
+            if tts_result.get("status") == "ok":
+                result["audio_file"] = tts_result.get("audio_file")
+            return jsonify(result), 200
         
         # Step 2: Language Model Inference
         llm_start = time.time()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1845,6 +1845,52 @@ class TestSpeakMoveIntegration(unittest.TestCase):
         result = self.ctrl._wait_for_move_completion(2.0)
         self.assertTrue(result)  # preempted
 
+    # --- State machine transition tests (Plan 3.3 from #60) ---
+
+    def test_move_rejected_during_recording(self):
+        """Move should be rejected when state is RECORDING (Plan 3.3)."""
+        self.ctrl.set_state(self._State.RECORDING)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+        self.assertEqual(self.ctrl.get_state(), self._State.RECORDING)
+
+    def test_move_rejected_during_playing(self):
+        """Move should be rejected when state is PLAYING (Plan 3.3)."""
+        self.ctrl.set_state(self._State.PLAYING)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+        self.assertEqual(self.ctrl.get_state(), self._State.PLAYING)
+
+    def test_move_rejected_during_processing(self):
+        """Move should be rejected when state is PROCESSING."""
+        self.ctrl.set_state(self._State.PROCESSING)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+
+    def test_move_rejected_during_rearming(self):
+        """Move should be rejected when state is REARMING."""
+        self.ctrl.set_state(self._State.REARMING)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+
+    def test_idle_to_moving_to_idle_clean_cycle(self):
+        """Full IDLE -> MOVING -> IDLE cycle (Plan 3.3)."""
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+        ok = self.ctrl.start_moving(reason="test")
+        self.assertTrue(ok)
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+        self.ctrl.stop_moving(reason="complete")
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_sequential_move_cycles(self):
+        """Multiple IDLE -> MOVING -> IDLE cycles should all succeed."""
+        for i in range(3):
+            self.ctrl.set_state(self._State.IDLE)
+            ok = self.ctrl.start_moving(reason=f"cycle_{i}")
+            self.assertTrue(ok, f"Cycle {i} failed to start")
+            self.ctrl.stop_moving(reason="complete")
+            self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1351,5 +1351,101 @@ class TestMovingState(unittest.TestCase):
         self.assertTrue(resume_called)
 
 
+class TestTeleopEndpoint(unittest.TestCase):
+    """Unit tests for the HTTP teleop endpoint (#51).
+
+    Tests the ControllerAPIHandler's /api/move endpoint logic.
+    These tests call the controller methods directly (not via HTTP),
+    verifying parameter validation and movement commands.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            _ctrl_path = os.path.normpath(
+                os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+            )
+            if _ctrl_path not in sys.path:
+                sys.path.insert(0, _ctrl_path)
+            from misty_controller import MistyController, State
+            cls._MistyController = MistyController
+            cls._State = State
+        except Exception as exc:
+            cls._MistyController = None
+            print(f"[TestTeleopEndpoint] Could not import misty_controller: {exc}")
+
+    def setUp(self):
+        if self._MistyController is None:
+            self.skipTest("misty_controller could not be imported")
+        self.ctrl = self._MistyController()
+        self._post_calls = []
+        self.ctrl.misty_post = lambda endpoint, body=None, timeout=5.0: (
+            self._post_calls.append((endpoint, body)) or {"status": "Success", "result": True}
+        )
+
+    def test_halt_command_immediate(self):
+        """Halt command should issue halt regardless of state."""
+        self.ctrl.halt()
+        halt_calls = [c for c in self._post_calls if c[0] == "/api/halt"]
+        self.assertEqual(len(halt_calls), 1)
+
+    def test_forward_movement_via_drive_time(self):
+        """Forward command should use drive_time with positive velocity."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.start_moving(reason="teleop_forward")
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+        # Execute forward drive
+        self.ctrl.drive_time(20, 0, 1000)
+        drive_calls = [c for c in self._post_calls if c[0] == "/api/drive/time"]
+        self.assertEqual(len(drive_calls), 1)
+        _, body = drive_calls[0]
+        self.assertEqual(body["LinearVelocity"], 20)
+        self.assertEqual(body["AngularVelocity"], 0)
+        self.assertEqual(body["TimeMs"], 1000)
+
+    def test_backward_movement_via_drive_time(self):
+        """Backward command should use drive_time with negative velocity."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.start_moving(reason="teleop_backward")
+        self.ctrl.drive_time(-15, 0, 800)
+        drive_calls = [c for c in self._post_calls if c[0] == "/api/drive/time"]
+        self.assertEqual(len(drive_calls), 1)
+        _, body = drive_calls[0]
+        self.assertEqual(body["LinearVelocity"], -15)
+
+    def test_rotate_movement_via_drive_time(self):
+        """Rotate command should use drive_time with angular only."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.start_moving(reason="teleop_rotate")
+        self.ctrl.drive_time(0, 20, 1500)
+        drive_calls = [c for c in self._post_calls if c[0] == "/api/drive/time"]
+        _, body = drive_calls[0]
+        self.assertEqual(body["LinearVelocity"], 0)
+        self.assertEqual(body["AngularVelocity"], 20)
+
+    def test_cannot_move_when_not_idle(self):
+        """Movement should be rejected when not in IDLE state."""
+        self.ctrl.set_state(self._State.RECORDING)
+        result = self.ctrl.start_moving(reason="teleop")
+        self.assertFalse(result)
+
+    def test_speed_clamped_to_max(self):
+        """Speed above max should be clamped by drive methods."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.start_moving(reason="test")
+        self.ctrl.drive_time(50, 0, 1000)  # 50 > max 30
+        drive_calls = [c for c in self._post_calls if c[0] == "/api/drive/time"]
+        _, body = drive_calls[0]
+        self.assertEqual(body["LinearVelocity"], self.ctrl.DRIVE_MAX_LINEAR_PCT)
+
+    def test_sensors_endpoint_returns_snapshot(self):
+        """get_hazard_snapshot should return usable data for /api/sensors."""
+        snapshot = self.ctrl.get_hazard_snapshot()
+        self.assertIn("tof_readings", snapshot)
+        self.assertIn("bump_states", snapshot)
+        self.assertIn("active_hazards", snapshot)
+        self.assertEqual(len(snapshot["tof_readings"]), 8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1093,5 +1093,172 @@ class TestHazardTelemetry(unittest.TestCase):
         self.assertNotEqual(name1, name2)
 
 
+class TestMovingState(unittest.TestCase):
+    """Unit tests for MOVING state and preemption logic (#50).
+
+    These tests mock HTTP calls — no live robot required.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            _ctrl_path = os.path.normpath(
+                os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+            )
+            if _ctrl_path not in sys.path:
+                sys.path.insert(0, _ctrl_path)
+            from misty_controller import MistyController, State, PREEMPTION_PRIORITY
+            cls._MistyController = MistyController
+            cls._State = State
+            cls._PREEMPTION_PRIORITY = PREEMPTION_PRIORITY
+        except Exception as exc:
+            cls._MistyController = None
+            print(f"[TestMovingState] Could not import misty_controller: {exc}")
+
+    def setUp(self):
+        if self._MistyController is None:
+            self.skipTest("misty_controller could not be imported")
+        self.ctrl = self._MistyController()
+        self._post_calls = []
+        self.ctrl.misty_post = lambda endpoint, body=None, timeout=5.0: (
+            self._post_calls.append((endpoint, body)) or {"status": "Success", "result": True}
+        )
+
+    # --- State enum ---
+
+    def test_moving_state_exists(self):
+        """MOVING should be a valid state."""
+        self.assertEqual(self._State.MOVING.value, "MOVING")
+
+    def test_preemption_priority_defined(self):
+        """Preemption priority list should be defined."""
+        self.assertIn("hazard_stop", self._PREEMPTION_PRIORITY)
+        self.assertIn("bump_contact", self._PREEMPTION_PRIORITY)
+        self.assertIn("wake_word", self._PREEMPTION_PRIORITY)
+        self.assertIn("move_complete", self._PREEMPTION_PRIORITY)
+
+    # --- start_moving ---
+
+    def test_start_moving_from_idle(self):
+        """start_moving should succeed from IDLE state."""
+        self.ctrl.set_state(self._State.IDLE)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertTrue(result)
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+
+    def test_start_moving_blocked_not_idle(self):
+        """start_moving should fail if not in IDLE state."""
+        self.ctrl.set_state(self._State.RECORDING)
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+        self.assertEqual(self.ctrl.get_state(), self._State.RECORDING)
+
+    def test_start_moving_blocked_active_hazard(self):
+        """start_moving should fail if hazards are active."""
+        self.ctrl.set_state(self._State.IDLE)
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.active_hazards = [{"type": "tof", "sensor": "front"}]
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_start_moving_blocked_bump_active(self):
+        """start_moving should fail if any bump sensor is active."""
+        self.ctrl.set_state(self._State.IDLE)
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.any_bump_active = True
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+
+    def test_start_moving_blocked_battery_critical(self):
+        """start_moving should fail if battery is critically low."""
+        self.ctrl.set_state(self._State.IDLE)
+        with self.ctrl.battery_lock:
+            self.ctrl.battery.charge_percent = 0.05
+            self.ctrl.battery.last_updated = time.time()
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+
+    # --- stop_moving ---
+
+    def test_stop_moving_halts_and_returns_to_idle(self):
+        """stop_moving should halt motors and return to IDLE."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl.stop_moving(reason="move_complete")
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+        # Should have called /api/halt
+        halt_calls = [c for c in self._post_calls if c[0] == "/api/halt"]
+        self.assertEqual(len(halt_calls), 1)
+
+    def test_stop_moving_noop_if_not_moving(self):
+        """stop_moving should do nothing if not in MOVING state."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.stop_moving(reason="test")
+        # No halt call expected
+        halt_calls = [c for c in self._post_calls if c[0] == "/api/halt"]
+        self.assertEqual(len(halt_calls), 0)
+
+    # --- preempt_movement ---
+
+    def test_preempt_halts_and_returns_to_idle(self):
+        """preempt_movement should halt motors and return to IDLE."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl.preempt_movement("hazard_stop")
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+        halt_calls = [c for c in self._post_calls if c[0] == "/api/halt"]
+        self.assertEqual(len(halt_calls), 1)
+
+    def test_preempt_noop_if_not_moving(self):
+        """preempt_movement should do nothing if not in MOVING state."""
+        self.ctrl.set_state(self._State.IDLE)
+        self.ctrl.preempt_movement("hazard_stop")
+        halt_calls = [c for c in self._post_calls if c[0] == "/api/halt"]
+        self.assertEqual(len(halt_calls), 0)
+
+    # --- Hazard preemption integration ---
+
+    def test_hazard_event_preempts_movement(self):
+        """Active hazard during MOVING should preempt movement."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [],
+            "timeOfFlightSensorsHazardState": [
+                {"sensorName": "TOF_FC", "inHazard": True, "distance": 50},
+            ],
+        })
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_hazard_cleared_no_preempt(self):
+        """Hazard cleared event should NOT affect MOVING state."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [],
+            "timeOfFlightSensorsHazardState": [
+                {"sensorName": "TOF_FC", "inHazard": False},
+            ],
+        })
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+
+    # --- Bump preemption integration ---
+
+    def test_bump_event_preempts_movement(self):
+        """Bump contact during MOVING should preempt movement."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._handle_bump_event({
+            "sensorName": "Bump_FrontRight",
+            "isContacted": True,
+        })
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_bump_release_no_preempt(self):
+        """Bump release should NOT preempt movement."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._handle_bump_event({
+            "sensorName": "Bump_FrontRight",
+            "isContacted": False,
+        })
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -726,5 +726,372 @@ class TestDrivePrimitives(unittest.TestCase):
         self.assertTrue(body["Reverse"])
 
 
+class TestHazardTelemetry(unittest.TestCase):
+    """Unit tests for hazard/sensor telemetry subscription and handling (#49).
+
+    These tests mock WebSocket — no live robot required.
+    """
+
+    _ctrl = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            _ctrl_path = os.path.normpath(
+                os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+            )
+            if _ctrl_path not in sys.path:
+                sys.path.insert(0, _ctrl_path)
+            from misty_controller import (
+                MistyController, HazardState, ToFReading,
+                TOF_SENSORS, TOF_FORWARD_SENSORS, TOF_REVERSE_SENSORS,
+                TELEMETRY_STALE_TIMEOUT_S,
+            )
+            cls._MistyController = MistyController
+            cls._HazardState = HazardState
+            cls._ToFReading = ToFReading
+            cls._TOF_SENSORS = TOF_SENSORS
+            cls._TOF_FORWARD_SENSORS = TOF_FORWARD_SENSORS
+            cls._TOF_REVERSE_SENSORS = TOF_REVERSE_SENSORS
+            cls._TELEMETRY_STALE_TIMEOUT_S = TELEMETRY_STALE_TIMEOUT_S
+        except Exception as exc:
+            cls._MistyController = None
+            print(f"[TestHazardTelemetry] Could not import misty_controller: {exc}")
+
+    def setUp(self):
+        if self._MistyController is None:
+            self.skipTest("misty_controller could not be imported")
+        self.ctrl = self._MistyController()
+        # Mock misty_post to capture calls
+        self._post_calls = []
+        self.ctrl.misty_post = lambda endpoint, body=None, timeout=5.0: (
+            self._post_calls.append((endpoint, body)) or {"status": "Success", "result": True}
+        )
+
+    # --- HazardState initialization ---
+
+    def test_hazard_state_initialized(self):
+        """Controller should initialize with empty HazardState."""
+        self.assertIsNotNone(self.ctrl.hazard)
+        self.assertEqual(self.ctrl.hazard.active_hazards, [])
+        self.assertEqual(self.ctrl.hazard.last_hazard_time, 0.0)
+        self.assertFalse(self.ctrl.hazard.hazard_halt_issued)
+        self.assertFalse(self.ctrl.hazard.any_bump_active)
+
+    def test_tof_readings_initialized_for_all_sensors(self):
+        """ToF readings dict should have entries for all 8 sensors."""
+        self.assertEqual(len(self.ctrl.hazard.tof_readings), 8)
+        for sid in self._TOF_SENSORS:
+            self.assertIn(sid, self.ctrl.hazard.tof_readings)
+            reading = self.ctrl.hazard.tof_readings[sid]
+            self.assertEqual(reading.sensor_id, sid)
+            self.assertFalse(reading.is_valid)
+
+    # --- ToF event handling ---
+
+    def test_handle_tof_event_updates_reading(self):
+        """ToF event should update the per-sensor reading."""
+        self.ctrl._handle_tof_event({
+            "sensorId": "toffc",
+            "distanceInMeters": 0.350,
+            "status": 0,
+        })
+        reading = self.ctrl.hazard.tof_readings["toffc"]
+        self.assertAlmostEqual(reading.distance_mm, 350.0, places=1)
+        self.assertEqual(reading.status, 0)
+        self.assertTrue(reading.is_valid)
+        self.assertGreater(reading.last_updated, 0)
+
+    def test_handle_tof_event_invalid_status(self):
+        """ToF event with high status should mark reading as invalid."""
+        self.ctrl._handle_tof_event({
+            "sensorId": "toffr",
+            "distanceInMeters": 0.100,
+            "status": 255,
+        })
+        reading = self.ctrl.hazard.tof_readings["toffr"]
+        self.assertFalse(reading.is_valid)
+        self.assertEqual(reading.status, 255)
+
+    def test_handle_tof_event_status_2_is_valid(self):
+        """Status 2 (ranging complete) should be treated as valid."""
+        self.ctrl._handle_tof_event({
+            "sensorId": "toffl",
+            "distanceInMeters": 0.500,
+            "status": 2,
+        })
+        self.assertTrue(self.ctrl.hazard.tof_readings["toffl"].is_valid)
+
+    def test_handle_tof_ignores_unknown_sensor(self):
+        """Unknown sensor ID should be silently ignored."""
+        self.ctrl._handle_tof_event({
+            "sensorId": "unknown_sensor",
+            "distanceInMeters": 0.100,
+            "status": 0,
+        })
+        # No crash, no new entry
+        self.assertNotIn("unknown_sensor", self.ctrl.hazard.tof_readings)
+
+    # --- Hazard event handling ---
+
+    def test_handle_hazard_event_with_bump(self):
+        """HazardNotification with bump hazard should record active hazards."""
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [
+                {"sensorName": "Bump_FrontRight", "inHazard": True},
+                {"sensorName": "Bump_FrontLeft", "inHazard": False},
+            ],
+            "timeOfFlightSensorsHazardState": [],
+        })
+        self.assertEqual(len(self.ctrl.hazard.active_hazards), 1)
+        self.assertEqual(self.ctrl.hazard.active_hazards[0]["type"], "bump")
+        self.assertTrue(self.ctrl.hazard.hazard_halt_issued)
+
+    def test_handle_hazard_event_with_tof(self):
+        """HazardNotification with ToF hazard should record active hazards."""
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [],
+            "timeOfFlightSensorsHazardState": [
+                {"sensorName": "TOF_FrontCenter", "inHazard": True, "distance": 80},
+            ],
+        })
+        self.assertEqual(len(self.ctrl.hazard.active_hazards), 1)
+        self.assertEqual(self.ctrl.hazard.active_hazards[0]["type"], "tof")
+        self.assertEqual(self.ctrl.hazard.active_hazards[0]["distance_mm"], 80)
+
+    def test_handle_hazard_cleared(self):
+        """HazardNotification with no active hazards should clear state."""
+        # First, set a hazard
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [{"sensorName": "Bump_FR", "inHazard": True}],
+            "timeOfFlightSensorsHazardState": [],
+        })
+        self.assertTrue(self.ctrl.hazard.hazard_halt_issued)
+        # Now clear it
+        self.ctrl._handle_hazard_event({
+            "bumpSensorsHazardState": [{"sensorName": "Bump_FR", "inHazard": False}],
+            "timeOfFlightSensorsHazardState": [],
+        })
+        self.assertEqual(self.ctrl.hazard.active_hazards, [])
+        self.assertFalse(self.ctrl.hazard.hazard_halt_issued)
+
+    # --- Bump event handling ---
+
+    def test_handle_bump_event_pressed(self):
+        """Bump contact should be recorded and any_bump_active set."""
+        self.ctrl._handle_bump_event({
+            "sensorName": "Bump_FrontRight",
+            "isContacted": True,
+        })
+        self.assertTrue(self.ctrl.hazard.any_bump_active)
+        self.assertIn("Bump_FrontRight", self.ctrl.hazard.bump_states)
+        self.assertTrue(self.ctrl.hazard.bump_states["Bump_FrontRight"]["is_pressed"])
+
+    def test_handle_bump_event_released(self):
+        """Bump release should clear that sensor."""
+        # Press first
+        self.ctrl._handle_bump_event({"sensorName": "Bump_FrontLeft", "isContacted": True})
+        self.assertTrue(self.ctrl.hazard.any_bump_active)
+        # Release
+        self.ctrl._handle_bump_event({"sensorName": "Bump_FrontLeft", "isContacted": False})
+        self.assertFalse(self.ctrl.hazard.any_bump_active)
+
+    def test_multiple_bumps_any_active(self):
+        """any_bump_active should be True if ANY bump is still pressed."""
+        self.ctrl._handle_bump_event({"sensorName": "Bump_FR", "isContacted": True})
+        self.ctrl._handle_bump_event({"sensorName": "Bump_FL", "isContacted": True})
+        # Release one
+        self.ctrl._handle_bump_event({"sensorName": "Bump_FR", "isContacted": False})
+        self.assertTrue(self.ctrl.hazard.any_bump_active)  # FL still pressed
+
+    # --- check_forward_clear ---
+
+    def test_check_forward_clear_all_good(self):
+        """Forward clear when all forward sensors have valid, distant readings."""
+        now = time.time()
+        for sid in self._TOF_FORWARD_SENSORS:
+            with self.ctrl.hazard_lock:
+                r = self.ctrl.hazard.tof_readings[sid]
+                r.distance_mm = 500.0
+                r.status = 0
+                r.is_valid = True
+                r.last_updated = now
+        self.assertTrue(self.ctrl.check_forward_clear())
+
+    def test_check_forward_clear_close_obstacle(self):
+        """Forward NOT clear when a front sensor detects close obstacle."""
+        now = time.time()
+        for sid in self._TOF_FORWARD_SENSORS:
+            with self.ctrl.hazard_lock:
+                r = self.ctrl.hazard.tof_readings[sid]
+                r.distance_mm = 500.0
+                r.status = 0
+                r.is_valid = True
+                r.last_updated = now
+        # Place obstacle in front center
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.tof_readings["toffc"].distance_mm = 100.0
+        self.assertFalse(self.ctrl.check_forward_clear())
+
+    def test_check_forward_clear_stale_data(self):
+        """Forward NOT clear when sensor data is stale (fail closed)."""
+        # Leave last_updated at 0 (stale)
+        self.assertFalse(self.ctrl.check_forward_clear())
+
+    def test_check_forward_clear_invalid_sensor(self):
+        """Forward NOT clear when a sensor has invalid status."""
+        now = time.time()
+        for sid in self._TOF_FORWARD_SENSORS:
+            with self.ctrl.hazard_lock:
+                r = self.ctrl.hazard.tof_readings[sid]
+                r.distance_mm = 500.0
+                r.status = 0
+                r.is_valid = True
+                r.last_updated = now
+        # Invalidate one sensor
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.tof_readings["toffl"].is_valid = False
+        self.assertFalse(self.ctrl.check_forward_clear())
+
+    # --- check_reverse_clear ---
+
+    def test_check_reverse_clear_all_good(self):
+        """Reverse clear when rear sensors have valid, distant readings."""
+        now = time.time()
+        for sid in self._TOF_REVERSE_SENSORS:
+            with self.ctrl.hazard_lock:
+                r = self.ctrl.hazard.tof_readings[sid]
+                r.distance_mm = 400.0
+                r.status = 0
+                r.is_valid = True
+                r.last_updated = now
+        self.assertTrue(self.ctrl.check_reverse_clear())
+
+    def test_check_reverse_clear_obstacle_behind(self):
+        """Reverse NOT clear when rear sensor detects obstacle."""
+        now = time.time()
+        for sid in self._TOF_REVERSE_SENSORS:
+            with self.ctrl.hazard_lock:
+                r = self.ctrl.hazard.tof_readings[sid]
+                r.distance_mm = 400.0
+                r.status = 0
+                r.is_valid = True
+                r.last_updated = now
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.tof_readings["tofr"].distance_mm = 50.0
+        self.assertFalse(self.ctrl.check_reverse_clear())
+
+    # --- check_sensors_fresh ---
+
+    def test_check_sensors_fresh_all_recent(self):
+        """All sensors fresh when recently updated."""
+        now = time.time()
+        for sid in self._TOF_SENSORS:
+            with self.ctrl.hazard_lock:
+                self.ctrl.hazard.tof_readings[sid].last_updated = now
+        self.assertTrue(self.ctrl.check_sensors_fresh())
+
+    def test_check_sensors_fresh_one_stale(self):
+        """Not fresh if any sensor is stale."""
+        now = time.time()
+        for sid in self._TOF_SENSORS:
+            with self.ctrl.hazard_lock:
+                self.ctrl.hazard.tof_readings[sid].last_updated = now
+        # Make one stale
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.tof_readings["tofr"].last_updated = now - 10.0
+        self.assertFalse(self.ctrl.check_sensors_fresh())
+
+    def test_check_sensors_fresh_subset(self):
+        """Can check freshness of specific sensor subset."""
+        now = time.time()
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.tof_readings["toffc"].last_updated = now
+            self.ctrl.hazard.tof_readings["toffr"].last_updated = now
+        self.assertTrue(self.ctrl.check_sensors_fresh({"toffc", "toffr"}))
+        # But full set would fail
+        self.assertFalse(self.ctrl.check_sensors_fresh())
+
+    # --- get_hazard_snapshot ---
+
+    def test_get_hazard_snapshot_returns_dict(self):
+        """Snapshot should return a dict with expected keys."""
+        snapshot = self.ctrl.get_hazard_snapshot()
+        self.assertIsInstance(snapshot, dict)
+        self.assertIn("active_hazards", snapshot)
+        self.assertIn("tof_readings", snapshot)
+        self.assertIn("bump_states", snapshot)
+        self.assertIn("any_bump_active", snapshot)
+        self.assertEqual(len(snapshot["tof_readings"]), 8)
+
+    def test_get_hazard_snapshot_includes_friendly_names(self):
+        """Snapshot ToF readings should include friendly sensor names."""
+        snapshot = self.ctrl.get_hazard_snapshot()
+        self.assertEqual(snapshot["tof_readings"]["toffc"]["friendly_name"], "front_center")
+        self.assertEqual(snapshot["tof_readings"]["tofr"]["friendly_name"], "rear")
+
+    # --- WebSocket subscription methods ---
+
+    def test_ws_subscribe_hazard_sends_message(self):
+        """_ws_subscribe_hazard should send subscribe JSON via WebSocket."""
+        sent_messages = []
+        mock_ws = unittest.mock.MagicMock()
+        mock_ws.send = lambda msg: sent_messages.append(msg)
+        self.ctrl.ws = mock_ws
+
+        self.ctrl._ws_subscribe_hazard()
+
+        # Should have sent unsubscribe(s) + subscribe
+        subscribe_msgs = [m for m in sent_messages if "subscribe" in m.lower()]
+        self.assertTrue(len(subscribe_msgs) >= 1)
+        # Last message should be the subscribe
+        last = json.loads(subscribe_msgs[-1])
+        self.assertEqual(last["Operation"], "subscribe")
+        self.assertEqual(last["Type"], "HazardNotification")
+        self.assertEqual(last["DebounceMs"], 0)
+
+    def test_ws_subscribe_tof_sends_message(self):
+        """_ws_subscribe_tof should send subscribe JSON with 250ms debounce."""
+        sent_messages = []
+        mock_ws = unittest.mock.MagicMock()
+        mock_ws.send = lambda msg: sent_messages.append(msg)
+        self.ctrl.ws = mock_ws
+
+        self.ctrl._ws_subscribe_tof()
+
+        subscribe_msgs = [m for m in sent_messages if '"subscribe"' in m.lower()]
+        last = json.loads(subscribe_msgs[-1])
+        self.assertEqual(last["Type"], "TimeOfFlight")
+        self.assertEqual(last["DebounceMs"], 250)
+
+    def test_ws_subscribe_bump_sends_message(self):
+        """_ws_subscribe_bump should send subscribe JSON with 0 debounce."""
+        sent_messages = []
+        mock_ws = unittest.mock.MagicMock()
+        mock_ws.send = lambda msg: sent_messages.append(msg)
+        self.ctrl.ws = mock_ws
+
+        self.ctrl._ws_subscribe_bump()
+
+        subscribe_msgs = [m for m in sent_messages if '"subscribe"' in m.lower()]
+        last = json.loads(subscribe_msgs[-1])
+        self.assertEqual(last["Type"], "BumpSensor")
+        self.assertEqual(last["DebounceMs"], 0)
+
+    def test_ws_subscribe_uses_unique_names(self):
+        """Consecutive subscriptions should use different event names."""
+        mock_ws = unittest.mock.MagicMock()
+        self.ctrl.ws = mock_ws
+
+        self.ctrl._ws_subscribe_hazard()
+        name1 = self.ctrl._hazard_event_name
+
+        time.sleep(0.001)  # ensure time_ns differs
+        self.ctrl._ws_subscribe_hazard()
+        name2 = self.ctrl._hazard_event_name
+
+        self.assertNotEqual(name1, name2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -569,6 +569,143 @@ class TestPromptLimiting(unittest.TestCase):
                           "Brevity reminder should be suppressed in summary mode")
 
 
+class TestMovementIntentClassification(unittest.TestCase):
+    """Unit tests for movement intent detection (#54).
+
+    Tests the regex-based movement command classification in orchestration_service.
+    """
+
+    _svc = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import orchestration_service
+            cls._svc = orchestration_service
+        except Exception as exc:
+            cls._svc = None
+            print(f"[TestMovementIntentClassification] Could not import: {exc}")
+
+    def setUp(self):
+        if self._svc is None:
+            self.skipTest("orchestration_service could not be imported")
+
+    # --- Forward commands ---
+
+    def test_go_forward(self):
+        result = self._svc.classify_movement_intent("go forward")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "forward")
+
+    def test_move_ahead(self):
+        result = self._svc.classify_movement_intent("move ahead")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "forward")
+
+    def test_come_here(self):
+        result = self._svc.classify_movement_intent("come here")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "forward")
+
+    def test_come_to_me(self):
+        result = self._svc.classify_movement_intent("come to me")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "forward")
+
+    def test_drive_straight(self):
+        result = self._svc.classify_movement_intent("drive straight")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "forward")
+
+    # --- Backward commands ---
+
+    def test_go_back(self):
+        result = self._svc.classify_movement_intent("go back")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "backward")
+
+    def test_move_backward(self):
+        result = self._svc.classify_movement_intent("move backward")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "backward")
+
+    def test_back_up(self):
+        result = self._svc.classify_movement_intent("back up")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "backward")
+
+    def test_reverse(self):
+        result = self._svc.classify_movement_intent("reverse")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "backward")
+
+    # --- Rotate commands ---
+
+    def test_turn_left(self):
+        result = self._svc.classify_movement_intent("turn left")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "rotate_left")
+
+    def test_rotate_right(self):
+        result = self._svc.classify_movement_intent("rotate right")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "rotate_right")
+
+    def test_spin_left(self):
+        result = self._svc.classify_movement_intent("spin left")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "rotate_left")
+
+    def test_look_right(self):
+        result = self._svc.classify_movement_intent("look right")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "rotate_right")
+
+    # --- Stop commands ---
+
+    def test_stop(self):
+        result = self._svc.classify_movement_intent("stop")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "stop")
+
+    def test_halt(self):
+        result = self._svc.classify_movement_intent("halt")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "stop")
+
+    def test_freeze(self):
+        result = self._svc.classify_movement_intent("freeze")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "stop")
+
+    def test_dont_move(self):
+        result = self._svc.classify_movement_intent("don't move")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["command"], "stop")
+
+    # --- Non-movement commands (should return None) ---
+
+    def test_hello(self):
+        result = self._svc.classify_movement_intent("hello misty")
+        self.assertIsNone(result)
+
+    def test_whats_the_weather(self):
+        result = self._svc.classify_movement_intent("what's the weather today")
+        self.assertIsNone(result)
+
+    def test_tell_me_a_story(self):
+        result = self._svc.classify_movement_intent("tell me a story")
+        self.assertIsNone(result)
+
+    def test_empty_string(self):
+        result = self._svc.classify_movement_intent("")
+        self.assertIsNone(result)
+
+    def test_none_input(self):
+        result = self._svc.classify_movement_intent(None)
+        self.assertIsNone(result)
+
+
 class TestDrivePrimitives(unittest.TestCase):
     """Unit tests for drive/locomotion methods (#48).
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1107,10 +1107,17 @@ class TestMovingState(unittest.TestCase):
             )
             if _ctrl_path not in sys.path:
                 sys.path.insert(0, _ctrl_path)
-            from misty_controller import MistyController, State, PREEMPTION_PRIORITY
+            from misty_controller import (
+                MistyController, State, PREEMPTION_PRIORITY,
+                BATTERY_MOVEMENT_CUTOFF, BATTERY_MOVEMENT_VOLTAGE_MIN,
+                BATTERY_VOLTAGE_DROP_HALT,
+            )
             cls._MistyController = MistyController
             cls._State = State
             cls._PREEMPTION_PRIORITY = PREEMPTION_PRIORITY
+            cls._BATTERY_MOVEMENT_CUTOFF = BATTERY_MOVEMENT_CUTOFF
+            cls._BATTERY_MOVEMENT_VOLTAGE_MIN = BATTERY_MOVEMENT_VOLTAGE_MIN
+            cls._BATTERY_VOLTAGE_DROP_HALT = BATTERY_VOLTAGE_DROP_HALT
         except Exception as exc:
             cls._MistyController = None
             print(f"[TestMovingState] Could not import misty_controller: {exc}")
@@ -1171,13 +1178,33 @@ class TestMovingState(unittest.TestCase):
         self.assertFalse(result)
 
     def test_start_moving_blocked_battery_critical(self):
-        """start_moving should fail if battery is critically low."""
+        """start_moving should fail if battery is below movement cutoff (25%)."""
         self.ctrl.set_state(self._State.IDLE)
         with self.ctrl.battery_lock:
-            self.ctrl.battery.charge_percent = 0.05
+            self.ctrl.battery.charge_percent = 0.20  # below 25% movement cutoff
             self.ctrl.battery.last_updated = time.time()
         result = self.ctrl.start_moving(reason="test")
         self.assertFalse(result)
+
+    def test_start_moving_blocked_low_voltage(self):
+        """start_moving should fail if voltage is below movement minimum (#52)."""
+        self.ctrl.set_state(self._State.IDLE)
+        with self.ctrl.battery_lock:
+            self.ctrl.battery.charge_percent = 0.30  # above percentage cutoff
+            self.ctrl.battery.voltage = 7.2  # below 7.5V voltage minimum
+            self.ctrl.battery.last_updated = time.time()
+        result = self.ctrl.start_moving(reason="test")
+        self.assertFalse(result)
+
+    def test_start_moving_ok_with_good_battery(self):
+        """start_moving should succeed with good battery levels."""
+        self.ctrl.set_state(self._State.IDLE)
+        with self.ctrl.battery_lock:
+            self.ctrl.battery.charge_percent = 0.50
+            self.ctrl.battery.voltage = 8.0
+            self.ctrl.battery.last_updated = time.time()
+        result = self.ctrl.start_moving(reason="test")
+        self.assertTrue(result)
 
     # --- stop_moving ---
 
@@ -1258,6 +1285,70 @@ class TestMovingState(unittest.TestCase):
             "isContacted": False,
         })
         self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+
+    # --- Battery preemption during movement (#52) ---
+
+    def test_battery_low_preempts_movement(self):
+        """Battery dropping below movement cutoff during MOVING should preempt."""
+        self.ctrl.set_state(self._State.MOVING)
+        from misty_controller import BatteryState
+        b = BatteryState(charge_percent=0.20, voltage=7.8, last_updated=time.time())
+        self.ctrl._evaluate_battery_thresholds(b)
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_battery_voltage_low_preempts_movement(self):
+        """Voltage below minimum during MOVING should preempt."""
+        self.ctrl.set_state(self._State.MOVING)
+        from misty_controller import BatteryState
+        b = BatteryState(charge_percent=0.30, voltage=7.2, last_updated=time.time())
+        self.ctrl._evaluate_battery_thresholds(b)
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_battery_voltage_drop_preempts_movement(self):
+        """Rapid voltage drop during MOVING should preempt."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._last_battery_voltage = 8.0
+        from misty_controller import BatteryState
+        # Drop of 0.4V (> 0.3V threshold)
+        b = BatteryState(charge_percent=0.40, voltage=7.6, last_updated=time.time())
+        self.ctrl._evaluate_battery_thresholds(b)
+        self.assertEqual(self.ctrl.get_state(), self._State.IDLE)
+
+    def test_battery_ok_no_preempt_during_movement(self):
+        """Normal battery during MOVING should not preempt."""
+        self.ctrl.set_state(self._State.MOVING)
+        self.ctrl._last_battery_voltage = 8.0
+        from misty_controller import BatteryState
+        b = BatteryState(charge_percent=0.50, voltage=7.9, last_updated=time.time())
+        self.ctrl._evaluate_battery_thresholds(b)
+        self.assertEqual(self.ctrl.get_state(), self._State.MOVING)
+
+    # --- Wake word pause/resume (#53) ---
+
+    def test_start_moving_pauses_wake_word(self):
+        """start_moving should pause the wake word listener."""
+        self.ctrl.set_state(self._State.IDLE)
+        pause_called = []
+        mock_listener = unittest.mock.MagicMock()
+        mock_listener.pause = lambda: pause_called.append(True)
+        self.ctrl._wake_word_listener = mock_listener
+
+        self.ctrl.start_moving(reason="test")
+        self.assertTrue(pause_called)
+
+    def test_stop_moving_resumes_wake_word(self):
+        """stop_moving should resume the wake word listener after settle."""
+        self.ctrl.set_state(self._State.MOVING)
+        resume_called = []
+        mock_listener = unittest.mock.MagicMock()
+        mock_listener.resume = lambda: resume_called.append(True)
+        self.ctrl._wake_word_listener = mock_listener
+        # Override settle time for test speed
+        self.ctrl.MOVEMENT_SETTLE_MS = 10
+
+        self.ctrl.stop_moving(reason="test")
+        time.sleep(0.1)  # allow thread to complete
+        self.assertTrue(resume_called)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -705,6 +705,33 @@ class TestMovementIntentClassification(unittest.TestCase):
         result = self._svc.classify_movement_intent(None)
         self.assertIsNone(result)
 
+    # --- Movement acknowledgments (#55) ---
+
+    def test_get_movement_ack_forward(self):
+        """Movement acknowledgment for forward should be a non-empty string."""
+        ack = self._svc._get_movement_acknowledgment("forward")
+        self.assertIsInstance(ack, str)
+        self.assertTrue(len(ack) > 0)
+
+    def test_get_movement_ack_stop(self):
+        ack = self._svc._get_movement_acknowledgment("stop")
+        self.assertIsInstance(ack, str)
+        self.assertTrue(len(ack) > 0)
+
+    def test_get_movement_ack_unknown_command(self):
+        """Unknown command should return fallback 'Okay!'."""
+        ack = self._svc._get_movement_acknowledgment("unknown_cmd")
+        self.assertEqual(ack, "Okay!")
+
+    def test_movement_prompt_supplement_exists(self):
+        """MOVEMENT_PROMPT_SUPPLEMENT should be defined."""
+        self.assertTrue(hasattr(self._svc, 'MOVEMENT_PROMPT_SUPPLEMENT'))
+        self.assertIn("move", self._svc.MOVEMENT_PROMPT_SUPPLEMENT.lower())
+
+    def test_system_prompt_mentions_movement(self):
+        """System prompt should mention Misty can move."""
+        self.assertIn("move", self._svc.SYSTEM_PROMPT.lower())
+
 
 class TestDrivePrimitives(unittest.TestCase):
     """Unit tests for drive/locomotion methods (#48).

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ import requests
 import json
 import time
 import os
+import threading
 from io import BytesIO
 from urllib.parse import urlparse, urlunparse
 
@@ -1609,6 +1610,240 @@ class TestTeleopEndpoint(unittest.TestCase):
         self.assertIn("bump_states", snapshot)
         self.assertIn("active_hazards", snapshot)
         self.assertEqual(len(snapshot["tof_readings"]), 8)
+
+
+class TestSpeakMoveIntegration(unittest.TestCase):
+    """Unit tests for combined speak + move responses (#56).
+
+    Validates that movement responses from orchestration are correctly
+    detected, acknowledgment audio is played, and movement is executed.
+    Uses mocked HTTP and state machine.
+    """
+
+    _ctrl = None
+    _ctrl_mod = None
+    _State = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            _ctrl_path = os.path.normpath(
+                os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+            )
+            if _ctrl_path not in sys.path:
+                sys.path.insert(0, _ctrl_path)
+            import misty_controller as _ctrl_mod
+            cls._ctrl_mod = _ctrl_mod
+            cls._State = _ctrl_mod.State
+        except Exception as e:
+            raise unittest.SkipTest(f"Cannot import misty_controller: {e}")
+
+    def setUp(self):
+        """Create controller with mocked HTTP and WebSocket."""
+        self._post_calls = []
+
+        def mock_post(path, body=None, timeout=None):
+            self._post_calls.append((path, body))
+            return {"status": "Success"}
+
+        self.ctrl = self._ctrl_mod.MistyController.__new__(self._ctrl_mod.MistyController)
+        self.ctrl.misty_ip = "10.0.0.99"
+        self.ctrl.state = self._State.IDLE
+        self.ctrl.state_lock = threading.Lock()
+        self.ctrl.battery = self._ctrl_mod.BatteryState()
+        self.ctrl.battery_lock = threading.Lock()
+        self.ctrl.battery.charge_percent = 0.50
+        self.ctrl.battery.voltage = 8.0
+        self.ctrl.battery.last_updated = time.time()
+        self.ctrl.hazard = self._ctrl_mod.HazardState()
+        self.ctrl.hazard_lock = threading.Lock()
+        self.ctrl.last_activity_time = time.time()
+        self.ctrl._wake_word_listener = None
+        self.ctrl.misty_post = mock_post
+        self.ctrl.DRIVE_MAX_DURATION_MS = 3000
+        self.ctrl.MOVEMENT_SETTLE_MS = 100  # fast for tests
+
+    # --- _do_orchestrate_and_respond movement detection ---
+
+    def test_movement_response_detected(self):
+        """When orchestrate returns type=movement, return dict with movement info."""
+        movement_result = {
+            "status": "ok",
+            "type": "movement",
+            "movement": {"command": "forward"},
+            "user_text": "come here",
+            "response_text": "On my way!",
+            "pipeline_ms": 150,
+        }
+        # Mock requests.post and requests.get
+        import unittest.mock as mock
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = movement_result
+        mock_resp.status_code = 200
+
+        with mock.patch("requests.post", return_value=mock_resp):
+            result = self.ctrl._do_orchestrate_and_respond(1, b"fake_audio", time.time())
+
+        self.assertIsInstance(result, dict)
+        self.assertTrue(result["had_speech"])
+        self.assertEqual(result["movement"]["command"], "forward")
+
+    def test_normal_response_returns_true(self):
+        """Normal conversational response should return True (not a dict)."""
+        normal_result = {
+            "status": "ok",
+            "transcribedText": "hello",
+            "inferenceResponse": "Hi there!",
+            "responseAudio": "/api/audio/resp.wav",
+            "latencyMs": 500,
+        }
+        import unittest.mock as mock
+        mock_post_resp = mock.MagicMock()
+        mock_post_resp.json.return_value = normal_result
+        mock_post_resp.status_code = 200
+
+        mock_get_resp = mock.MagicMock()
+        mock_get_resp.content = b"\x00" * 1000  # fake WAV data
+        mock_get_resp.raise_for_status = mock.MagicMock()
+
+        # Mock upload_and_play_audio to return short duration
+        self.ctrl.upload_and_play_audio = mock.MagicMock(return_value=0.1)
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+        self.ctrl.move_head = mock.MagicMock()
+
+        with mock.patch("requests.post", return_value=mock_post_resp), \
+             mock.patch("requests.get", return_value=mock_get_resp), \
+             mock.patch("time.sleep"):
+            result = self.ctrl._do_orchestrate_and_respond(1, b"fake", time.time())
+
+        self.assertTrue(result)
+        self.assertNotIsInstance(result, dict)
+
+    def test_empty_stt_returns_false(self):
+        """Empty STT should return False."""
+        import unittest.mock as mock
+        mock_resp = mock.MagicMock()
+        mock_resp.json.return_value = {"status": "error", "error": "empty_stt"}
+        mock_resp.status_code = 400
+
+        with mock.patch("requests.post", return_value=mock_resp):
+            result = self.ctrl._do_orchestrate_and_respond(1, b"fake", time.time())
+
+        self.assertFalse(result)
+
+    # --- _execute_voice_movement ---
+
+    def test_voice_movement_forward(self):
+        """Voice forward command should call drive_time with positive linear."""
+        import unittest.mock as mock
+
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+        self.ctrl.halt = mock.MagicMock()
+        self.ctrl.drive_time = mock.MagicMock()
+
+        movement = {"command": "forward", "distance_mm": 200, "speed_pct": 20}
+        self.ctrl._execute_voice_movement(1, movement)
+
+        # Should have called drive_time with positive linear velocity
+        self.ctrl.drive_time.assert_called_once()
+        args = self.ctrl.drive_time.call_args[0]
+        self.assertGreater(args[0], 0)  # positive linear
+        self.assertEqual(args[1], 0)     # no angular
+
+    def test_voice_movement_stop_halts_immediately(self):
+        """Voice stop command should halt immediately without state transition."""
+        import unittest.mock as mock
+        self.ctrl.halt = mock.MagicMock()
+        self.ctrl._execute_voice_movement(1, {"command": "stop"})
+        self.ctrl.halt.assert_called_once()
+
+    def test_voice_movement_blocked_by_hazard(self):
+        """Voice movement should be blocked when hazards are active."""
+        import unittest.mock as mock
+
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+
+        # Set active hazard
+        with self.ctrl.hazard_lock:
+            self.ctrl.hazard.active_hazards = ["TOF_FrontCenter"]
+
+        self.ctrl._speak_movement_failure = mock.MagicMock()
+        self.ctrl._execute_voice_movement(1, {"command": "forward"})
+
+        # Should have called failure speech, not drive
+        self.ctrl._speak_movement_failure.assert_called_once()
+
+    def test_voice_movement_clamps_speed(self):
+        """Voice movement should clamp speed to DRIVE_MAX_LINEAR_PCT."""
+        import unittest.mock as mock
+
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+        self.ctrl.halt = mock.MagicMock()
+        self.ctrl.drive_time = mock.MagicMock()
+
+        # Request 50% speed — should be clamped to DRIVE_MAX_LINEAR_PCT (30)
+        movement = {"command": "forward", "distance_mm": 200, "speed_pct": 50}
+        self.ctrl._execute_voice_movement(1, movement)
+
+        # The speed_pct clamped internally, but drive_time gets the clamped value
+        self.ctrl.drive_time.assert_called_once()
+        args = self.ctrl.drive_time.call_args[0]
+        self.assertLessEqual(args[0], self._ctrl_mod.MistyController.DRIVE_MAX_LINEAR_PCT)
+
+    def test_voice_movement_backward(self):
+        """Voice backward command should use negative linear velocity."""
+        import unittest.mock as mock
+
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+        self.ctrl.halt = mock.MagicMock()
+        self.ctrl.drive_time = mock.MagicMock()
+
+        self.ctrl._execute_voice_movement(1, {"command": "backward", "distance_mm": 150})
+
+        self.ctrl.drive_time.assert_called_once()
+        args = self.ctrl.drive_time.call_args[0]
+        self.assertLess(args[0], 0)  # negative linear
+
+    def test_voice_movement_rotate(self):
+        """Voice rotate command should use angular velocity, zero linear."""
+        import unittest.mock as mock
+
+        self.ctrl.set_led = mock.MagicMock()
+        self.ctrl.display_image = mock.MagicMock()
+        self.ctrl.halt = mock.MagicMock()
+        self.ctrl.drive_time = mock.MagicMock()
+
+        self.ctrl._execute_voice_movement(1, {"command": "rotate_left", "angle_deg": 90})
+
+        self.ctrl.drive_time.assert_called_once()
+        args = self.ctrl.drive_time.call_args[0]
+        self.assertEqual(args[0], 0)     # no linear
+        self.assertGreater(args[1], 0)   # positive angular
+
+    # --- _wait_for_move_completion ---
+
+    def test_wait_for_move_returns_false_on_normal_completion(self):
+        """Should return False (not preempted) if state stays MOVING until timeout."""
+        self.ctrl.set_state(self._State.MOVING)
+        result = self.ctrl._wait_for_move_completion(0.3)
+        self.assertFalse(result)  # completed normally
+
+    def test_wait_for_move_returns_true_on_preemption(self):
+        """Should return True if state changes from MOVING (preempted)."""
+        self.ctrl.set_state(self._State.MOVING)
+
+        def preempt_after_delay():
+            time.sleep(0.1)
+            self.ctrl.set_state(self._State.IDLE)
+
+        threading.Thread(target=preempt_after_delay, daemon=True).start()
+        result = self.ctrl._wait_for_move_completion(2.0)
+        self.assertTrue(result)  # preempted
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements Issue #49: Subscribe to safety telemetry (HazardNotification, TimeOfFlight, BumpSensor) via WebSocket for navigation safety awareness.

## Changes

### misty_controller.py
- **New data structures**: HazardState, ToFReading dataclasses + sensor position maps
- **3 new WebSocket subscriptions**: _ws_subscribe_hazard(), _ws_subscribe_tof(), _ws_subscribe_bump() with unique timestamped names (time_ns)
- **3 event handlers**: _handle_hazard_event(), _handle_tof_event(), _handle_bump_event() — update thread-safe state
- **Safety query methods**: check_forward_clear(), check_reverse_clear(), check_sensors_fresh(), get_hazard_snapshot()
- **Optimized WS message routing**: High-frequency telemetry events handled BEFORE the per-message INFO log to avoid 32+ msg/s log overhead

### Design decisions
- **Subscribe always** — data available before any move command
- **Per-sensor freshness** with 1.0s stale timeout (fail closed)
- **ToF status validation** — only status 0/2 treated as reliable
- **Direction-aware checks** — forward vs reverse sensor sets
- **DebounceMs=0** for HazardNotification + BumpSensor (safety-critical)
- **DebounceMs=250** for TimeOfFlight (advisory/proactive)
- Thread-safe with dedicated \hazard_lock\

### Tests
- 27 new unit tests in \TestHazardTelemetry\ class (all passing)
- Covers: state init, event handling, clearance checks, subscription wire format, unique names

## Depends on
- PR #61 (drive primitives, #48) ✅

Closes #49