### PR TITLE
Add issue implementation loop skill

### DIFF
--- a/.github/skills/feature-planning/SKILL.md
+++ b/.github/skills/feature-planning/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: feature-planning
+description: Use when asked to plan a future feature, create a GitHub issue from a plan, label or prioritize a feature request, or explicitly avoid immediate implementation.
+---
+
+# Feature Planning Skill
+
+Use this skill when the user asks to plan a future feature, create a GitHub issue for later implementation, label or prioritize a feature request, or explicitly says not to implement yet.
+
+Common trigger phrases include:
+
+- "plan a feature"
+- "new feature capability"
+- "create an issue for later implementation"
+- "generate a GitHub issue from this plan"
+- "do not execute"
+- "do not implement"
+- "not immediately execute"
+
+## Core rule
+
+Separate planning from implementation.
+
+If the user asks for a plan or issue only, do not change application source code, tests, docs, assets, or runtime behavior beyond the requested planning or GitHub issue artifact. Create the requested plan/issue, label it appropriately, report the result, and stop.
+
+Only start implementation when the user explicitly asks to implement, start, execute, or get to work on the feature.
+
+## Planning workflow
+
+1. **Review context**
+   - Read the relevant source files, docs, existing issues, and recent related user requests.
+   - If the request references an external article, video, repo, or docs page, inspect it enough to understand the implementation pattern and constraints.
+   - Check whether an existing issue already covers the feature.
+
+2. **Clarify only when necessary**
+   - Ask a question only when feature scope, behavior, or target architecture is genuinely ambiguous.
+   - If the user has provided enough context, make a reasonable engineering decision and proceed.
+
+3. **Draft a concise feature issue**
+   - Include these sections when applicable:
+     - `## Summary`
+     - `## Current state`
+     - `## Proposed approach`
+     - `## Risks / constraints`
+     - `## Acceptance criteria`
+     - `## Related issues`
+   - Keep the issue specific enough for later implementation.
+   - If the feature was inspired by an external reference, describe what can be reused as a pattern and what should not be copied.
+
+4. **Respect no-execution requests**
+   - When the user says not to execute or not to implement, create only the issue or plan artifact requested.
+   - Explicitly state in the final response that no implementation work was performed.
+
+## Label and priority guidance
+
+Use `enhancement` for new feature capability issues.
+
+Apply exactly one priority label when possible:
+
+- `priority: high` — demo-readiness, reliability, safety, wake-word/audio blockers, or major user-facing issues.
+- `priority: medium` — meaningful product polish, maintainability, validation spikes, or useful feature work that is not blocking.
+- `priority: low` — deferred, conditional, exploratory, or non-blocking improvements.
+
+Preserve existing non-priority labels unless the request explicitly asks to reprioritize or relabel broader backlog items.
+
+## GitHub issue discipline
+
+- Before creating an issue, search for obvious duplicates by title and topic.
+- If a duplicate exists, update or reference the existing issue instead of creating a new one.
+- Link related current-repository issues using `#<number>`.
+- For repositories outside this one, use fully qualified references like `owner/repo#123`.
+- Keep issue titles action-oriented and concise.
+
+## Final response
+
+After creating or updating an issue, report:
+
+- issue number and title
+- issue URL when available
+- labels applied
+- whether any implementation work was intentionally not performed
+
+Keep the final response concise.

--- a/.github/skills/issue-implementation-loop/SKILL.md
+++ b/.github/skills/issue-implementation-loop/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: issue-implementation-loop
+description: Use when asked to run or define an agent loop that reviews GitHub issues, prioritizes by labels, implements ready work, verifies changes, and off-ramps inefficient loops.
+---
+
+# Issue Implementation Loop Skill
+
+Use this skill when the user asks an agent to review GitHub issues, select prioritized work, implement from issue success criteria, run verification, monitor loop performance, or create an off-ramp for work that is not efficient to automate.
+
+This workflow is **both agent and skill**:
+
+- The **agent** is the autonomous executor. It reads issues, chooses ready work, edits files, runs commands, opens PRs, and reports results.
+- This **skill** is the reusable policy and runbook. It defines selection rules, guardrails, verification, metrics, and off-ramp behavior.
+
+## Core rule
+
+Implement only issues that are ready, scoped, and verifiable.
+
+If an issue is vague, missing acceptance criteria, likely duplicated, blocked, or better suited to planning than execution, invoke the `feature-planning` skill instead of starting implementation.
+
+## Loop workflow
+
+1. **Review candidate issues**
+   - List open issues in the current repository.
+   - Exclude closed issues, issues assigned to someone else when ownership is unclear, and issues explicitly marked blocked or deferred.
+   - Prefer issues with clear `## Acceptance criteria`, `## Success criteria`, or an equivalent checklist.
+
+2. **Prioritize by labels**
+   - Work in this order:
+     1. `priority: high`
+     2. `priority: medium`
+     3. `priority: low`
+   - Within the same priority, prefer issues with the clearest acceptance criteria, smallest safe diff, and strongest verification path.
+   - Do not invent priority. If priority is missing and the issue is not urgent, use `feature-planning` to refine or label it before implementation.
+
+3. **Plan the implementation**
+   - Restate the acceptance criteria as an execution checklist.
+   - Identify affected files, tests, docs, and runtime constraints.
+   - Create a feature branch; never work directly on `main`.
+   - Keep the planned diff narrow and tied to the issue.
+
+4. **Implement iteratively**
+   - Make surgical code or documentation changes that satisfy the checklist.
+   - Preserve repository conventions and existing behavior unless the issue explicitly changes behavior.
+   - Do not silently skip invalid input, broad errors, failed checks, or unavailable dependencies.
+
+5. **Verify**
+   - Run the smallest targeted lint, test, build, or documentation check that covers the change.
+   - Add or update tests when behavior changes and a practical test path exists.
+   - If live services, hardware, or credentials are required and unavailable, state exactly which check could not run and why.
+
+6. **Report and hand off**
+   - Open or prepare a PR that links the issue.
+   - Include the completed success-criteria checklist.
+   - Include commands run and verification results.
+   - Note any unavailable checks, residual risks, or manual validation needed.
+
+## When to invoke `feature-planning`
+
+Invoke `feature-planning` instead of implementing when:
+
+- The issue is a new feature idea without acceptance criteria.
+- The issue may duplicate existing work.
+- The requested behavior has multiple reasonable designs and no clear choice.
+- The work requires reprioritization or label cleanup before execution.
+- The loop needs to create a human-review issue as an off-ramp.
+- A failed implementation attempt reveals that the issue needs a smaller or clearer scope.
+
+After `feature-planning` produces a ready issue with labels and acceptance criteria, the agent may return to this skill for implementation.
+
+## Off-ramp behavior
+
+Use an off-ramp when continuing the loop is less efficient or less safe than human review.
+
+First try to correct agent behavior when the failure is local and recoverable:
+
+- Fix an obviously wrong file target.
+- Narrow an overly broad diff.
+- Re-run a failed command only after addressing the cause.
+- Replace a speculative approach with a repository pattern found in existing code.
+
+Stop and create or comment a human-review issue when any of these occur:
+
+- Acceptance criteria are absent or contradictory.
+- The agent has made two unsuccessful implementation attempts for the same issue.
+- Verification cannot be run and there is no credible substitute.
+- The required change crosses unrelated subsystems.
+- The diff is growing beyond the issue scope.
+- Required credentials, services, hardware, or external access are unavailable.
+- The task is blocked on product, safety, privacy, or architectural decisions.
+
+The off-ramp record must include:
+
+- Issue number and title.
+- What was attempted.
+- Why the loop stopped.
+- Evidence from commands, errors, tests, or code review.
+- Recommended next human decision.
+
+## Loop performance monitoring
+
+Track these metrics for each loop run:
+
+- Issues reviewed.
+- Issue selected and priority label.
+- Started and completed timestamps.
+- Iteration count.
+- Files changed.
+- Commands run.
+- Verification status.
+- Failures and retries.
+- Off-ramp reason, when applicable.
+
+Use these metrics to decide whether to continue, narrow scope, switch to `feature-planning`, or stop for human review.
+
+## Verification guidance
+
+- Prefer targeted tests over full suites when they cover the changed behavior.
+- Escalate to broader tests only when targeted checks are insufficient or reveal shared-risk failures.
+- Documentation-only changes do not need code tests unless documentation tests exist.
+- Hardware-dependent Misty checks should be reported as manual validation when the robot or live services are unavailable.
+- Never report success for skipped or unavailable checks; report them as not run with the reason.
+
+## Final response
+
+Report:
+
+- Issue number and title.
+- Branch or PR, when available.
+- Success criteria completed.
+- Verification commands and results.
+- Any off-ramp, unavailable check, or manual follow-up.
+
+Keep the response concise and distinguish completed work from planned or blocked work.

--- a/logs/log_2026-06-27.md
+++ b/logs/log_2026-06-27.md
@@ -14,6 +14,9 @@
 10. Explain month-to-date AIC usage.
 11. Create a reusable skill for future log updates because the original log did not include an AIC snapshot.
 12. Read the day's request sequence, evaluate prompt efficiency, and write the results to a new markdown file under `docs\`.
+13. Identify whether an issue-reviewing automation loop should be an agent, a skill, or both.
+14. Decide whether the loop should use the `feature-planning` skill during implementation.
+15. Generate a GitHub issue for the skill-backed agent implementation loop, then execute it.
 
 ## AI/Copilot usage
 
@@ -36,10 +39,13 @@
 - Queried recorded AIC usage from session history.
 - Added the project skill `.github\skills\log-updates\SKILL.md` to standardize daily log updates and require AIC snapshots.
 - Analyzed the request sequence for prompt efficiency and documented the findings in `docs\prompt-efficiency-evaluation-2026-06-27.md`.
+- Used the `feature-planning` skill to shape issue #75 for a skill-backed issue implementation loop.
+- Created GitHub issue #75, created branch `issue-75-implementation-loop-skill`, and added `.github\skills\issue-implementation-loop\SKILL.md` with the existing feature-planning skill included as its planning dependency.
+- Used the `log-updates` skill to update this daily log after repository changes.
 
 ## AIC usage snapshot
 
-Snapshot time: 2026-06-27 10:06 -04:00
+Snapshot time: 2026-06-27 11:12 -04:00
 
 Scope: day-to-date recorded usage for 2026-06-27. Current-session usage was not available by session ID in the session store, so this uses the best available recorded daily totals.
 
@@ -47,17 +53,17 @@ Source: `session_store_sql` over `events.usage_cost`.
 
 | Model | AICs | Usage events |
 |---|---:|---:|
-| `gpt-5.5` | 75.00 | 10 |
+| `gpt-5.5` | 1,320.00 | 176 |
 | `gpt-5.4-mini` | 7.92 | 24 |
 | `gpt-5.3-codex` | 2.00 | 2 |
-| **Total** | **84.92** | **36** |
+| **Total** | **1,329.92** | **202** |
 
 Additional usage lookups:
 
 | Scope | Total AICs |
 |---|---:|
 | 2026-06-26 | 802.26 |
-| June 2026 month-to-date | 5,211.97 |
+| June 2026 month-to-date | 6,456.97 |
 
 ## Repository updates
 
@@ -66,6 +72,10 @@ Additional usage lookups:
 - Added `.github\skills\log-updates\SKILL.md`.
 - Added `docs\prompt-efficiency-evaluation-2026-06-27.md`.
 - Updated `logs\log_2026-06-27.md`.
+- Created GitHub issue #75, "Add skill-backed agent workflow for issue implementation loops".
+- Added `.github\skills\feature-planning\SKILL.md`.
+- Added `.github\skills\issue-implementation-loop\SKILL.md`.
+- Updated `logs\log_2026-06-27.md` again.
 
 ## Logging convention
 


### PR DESCRIPTION
## Summary

- add the `feature-planning` project skill so planning/off-ramp issue creation has a reusable policy
- add the `issue-implementation-loop` project skill for agent-driven issue selection, implementation, verification, metrics, and off-ramps
- update the daily repository log with issue #75 work and the latest AIC usage snapshot

## Success criteria

- [x] A repository skill exists for the issue implementation loop.
- [x] The skill states that the executor is an agent and the reusable policy/runbook is a skill.
- [x] The skill explains when to invoke `feature-planning` instead of implementing immediately.
- [x] The skill defines label-based priority selection.
- [x] The skill requires implementation to be driven by issue success criteria.
- [x] The skill defines off-ramp behavior that either corrects agent behavior or logs/comments an issue for human review.
- [x] The skill requires loop performance monitoring.
- [x] The skill requires appropriate lint/test/build verification and clear reporting of unavailable checks.

## Verification

- `git diff --check`

Refs #75
