### PR TITLE
Add issue implementation loop agent and skills

### DIFF
--- a/.github/agents/issue-implementation-loop.md
+++ b/.github/agents/issue-implementation-loop.md
@@ -1,0 +1,24 @@
+---
+name: issue-implementation-loop
+description: Reviews GitHub issues, prioritizes ready work by labels, implements against success criteria, verifies changes, and off-ramps inefficient loops.
+---
+
+You are the issue implementation loop agent for the Misty II + Foundry Local repository.
+
+Your job is to run a bounded implementation loop over GitHub issues:
+
+1. Review open issues in the current repository.
+2. Select ready work by priority labels: `priority: high`, then `priority: medium`, then `priority: low`.
+3. Implement only issues with clear acceptance criteria or success criteria.
+4. Create a feature branch; never push directly to `main`.
+5. Make narrow changes that satisfy the selected issue.
+6. Run the smallest lint, test, build, or documentation check that verifies the change.
+7. Open a pull request that links or closes the issue and includes the verification evidence.
+
+Use `.github\skills\issue-implementation-loop\SKILL.md` as the policy for the loop. Use `.github\skills\feature-planning\SKILL.md` before implementation when an issue is vague, duplicated, missing criteria, blocked, or needs a human-review off-ramp.
+
+Stop the loop instead of continuing inefficiently when acceptance criteria are absent or contradictory, two implementation attempts fail, verification cannot run with no credible substitute, the diff grows beyond issue scope, required external access is unavailable, or the work needs product/safety/architecture input.
+
+When stopping, leave a clear off-ramp record with the issue number, what was attempted, why the loop stopped, evidence from commands or code review, and the next human decision needed.
+
+Always report completed work separately from unavailable checks or follow-up needed.

--- a/.github/skills/feature-planning/SKILL.md
+++ b/.github/skills/feature-planning/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: feature-planning
+description: Use when asked to plan a future feature, create a GitHub issue from a plan, label or prioritize a feature request, or explicitly avoid immediate implementation.
+---
+
+# Feature Planning Skill
+
+Use this skill when the user asks to plan a future feature, create a GitHub issue for later implementation, label or prioritize a feature request, or explicitly says not to implement yet.
+
+Common trigger phrases include:
+
+- "plan a feature"
+- "new feature capability"
+- "create an issue for later implementation"
+- "generate a GitHub issue from this plan"
+- "do not execute"
+- "do not implement"
+- "not immediately execute"
+
+## Core rule
+
+Separate planning from implementation.
+
+If the user asks for a plan or issue only, do not change application source code, tests, docs, assets, or runtime behavior beyond the requested planning or GitHub issue artifact. Create the requested plan/issue, label it appropriately, report the result, and stop.
+
+Only start implementation when the user explicitly asks to implement, start, execute, or get to work on the feature.
+
+## Planning workflow
+
+1. **Review context**
+   - Read the relevant source files, docs, existing issues, and recent related user requests.
+   - If the request references an external article, video, repo, or docs page, inspect it enough to understand the implementation pattern and constraints.
+   - Check whether an existing issue already covers the feature.
+
+2. **Clarify only when necessary**
+   - Ask a question only when feature scope, behavior, or target architecture is genuinely ambiguous.
+   - If the user has provided enough context, make a reasonable engineering decision and proceed.
+
+3. **Draft a concise feature issue**
+   - Include these sections when applicable:
+     - `## Summary`
+     - `## Current state`
+     - `## Proposed approach`
+     - `## Risks / constraints`
+     - `## Acceptance criteria`
+     - `## Related issues`
+   - Keep the issue specific enough for later implementation.
+   - If the feature was inspired by an external reference, describe what can be reused as a pattern and what should not be copied.
+
+4. **Respect no-execution requests**
+   - When the user says not to execute or not to implement, create only the issue or plan artifact requested.
+   - Explicitly state in the final response that no implementation work was performed.
+
+## Label and priority guidance
+
+Use `enhancement` for new feature capability issues.
+
+Apply exactly one priority label when possible:
+
+- `priority: high` - demo-readiness, reliability, safety, wake-word/audio blockers, or major user-facing issues.
+- `priority: medium` - meaningful product polish, maintainability, validation spikes, or useful feature work that is not blocking.
+- `priority: low` - deferred, conditional, exploratory, or non-blocking improvements.
+
+Preserve existing non-priority labels unless the request explicitly asks to reprioritize or relabel broader backlog items.
+
+## GitHub issue discipline
+
+- Before creating an issue, search for obvious duplicates by title and topic.
+- If a duplicate exists, update or reference the existing issue instead of creating a new one.
+- Link related current-repository issues using `#<number>`.
+- For repositories outside this one, use fully qualified references like `owner/repo#123`.
+- Keep issue titles action-oriented and concise.
+
+## Final response
+
+After creating or updating an issue, report:
+
+- issue number and title
+- issue URL when available
+- labels applied
+- whether any implementation work was intentionally not performed
+
+Keep the final response concise.

--- a/.github/skills/feature-planning/SKILL.md
+++ b/.github/skills/feature-planning/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: feature-planning
+description: Use when asked to plan a future feature, create a GitHub issue from a plan, label or prioritize a feature request, or explicitly avoid immediate implementation.
+---
+
+# Feature Planning Skill
+
+Use this skill when the user asks to plan a future feature, create a GitHub issue for later implementation, label or prioritize a feature request, or explicitly says not to implement yet.
+
+Common trigger phrases include:
+
+- "plan a feature"
+- "new feature capability"
+- "create an issue for later implementation"
+- "generate a GitHub issue from this plan"
+- "do not execute"
+- "do not implement"
+- "not immediately execute"
+
+## Core rule
+
+Separate planning from implementation.
+
+If the user asks for a plan or issue only, do not change application source code, tests, docs, assets, or runtime behavior beyond the requested planning or GitHub issue artifact. Create the requested plan/issue, label it appropriately, report the result, and stop.
+
+Only start implementation when the user explicitly asks to implement, start, execute, or get to work on the feature.
+
+## Planning workflow
+
+1. **Review context**
+   - Read the relevant source files, docs, existing issues, and recent related user requests.
+   - If the request references an external article, video, repo, or docs page, inspect it enough to understand the implementation pattern and constraints.
+   - Check whether an existing issue already covers the feature.
+
+2. **Clarify only when necessary**
+   - Ask a question only when feature scope, behavior, or target architecture is genuinely ambiguous.
+   - If the user has provided enough context, make a reasonable engineering decision and proceed.
+
+3. **Draft a concise feature issue**
+   - Include these sections when applicable:
+     - `## Summary`
+     - `## Current state`
+     - `## Proposed approach`
+     - `## Risks / constraints`
+     - `## Acceptance criteria`
+     - `## Related issues`
+   - Keep the issue specific enough for later implementation.
+   - If the feature was inspired by an external reference, describe what can be reused as a pattern and what should not be copied.
+
+4. **Respect no-execution requests**
+   - When the user says not to execute or not to implement, create only the issue or plan artifact requested.
+   - Explicitly state in the final response that no implementation work was performed.
+
+## Label and priority guidance
+
+Use `enhancement` for new feature capability issues.
+
+Apply exactly one priority label when possible:
+
+- `priority: high` — demo-readiness, reliability, safety, wake-word/audio blockers, or major user-facing issues.
+- `priority: medium` — meaningful product polish, maintainability, validation spikes, or useful feature work that is not blocking.
+- `priority: low` — deferred, conditional, exploratory, or non-blocking improvements.
+
+Preserve existing non-priority labels unless the request explicitly asks to reprioritize or relabel broader backlog items.
+
+## GitHub issue discipline
+
+- Before creating an issue, search for obvious duplicates by title and topic.
+- If a duplicate exists, update or reference the existing issue instead of creating a new one.
+- Link related current-repository issues using `#<number>`.
+- For repositories outside this one, use fully qualified references like `owner/repo#123`.
+- Keep issue titles action-oriented and concise.
+
+## Final response
+
+After creating or updating an issue, report:
+
+- issue number and title
+- issue URL when available
+- labels applied
+- whether any implementation work was intentionally not performed
+
+Keep the final response concise.

--- a/.github/skills/issue-implementation-loop/SKILL.md
+++ b/.github/skills/issue-implementation-loop/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: issue-implementation-loop
+description: Use when asked to run or define an agent loop that reviews GitHub issues, prioritizes by labels, implements ready work, verifies changes, and off-ramps inefficient loops.
+---
+
+# Issue Implementation Loop Skill
+
+Use this skill when the user asks an agent to review GitHub issues, select prioritized work, implement from issue success criteria, run verification, monitor loop performance, or create an off-ramp for work that is not efficient to automate.
+
+This workflow is **both agent and skill**:
+
+- The **agent** is the autonomous executor. It reads issues, chooses ready work, edits files, runs commands, opens PRs, and reports results.
+- This **skill** is the reusable policy and runbook. It defines selection rules, guardrails, verification, metrics, and off-ramp behavior.
+
+## Core rule
+
+Implement only issues that are ready, scoped, and verifiable.
+
+If an issue is vague, missing acceptance criteria, likely duplicated, blocked, or better suited to planning than execution, invoke the `feature-planning` skill instead of starting implementation.
+
+## Loop workflow
+
+1. **Review candidate issues**
+   - List open issues in the current repository.
+   - Exclude closed issues, issues assigned to someone else when ownership is unclear, and issues explicitly marked blocked or deferred.
+   - Prefer issues with clear `## Acceptance criteria`, `## Success criteria`, or an equivalent checklist.
+
+2. **Prioritize by labels**
+   - Work in this order:
+     1. `priority: high`
+     2. `priority: medium`
+     3. `priority: low`
+   - Within the same priority, prefer issues with the clearest acceptance criteria, smallest safe diff, and strongest verification path.
+   - Do not invent priority. If priority is missing and the issue is not urgent, use `feature-planning` to refine or label it before implementation.
+
+3. **Plan the implementation**
+   - Restate the acceptance criteria as an execution checklist.
+   - Identify affected files, tests, docs, and runtime constraints.
+   - Create a feature branch; never work directly on `main`.
+   - Keep the planned diff narrow and tied to the issue.
+
+4. **Implement iteratively**
+   - Make surgical code or documentation changes that satisfy the checklist.
+   - Preserve repository conventions and existing behavior unless the issue explicitly changes behavior.
+   - Do not silently skip invalid input, broad errors, failed checks, or unavailable dependencies.
+
+5. **Verify**
+   - Run the smallest targeted lint, test, build, or documentation check that covers the change.
+   - Add or update tests when behavior changes and a practical test path exists.
+   - If live services, hardware, or credentials are required and unavailable, state exactly which check could not run and why.
+
+6. **Report and hand off**
+   - Open or prepare a PR that links the issue.
+   - Include the completed success-criteria checklist.
+   - Include commands run and verification results.
+   - Note any unavailable checks, residual risks, or manual validation needed.
+
+## When to invoke `feature-planning`
+
+Invoke `feature-planning` instead of implementing when:
+
+- The issue is a new feature idea without acceptance criteria.
+- The issue may duplicate existing work.
+- The requested behavior has multiple reasonable designs and no clear choice.
+- The work requires reprioritization or label cleanup before execution.
+- The loop needs to create a human-review issue as an off-ramp.
+- A failed implementation attempt reveals that the issue needs a smaller or clearer scope.
+
+After `feature-planning` produces a ready issue with labels and acceptance criteria, the agent may return to this skill for implementation.
+
+## Off-ramp behavior
+
+Use an off-ramp when continuing the loop is less efficient or less safe than human review.
+
+First try to correct agent behavior when the failure is local and recoverable:
+
+- Fix an obviously wrong file target.
+- Narrow an overly broad diff.
+- Re-run a failed command only after addressing the cause.
+- Replace a speculative approach with a repository pattern found in existing code.
+
+Stop and create or comment a human-review issue when any of these occur:
+
+- Acceptance criteria are absent or contradictory.
+- The agent has made two unsuccessful implementation attempts for the same issue.
+- Verification cannot be run and there is no credible substitute.
+- The required change crosses unrelated subsystems.
+- The diff is growing beyond the issue scope.
+- Required credentials, services, hardware, or external access are unavailable.
+- The task is blocked on product, safety, privacy, or architectural decisions.
+
+The off-ramp record must include:
+
+- Issue number and title.
+- What was attempted.
+- Why the loop stopped.
+- Evidence from commands, errors, tests, or code review.
+- Recommended next human decision.
+
+## Loop performance monitoring
+
+Track these metrics for each loop run:
+
+- Issues reviewed.
+- Issue selected and priority label.
+- Started and completed timestamps.
+- Iteration count.
+- Files changed.
+- Commands run.
+- Verification status.
+- Failures and retries.
+- Off-ramp reason, when applicable.
+
+Use these metrics to decide whether to continue, narrow scope, switch to `feature-planning`, or stop for human review.
+
+## Verification guidance
+
+- Prefer targeted tests over full suites when they cover the changed behavior.
+- Escalate to broader tests only when targeted checks are insufficient or reveal shared-risk failures.
+- Documentation-only changes do not need code tests unless documentation tests exist.
+- Hardware-dependent Misty checks should be reported as manual validation when the robot or live services are unavailable.
+- Never report success for skipped or unavailable checks; report them as not run with the reason.
+
+## Final response
+
+Report:
+
+- Issue number and title.
+- Branch or PR, when available.
+- Success criteria completed.
+- Verification commands and results.
+- Any off-ramp, unavailable check, or manual follow-up.
+
+Keep the response concise and distinguish completed work from planned or blocked work.

--- a/.github/skills/log-updates/SKILL.md
+++ b/.github/skills/log-updates/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: log-updates
+description: Use when asked to create or update repository daily logs, record request history, summarize AI/Copilot usage, or capture AIC/AI Credits usage.
+---
+
+# Log Updates Skill
+
+Use this skill whenever the user asks to create, update, fix, or review repository logs, especially prompts mentioning logs, daily logs, request history, AI/Copilot usage, AIC, AI Credits, or usage metrics.
+
+## Required output file
+
+- Store logs in `logs\`.
+- Use one Markdown file per local calendar day when repository updates are made.
+- Name files with this exact pattern:
+
+```text
+logs\log_YYYY-MM-DD.md
+```
+
+- Use the current date from the user-provided `current_datetime` when available. Otherwise use the host date.
+- If the day's file already exists, update it in place. Do not create multiple logs for the same date.
+
+## Required sections
+
+Every daily log must include:
+
+1. `## Requests`
+   - List the user's requests for the day in chronological order.
+   - Include repo-affecting requests and related operational requests that influenced repo changes.
+
+2. `## AI/Copilot usage`
+   - Summarize the work Copilot performed.
+   - Include concrete tool or service usage when relevant, such as file edits, GitHub issue creation, GitHub CLI installation, web/doc lookups, and tests.
+
+3. `## AIC usage snapshot`
+   - Record quantitative AI Credits/AIC usage, not just a prose summary.
+   - Prefer current-session AIC usage if available from `/usage` or session history.
+   - If current-session usage is not available, record the best available scope, such as day-to-date usage from session history.
+   - Include:
+     - timestamp of the snapshot
+     - scope, for example `current session`, `day-to-date`, or `month-to-date`
+     - source, for example `/usage` or `session_store_sql events.usage_cost`
+     - total AICs
+     - model-level breakdown when available
+   - If AIC usage cannot be retrieved, explicitly write `AIC usage unavailable` and the reason. Do not omit this section.
+
+4. `## Repository updates`
+   - List files changed, issues/PRs created, labels created, or other persistent repo/GitHub changes.
+
+5. `## Logging convention`
+   - Keep or add the convention:
+
+```text
+logs\log_YYYY-MM-DD.md
+```
+
+## AIC usage guidance
+
+- Do not invent AIC numbers.
+- If a session store query tool is available, query usage data from events with non-null `usage_model` and sum `usage_cost`.
+- When querying by date, respect the timestamp timezone. If the user's `current_datetime` includes an offset, convert the local day window to the timestamp storage timezone if needed.
+- If only a day-to-date or month-to-date total is available, state that scope clearly.
+- If the user asks specifically for "at the time the log update was requested," capture the closest available snapshot and state the timestamp used.
+
+## Update discipline
+
+- Update the daily log whenever repository files are changed in response to the user.
+- If the user explicitly asks for a log update and no repo files changed, still update the daily log with the request and AIC snapshot.
+- Keep entries concise and factual.

--- a/README.md
+++ b/README.md
@@ -1,235 +1,305 @@
+# Misty II + Foundry Local Conversational Robot
 
-# Misty II + Foundry Local — Conversational AI Robot
+Turn a Misty II robot into a local conversational AI companion. Misty provides the physical robot presence - speakers, LED, display, movement, and tally-light behavior - while a Windows companion laptop runs wake-word detection, speech recording, STT, LLM inference, and TTS.
 
-> Turn a Misty II robot into a conversational AI assistant using fully local inference — no cloud, no API keys, no internet required after initial model downloads.
-
-## Project Scope
-
-This project integrates a **Misty II** social robot with **Microsoft Foundry Local** running on a Windows companion device to deliver a complete voice-interactive AI experience over local Wi-Fi. The system handles the full conversational loop — wake-word detection, speech-to-text, LLM reasoning, text-to-speech, and audio playback — all running locally on commodity hardware.
-
-**Primary use case:** Travel demos for developer advocacy — a portable, self-contained AI robot setup that works offline at conferences and events.
+The project is designed for portable developer demos: local Wi-Fi, no cloud inference, no API keys, and offline operation after the required tools and models are installed.
 
 ---
 
-## Architecture
+## Current Architecture
 
+This is a **two-device system**:
+
+| Device | Role |
+|---|---|
+| **Misty II** | Physical robot interface controlled over REST + WebSocket. Used for speakers, LED, display, movement, and recording/tally-light state. |
+| **Windows companion laptop** | Runs the controller, laptop-mic wake word listener, audio capture, orchestration service, and local model inference. |
+
+```text
+Laptop mic -> openWakeWord
+Laptop mic -> sounddevice WAV recording
+        |
+        v
+Misty Controller
+  - REST + WebSocket robot control
+  - State machine and re-arm logic
+  - LED/display/audio/movement behavior
+        |
+        v
+Orchestration Service (Flask)
+  - STT: faster-whisper
+  - LLM: Phi-3.5-mini via Foundry Local
+  - TTS: Kokoro-ONNX, fallback to pyttsx3
+        |
+        v
+Misty speakers + LED/display/movement
 ```
-┌──────────────────────────────┐         ┌──────────────────────────────────┐
-│        Misty II Robot        │         │     Windows Companion Device     │
-│                              │  Wi-Fi  │                                  │
-│  Speakers / LED / Display    │◄───────►│  Misty Controller (Python)      │
-│  Tally light (recording      │  REST + │    ├─ WebSocket event listener   │
-│    indicator only)           │  WS     │    ├─ REST API commands          │
-│                              │         │    └─ State machine (IDLE →      │
-│  Controlled entirely via     │         │        RECORDING → PROCESSING →  │
-│  REST API + WebSocket from   │         │        PLAYING → LISTENING →     │
-│  companion device            │         │        REARMING)                 │
-│                              │         │  Laptop Microphone (primary)     │
-│                              │         │    ├─ Wake word (openWakeWord)   │
-│                              │         │    └─ Speech recording (STT)     │
-│                              │         │  Orchestration Service (Flask)   │
-│                              │         │    ├─ STT  (faster-whisper)      │
-│                              │         │    ├─ LLM  (Phi-3.5-mini)  ───► Foundry Local
-│                              │         │    └─ TTS  (Kokoro / pyttsx3)   │
-│                              │         │                                  │
-│                              │         │  Foundry Local (LLM inference)   │
-└──────────────────────────────┘         └──────────────────────────────────┘
+
+The preferred mode is `USE_LAPTOP_WAKE_WORD=true`. In that mode, the laptop mic handles both wake word detection and STT recording. Misty's mic is not trusted for intelligence; it is used mainly to activate the robot tally light during recording and as a fallback path if laptop capture fails.
+
+---
+
+## Why the Laptop Does the AI Work
+
+Misty II's onboard hardware cannot reliably run modern inference workloads. The 2 GB RAM limit, final firmware, and fragile Snapdragon 410 ML/audio subsystem make on-robot AI impractical. The companion laptop avoids those constraints while preserving Misty's physical personality.
+
+Key lessons from testing:
+
+- Misty's on-robot JavaScript skill runtime is unreliable for this use case.
+- Misty's Snapdragon 410 keyphrase engine silently degrades after repeated audio cycles.
+- Misty's on-chip face detection/recognition pipeline is effectively non-functional.
+- Sensory-only reboot must not be used; full Core+Sensory reboot is the safe recovery path.
+- Laptop-side wake word, recording, STT, LLM, and TTS are the reliable path forward.
+
+See:
+
+- `docs\ADR-001-companion-device-over-onrobot-inference.md`
+- `docs\ADR-002-non-blocking-audio-pattern.md`
+- `docs\lessons-learned.md`
+- `docs\keyphrase-debugging.md`
+
+---
+
+## Conversational Flow
+
+1. Laptop mic detects the wake word with openWakeWord.
+2. Controller pauses wake-word listening to prevent self-wake.
+3. Misty plays a short greeting and turns green to cue speech.
+4. Laptop mic records the user's utterance; Misty's recording/tally light runs in parallel.
+5. Controller posts WAV audio to `/api/orchestrate`.
+6. Orchestration service runs STT -> LLM -> TTS.
+7. Controller downloads the generated WAV and uploads it to Misty for playback.
+8. Misty enters follow-up listening for continued conversation without requiring another wake word.
+9. Silence, movement completion, timeout, or max turn count ends the session and re-arms wake word detection.
+
+Misty's conversation state machine is:
+
+```text
+DISCONNECTED -> IDLE -> RECORDING -> PROCESSING -> PLAYING
+                      -> LISTENING -> PROCESSING -> PLAYING
+                      -> REARMING -> IDLE
 ```
 
-**Pipeline flow (laptop wake word mode):** Wake word (laptop mic + openWakeWord) → Record via laptop mic (Misty tally light only) → `POST /api/orchestrate` → STT → LLM → TTS → Upload audio to Misty → Playback → Re-arm wake word
+Movement adds a guarded `MOVING` state with battery, bump, hazard, and sensor freshness checks. Low battery adds `CHARGING`, and proactive recovery uses `REBOOTING`.
 
-> **Note:** Laptop wake word mode is opt-in via `USE_LAPTOP_WAKE_WORD=true`. Without it, the default path uses Misty's built-in "Hey Misty" keyphrase (subject to degradation — see #22).
+---
 
-> **Note:** We use the REST API + WebSocket approach (code runs on the laptop) instead of Misty's on-robot JavaScript SDK. The skill runtime proved unreliable — see [Implementation Guide](docs/IMPLEMENTATION_GUIDE.md) for details.
+## Model Stack
 
-### Why a Companion Device?
+| Role | Implementation | Notes |
+|---|---|---|
+| Wake word | openWakeWord | Runs on the laptop mic via `sounddevice`. |
+| STT | faster-whisper / whisper-tiny | Runs in-process in `orchestration_service.py`; not served by Foundry Local. |
+| Chat | Phi-3.5-mini | Served by Foundry Local using full model ID `Phi-3.5-mini-instruct-openvino-gpu:2`. |
+| TTS | Kokoro-ONNX | Primary offline neural TTS, in-process in the orchestration service. |
+| TTS fallback | pyttsx3 / Windows SAPI5 | Used when Kokoro is unavailable. |
 
-Misty II's onboard Snapdragon 820 + 410 (2 GB RAM) cannot run modern inference workloads — RAM is the bottleneck. A companion Windows laptop provides the compute while Misty handles audio I/O and interaction. See [ADR-001](docs/ADR-001-companion-device-over-onrobot-inference.md) for the full decision record.
+Foundry Local runs on a dynamic port. The orchestration service discovers it with `foundry service status` and strips the path to get the base URL. Override with `FOUNDRY_LOCAL_HOST` if needed.
 
 ---
 
 ## Repository Structure
 
+```text
+src\
+  windows-orchestration\
+    orchestration_service.py   # Flask STT -> LLM -> TTS service
+    misty_controller.py        # Misty REST/WebSocket controller and state machine
+    wake_word_listener.py      # Laptop mic openWakeWord + recording/VAD support
+    requirements.txt           # Python dependencies
+
+tests\
+  test_integration.py          # Integration and mocked service tests
+  autonomous_test_harness.py   # Long-running physical-system harness
+
+docs\
+  ADR-001-companion-device-over-onrobot-inference.md
+  ADR-002-non-blocking-audio-pattern.md
+  IMPLEMENTATION_GUIDE.md
+  FOUNDRY_LOCAL_SETUP.md
+  lessons-learned.md
+  keyphrase-debugging.md
+
+misty-skills-backup\
+  README.md
+  all_skills_metadata.json     # Metadata for removed on-robot skills
+
+plans\                         # Historical planning prompts and notes
 ```
-├── src/
-│   └── windows-orchestration/          # Companion device services
-│   │
-│   └── windows-orchestration/          # Python services on companion device
-│       ├── orchestration_service.py    #   STT → LLM → TTS pipeline (~500 LOC)
-│       ├── misty_controller.py         #   REST+WebSocket controller for Misty (~1300 LOC)
-│       ├── wake_word_listener.py       #   Laptop mic wake word + recording (~450 LOC)
-│       ├── requirements.txt            #   Dependencies (Flask, requests, websocket-client, faster-whisper)
-│       └── .env.example                #   Configuration template
-│
-├── misty-skills-backup/                # Backup of legacy JavaScript skills and deleted on-robot skills
-│   ├── README.md                       #   Why skills were removed, restoration notes
-│   └── all_skills_metadata.json        #   Metadata for all 11 skills (pre-cleanup)
-│
-├── tests/
-│   └── test_integration.py             # Integration test suite (health, connectivity, latency)
-│
-├── docs/
-│   ├── ADR-001-companion-device-over-onrobot-inference.md
-│   ├── FOUNDRY_LOCAL_SETUP.md
-│   ├── IMPLEMENTATION_GUIDE.md         # Full setup & troubleshooting guide
-│   └── IMPLEMENTATION_SUMMARY.md       # Build log and design decisions
-│
-└── plans/                              # Prompt plans for various deployment scenarios
-    ├── planConversationalRobot.prompt.md
-    ├── planRaspberryPi.prompt.md
-    ├── planTravelDemo-GHCP.prompt.md
-    └── planWindowsFoundry.prompt.md
-```
-
----
-
-## Key Design Decisions
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Inference location | Companion device (laptop) | Misty hardware too constrained; laptop already in travel kit |
-| Model server | Foundry Local | Local-only, OpenAI-compatible API, no cloud dependency |
-| Chat model | Phi-3.5-mini (3.8B) via **Foundry Local** | Fast, high-quality, fits CPU inference budget. Served by Foundry Local at `/v1/chat/completions`. |
-| STT model | Whisper-tiny via **faster-whisper** (in-process) | Foundry Local has no REST endpoint for Whisper — only C#/Rust SDK. We use [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (CTranslate2) which loads the model directly in the orchestration Python process. Model auto-downloaded from HuggingFace on first run (~75 MB). |
-| TTS model | Kokoro v1.0 ONNX (in-process), pyttsx3 fallback | [kokoro-onnx](https://github.com/thewh1teagle/kokoro-onnx) runs inference in the orchestration process via ONNX Runtime. Model files (`kokoro-v1.0.int8.onnx` 88 MB + `voices-v1.0.bin` 27 MB) stored locally. Falls back to pyttsx3 (Windows SAPI5) if Kokoro unavailable. |
-| Latency SLO | p50 < 3s, p95 < 6s (aspirational) | Currently ~23s end-to-end; see [#21](https://github.com/tammym-demos/misty_upgrade/issues/21) |
-| Network | Local Wi-Fi only | Privacy-first, offline-capable after initial model download |
-| Hardware | CPU-only (GPU optional) | Broad laptop compatibility |
-
-### Model Runtime Summary
-
-| Model | Purpose | Runtime | Origin |
-|-------|---------|---------|--------|
-| Phi-3.5-mini | Chat / LLM | **Foundry Local** (HTTP API) | Bundled with Foundry Local, managed via `foundry model` CLI |
-| Whisper-tiny | Speech-to-text | **faster-whisper** (in-process) | Auto-downloaded from [HuggingFace](https://huggingface.co/Systran/faster-whisper-tiny) on first run |
-| Kokoro v1.0 | Text-to-speech | **kokoro-onnx** (in-process) | Manually downloaded ONNX model files in `src/windows-orchestration/` |
-| pyttsx3 | TTS fallback | **pyttsx3** (in-process) | Windows built-in SAPI5 voices, no model files needed |
-
----
-
-## Configuration
-
-The orchestration service is configured via environment variables (copy `.env.example` to `.env`):
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `FOUNDRY_LOCAL_HOST` | Auto-discovered | Foundry Local base URL (overrides CLI discovery) |
-| `FOUNDRY_API_TIMEOUT` | `5.0` | Per-request timeout (seconds) for Foundry API calls |
-| `SERVICE_TIMEOUT` | `6.0` | Overall orchestration pipeline timeout (seconds) |
-| `KOKORO_VOICE` | `af_heart` | Kokoro TTS voice ID |
-| `SYSTEM_PROMPT` | *(see below)* | System prompt for the LLM; if unset, uses the built-in Misty persona prompt (sassy robot on a farm with Tammy, Burke, and dogs Percy & Granny) |
-| `MAX_USER_CHARS` | `400` | Maximum characters for a single transcribed user utterance. Longer inputs are truncated before LLM inference to reduce token count and latency. |
-| `MAX_CONTEXT_CHARS` | `3000` | Maximum total characters across all messages (system prompt + history) sent to the LLM. Oldest turns are removed first; the system prompt and latest user message are always preserved. Set to `0` to disable. |
-
-**Latency note:** `MAX_USER_CHARS` and `MAX_CONTEXT_CHARS` are the primary latency levers. Reducing these values lowers input token count and directly improves inference time, at the cost of context completeness.
 
 ---
 
 ## Quick Start
 
+Run these from the Windows companion device.
+
 ```powershell
-# 1. Start Foundry Local on the companion device
-pip install foundry-local
+# 1. Start Foundry Local
+python -m pip install foundry-local
 foundry
 
-# 2. Verify only the expected model is loaded (unload strays from prior testing)
+# 2. Verify the expected model is loaded
 foundry service ps
-# Expected: phi-3.5-mini only. If others appear: foundry model unload <alias>
 
-# 3. Install and run the orchestration service
+# 3. Install orchestration dependencies
 cd src\windows-orchestration
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
+
+# 4. Start the orchestration service
 python orchestration_service.py
+```
 
-# 4. Verify the service is healthy (port is auto-discovered from `foundry service status`)
-Invoke-RestMethod -Uri http://localhost:5000/api/health
+In a second terminal:
 
-# 5. Start the Misty controller (separate terminal)
-#    Set MISTY_IP and ORCHESTRATION_URL env vars if not using defaults
+```powershell
+cd src\windows-orchestration
+$env:USE_LAPTOP_WAKE_WORD = "true"
+$env:MISTY_IP = "10.0.0.44"
+$env:ORCHESTRATION_URL = "http://10.0.0.58:5000"
 python misty_controller.py
 ```
 
-The Misty controller connects to Misty via WebSocket and REST API — no skill deployment needed. Misty's LED turns green when ready. Say **"Hey, Misty!"** followed by your question. Misty says "What's up baby?" and her LED turns green — that's your cue to speak. After processing ("Let me think about that..."), she responds and keeps listening (cyan LED) for up to 90 seconds — just keep talking without saying the wake word again. Silence ends the conversation and re-arms the wake word.
+Health check:
 
-### Personality
+```powershell
+curl http://localhost:5000/api/health
+```
 
-Misty is a sassy little robot with big personality. She lives on a farm with Tammy, Burke (Tammy's husband), and two dogs — Percy and Granny. She loves sunshine and playing ball with the dogs. Her responses are witty, cheeky, and playful — like a fun friend who always has a comeback.
+Use the actual Misty IP and companion-device IP for your network. `ORCHESTRATION_URL` must be reachable from the controller process.
 
-### Audio Architecture
+---
 
-- **Wake word**: When `USE_LAPTOP_WAKE_WORD=true`, detected via laptop microphone using openWakeWord (not Misty's onboard mic). Otherwise, uses Misty's built-in "Hey Misty" keyphrase (default)
-- **Speech recording**: In laptop mode, captured from the laptop mic via sounddevice (16kHz, 16-bit mono)
-- **Misty's mic**: Not used for the primary STT path in laptop mode, but Misty's recorded audio is used as a fallback for STT if laptop capture is empty; it also drives Misty's recording/tally-light behavior during capture
-- **TTS phrases**: "What's up baby?" (greeting) and "Let me think about that." (thinking) are generated via Kokoro TTS at startup and uploaded to Misty
+## Configuration
 
-### Expressive Behavior
+Common environment variables:
 
-During conversations, Misty uses head movement and face animations to signal her state:
-- **Listening**: Green LED, tally light on — "speak now"
-- **Processing**: Blue LED, tilts head to the side, says "Let me think about that"
-- **Speaking**: Purple LED, faces forward, animated expression
-- **Follow-up**: Cyan LED, slight head tilt, warm expectant face
-- Head recenters when re-arming for the next wake word
+| Variable | Default | Purpose |
+|---|---:|---|
+| `USE_LAPTOP_WAKE_WORD` | false | Set to `true` for the recommended laptop-mic wake word and recording path. |
+| `MISTY_IP` | `10.0.0.44` | Misty robot IP address. |
+| `ORCHESTRATION_URL` | `http://10.0.0.58:5000` | URL for the Flask orchestration service. |
+| `FOUNDRY_LOCAL_HOST` | auto-discovered | Optional Foundry Local base URL override. |
+| `FOUNDRY_API_TIMEOUT` | `10.0` | Per-request timeout for Foundry API calls. |
+| `SERVICE_TIMEOUT` | `15.0` | Overall service timeout setting. |
+| `KOKORO_VOICE` | `af_sky` | Kokoro voice ID. |
+| `KOKORO_SPEED` | `1.2` | Kokoro speech speed. |
+| `MAX_USER_CHARS` | `400` | Per-utterance prompt character cap. |
+| `MAX_CONTEXT_CHARS` | `5000` | Total LLM context character budget. |
+| `FOLLOWUP_TIMEOUT_S` | `90` | Follow-up conversation window. |
+| `FOLLOWUP_MAX_TURNS` | `12` | Max follow-up recording cycles in one session. |
+| `PROACTIVE_REBOOT_AFTER_CYCLES` | `5` | Full reboot after this many successful conversation cycles. |
+| `PROACTIVE_REBOOT_AFTER_RECORDINGS` | `15` | Full reboot after this many recording cycles. |
 
-### On-Robot Skills — Cleaned Up
+Copy `src\windows-orchestration\.env.example` to `.env` if you want persistent local settings for the orchestration service.
 
-All auto-starting on-robot skills have been **deleted** from Misty to prevent microphone interference. The `faceDetection` skill previously auto-started on boot, grabbed the mic, and caused silent keyphrase failures. The controller also cancels all running skills on connect as a safety net.
+---
 
-Skill metadata was backed up to `misty-skills-backup/` before deletion.
+## Orchestration API
 
-### Keyphrase Watchdog
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/health` | Service and Foundry health. |
+| `GET` | `/api/diagnostics` | Current config, model aliases, TTS state, cache stats, latency budget. |
+| `POST` | `/api/orchestrate` | Main multipart WAV pipeline: STT -> LLM or movement intent -> TTS. |
+| `GET` | `/api/audio/<filename>` | Retrieve generated WAV response audio. |
+| `POST` | `/api/tts` | Generate raw WAV bytes for controller use. |
+| `POST` | `/api/fallback-tts` | Generate fallback TTS and return an audio URI. |
 
-Misty's sensory services (Snapdragon 410) can silently stop firing wake word events — a known firmware bug with no programmatic detection. The controller includes an automatic watchdog that detects this and self-recovers:
+`/api/orchestrate` returns normal conversational responses or movement responses. Movement commands short-circuit the LLM and return a quick TTS acknowledgment plus a bounded movement command for the controller to execute safely.
 
-1. **Soft reset** (90s): 🟡 Yellow LED flash → cancel skills → restart keyphrase
-2. **Second soft reset** (+60s): 🟡 Darker yellow → repeat
-3. **Full reboot** (+60s): 🔴 Red LED → full system reboot (Core+Sensory)
+---
 
-The watchdog only activates in IDLE state. Configure timeouts via `WATCHDOG_IDLE_TIMEOUT_S` and `WATCHDOG_ESCALATE_TIMEOUT_S` environment variables.
+## Controller Behavior
 
-### Startup Verification
+`misty_controller.py` is responsible for:
 
-All three services must be running. Start them in order — each depends on the previous:
+- WebSocket subscriptions for wake word, battery, hazard, ToF, bump, and optional face events.
+- REST calls for LED, display, recording, audio upload/playback, movement, halt, and reboot.
+- Laptop wake word listener lifecycle.
+- Conversation recording, response playback, follow-up listening, and re-arm.
+- Battery-aware charging mode and movement cutoffs.
+- Movement safety: bounded drive commands, hazard/bump preemption, sensor freshness checks, and emergency halt.
+- Proactive full reboot to avoid Misty's audio/keyphrase degradation.
+- A small controller test API on port `5001`.
 
-| # | Service | Verify | Notes |
-|---|---------|--------|-------|
-| 1 | **Foundry Local** | `foundry service status` / `foundry service ps` | Dynamic port; auto-discovered by orchestration service |
-| 2 | **Orchestration service** | `curl http://localhost:5000/api/health` | Reports Foundry and TTS status |
-| 3 | **Misty controller** | Misty LED turns green | Connects via WebSocket + REST |
+Controller test API:
 
-**Model management:** Only `phi-3.5-mini` should be loaded in Foundry (`foundry service ps`). Whisper-tiny STT runs in-process via faster-whisper (not through Foundry). Kokoro TTS runs in-process in the orchestration service — neither STT nor TTS are Foundry models and won't appear in `foundry model list`.
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/status` | Current state, turn ID, battery, and reboot counters. |
+| `GET` | `/api/mic/health` | Misty mic health check. |
+| `POST` | `/api/test/trigger` | Start a conversation turn while IDLE. |
+| `POST` | `/api/move` | Teleop movement command with strict bounds. |
+| `POST` | `/api/sensors` | Hazard and sensor telemetry snapshot. |
+
+---
+
+## Testing
+
+Most tests require live services or physical hardware.
+
+```powershell
+cd tests
+python -m pytest test_integration.py -v
+```
+
+Targeted examples:
+
+```powershell
+python -m pytest test_integration.py::TestPromptLimiting -v
+python -m pytest test_integration.py::TestWindowsOrchestration -v
+python -m pytest test_integration.py::TestFoundryLocalIntegration -v
+```
+
+Test prerequisites:
+
+| Test class | Requires |
+|---|---|
+| `TestPromptLimiting` | No live services; HTTP calls are mocked. |
+| `TestWindowsOrchestration` | Orchestration service running. |
+| `TestFoundryLocalIntegration` | Foundry Local running or `FOUNDRY_LOCAL_HOST` set. |
+| `TestMistyConnectivity` | Misty reachable on the network. |
+| `TestLatencySLO` | Orchestration service running. |
+| `TestVerificationChecklist` | Mixed; several items are manual/live-system checks. |
+
+For unattended physical testing, see `tests\autonomous_test_harness.py`.
+
+---
+
+## Operating Notes
+
+- Start services in order: Foundry Local, orchestration service, Misty controller.
+- Only the Phi-3.5-mini chat model should be loaded in Foundry Local for normal operation.
+- Whisper-tiny and Kokoro are not Foundry REST models; they run in the Python orchestration process.
+- Do not push changes directly to `main`; use a feature branch and PR.
+- Do not rely on Misty's on-robot skills for the current pipeline. Auto-starting skills were removed because they interfered with audio.
+- Do not use sensory-only reboot. Use full reboot with both `Core` and `SensoryServices` set to `true`.
+- On shutdown, stop keyphrase, stop recording, cancel skills, and turn the LED off so the tally light and audio resources are released.
+
+---
+
+## Known Issues and Mitigations
+
+| Issue | Status |
+|---|---|
+| Misty keyphrase silently fails after repeated cycles | Mitigated by laptop wake word and proactive full reboot. |
+| Misty's on-chip face detection is dead | Avoided; future/optional recognition should be laptop-side. |
+| Sensory-only reboot breaks the mic until physical power cycle | Avoided; code uses full Core+Sensory reboot. |
+| Misty mic can degrade after extended recording cycles | Mitigated by laptop STT recording and proactive reboot by recording count. |
+| TTS dominates response latency | Mitigated with Kokoro speed tuning and in-memory TTS cache. |
+| STT accuracy is limited by whisper-tiny and mic conditions | Beam search and laptop mic help, but noisy environments still need tuning. |
 
 ---
 
 ## Documentation
 
-- **[Implementation Guide](docs/IMPLEMENTATION_GUIDE.md)** — Full setup, deployment phases, and troubleshooting
-- **[Implementation Summary](docs/IMPLEMENTATION_SUMMARY.md)** — What was built, code stats, and known limitations
-- **[ADR-001](docs/ADR-001-companion-device-over-onrobot-inference.md)** — Why companion device over on-robot or backpack inference
-- **[Foundry Local Setup](docs/FOUNDRY_LOCAL_SETUP.md)** — Model server installation and configuration
-
----
-
-## Status
-
-**v1.0 — REST+WebSocket Architecture, Orchestration Service Complete**
-
-The project has moved from on-robot JavaScript skills to a laptop-driven REST+WebSocket architecture. The Misty controller and orchestration service run on the companion device. Wake word detection, recording, and audio playback are all handled via Misty's REST API.
-
-See [IMPLEMENTATION_SUMMARY.md](docs/IMPLEMENTATION_SUMMARY.md) for the full build log, known limitations, and future enhancement roadmap.
-
-### Known Issues
-
-| Issue | Summary |
-|-------|---------|
-| [#44](https://github.com/tammym-demos/misty_upgrade/issues/44) | Laptop mic for wake word + STT recording — implemented, Misty mic for tally light only |
-| [#28](https://github.com/tammym-demos/misty_upgrade/issues/28) | Keyphrase re-arm: sensory reboot abandoned (breaks mic) — soft re-arm only |
-| [#27](https://github.com/tammym-demos/misty_upgrade/issues/27) | STT accuracy: beam_size=5, whisper-tiny still garbles some follow-ups |
-| [#22](https://github.com/tammym-demos/misty_upgrade/issues/22) | Keyphrase silently fails — mitigated by laptop wake word + proactive reboot |
-| [#21](https://github.com/tammym-demos/misty_upgrade/issues/21) | End-to-end latency ~6-7s (target <3s) — TTS is dominant |
-| [#24](https://github.com/tammym-demos/misty_upgrade/issues/24) | LLM ignores brevity — max_tokens=60, post-LLM truncation to 35 words |
-| [#20](https://github.com/tammym-demos/misty_upgrade/issues/20) | VAD-controlled dynamic recording via laptop mic (6s minimum) |
-| [#19](https://github.com/tammym-demos/misty_upgrade/issues/19) | Conversation history capped at 8 messages (4 turns) |
+- `docs\IMPLEMENTATION_GUIDE.md` - Full setup and troubleshooting.
+- `docs\FOUNDRY_LOCAL_SETUP.md` - Foundry Local setup and model management.
+- `docs\IMPLEMENTATION_SUMMARY.md` - Historical build summary.
+- `docs\ADR-001-companion-device-over-onrobot-inference.md` - Companion-device decision.
+- `docs\ADR-002-non-blocking-audio-pattern.md` - Laptop-mic callback/queue/worker pattern.
+- `docs\lessons-learned.md` - Operational findings from real hardware testing.
+- `docs\keyphrase-debugging.md` - Keyphrase failure history and recovery notes.
 
 ---
 
@@ -237,10 +307,6 @@ See [IMPLEMENTATION_SUMMARY.md](docs/IMPLEMENTATION_SUMMARY.md) for the full bui
 
 This project is licensed under the [MIT License](LICENSE).
 
----
-
 ## Disclaimers
 
-- **Trademark:** Misty is a trademark of its respective owner.
-- **Affiliation:** This project is not affiliated with or endorsed by Misty Robotics or its successor entities.
-- **SDK:** This project requires the Misty SDK; users must comply with the Misty SDK license and terms of use.
+Misty is a trademark of its respective owner. This project is not affiliated with or endorsed by Misty Robotics, Furhat Robotics, Microsoft, or any successor entities. Users are responsible for complying with applicable SDK, model, and dependency licenses.

--- a/docs/prompt-efficiency-evaluation-2026-06-27.md
+++ b/docs/prompt-efficiency-evaluation-2026-06-27.md
@@ -1,0 +1,58 @@
+# Prompt Efficiency Evaluation - 2026-06-27
+
+Source: `logs\log_2026-06-27.md`
+
+## Overall assessment
+
+The request sequence was moderately efficient: it moved from repository understanding, to documentation alignment, to issue creation, to operational logging. That ordering reduced the risk of making uninformed edits because the codebase review came before README and instruction changes.
+
+The main inefficiency was fragmentation. Several related requests were issued as separate follow-ups, which increased context switching and caused one corrective loop when the daily log needed an AIC snapshot after it had already been created. A more batched initial prompt would likely have reduced total turns, tool calls, and rework.
+
+**Prompt efficiency score: 7.5 / 10**
+
+## Request sequence evaluation
+
+| # | Request | Efficiency impact | Evaluation |
+|---:|---|---|---|
+| 1 | Review the codebase and understand its intent. | High positive | Strong starting point; established context before changes. |
+| 2 | Determine whether the README reflects the codebase intent. | Positive | Natural follow-up to the codebase review. |
+| 3 | Refresh the README so it matches the current architecture and implementation. | Positive | Efficient once intent and drift were identified. |
+| 4 | Review whether the repository instructions are adequate. | Positive | Related to documentation quality, but could have been batched with README review. |
+| 5 | Identify efficiency improvements that could be gained. | Positive | Good transition from documentation review to backlog discovery. |
+| 6 | Create GitHub issues for the identified efficiency improvements and prioritize them with priority labels. | Positive | Turned findings into actionable work items. Efficient because the improvement list already existed. |
+| 7 | Install GitHub CLI and continue creating the issues. | Neutral | Necessary once the missing tool was discovered, but the prompt could have allowed any available GitHub tooling up front. |
+| 8 | Add this markdown log under `logs\`, including requests and AI/Copilot usage. | Positive | Good auditability request, but missing AIC requirements caused later rework. |
+| 9 | Explain yesterday's AIC usage. | Neutral | Useful operational query, but separate from the log request. |
+| 10 | Explain month-to-date AIC usage. | Neutral | Related to #9 and could have been requested together. |
+| 11 | Create a reusable skill for future log updates because the original log did not include an AIC snapshot. | High positive | Efficient long-term improvement; converts a discovered gap into reusable process automation. |
+
+## Efficiency strengths
+
+- The sequence followed a sensible discovery-to-action path: inspect, evaluate, update, create issues, then document.
+- The GitHub issue creation prompt was efficient because it reused findings already generated earlier in the session.
+- The final skill request improved future efficiency by encoding the desired daily log structure and AIC snapshot requirement.
+
+## Efficiency gaps
+
+- Documentation-related requests were split across README review, README refresh, repository instruction review, and efficiency review. These could have been bundled.
+- AIC usage requirements were introduced after the log was created, which caused avoidable rework.
+- GitHub issue creation depended on tooling availability discovered midstream; a tool-flexible prompt would have reduced interruption.
+- Usage questions were asked separately even though yesterday and month-to-date AIC usage shared the same data source and analysis pattern.
+
+## More efficient prompt pattern
+
+A more efficient initial prompt could have been:
+
+```text
+Review the repository intent, README, and repo instructions. Update the README if it is stale, identify efficiency improvements, create prioritized GitHub issues for those improvements using available GitHub tooling, and create today's daily log in logs\log_YYYY-MM-DD.md. The log must include request history, AI/Copilot usage, an AIC usage snapshot with model breakdown, repository updates, and the logging convention.
+```
+
+This would preserve the same outcomes while reducing follow-up prompts and preventing the AIC snapshot rework.
+
+## Recommendations
+
+1. Batch tightly related documentation and repository review requests into one prompt.
+2. State required output sections and quantitative reporting requirements before asking for file creation.
+3. Prefer outcome-based tooling instructions, such as "use available GitHub tooling," over naming a specific tool unless that tool is required.
+4. Ask related usage-analysis questions together when they share the same data source.
+5. Keep the reusable log skill active for future sessions so AIC snapshots are captured during initial log creation rather than as a correction.

--- a/lessonsLearned/esp32-companion-ai-lessons.md
+++ b/lessonsLearned/esp32-companion-ai-lessons.md
@@ -1,0 +1,94 @@
+# ESP32 Companion AI Lessons
+
+## Summary
+
+The ESP32 examples are useful inspiration for adding low-cost physical interactivity to Misty, but they do not change the core architecture decision for this project: Misty's AI workload should stay on the Windows companion device.
+
+The key lesson is that an ESP32 can be a strong **peripheral controller**, not a realistic replacement for the companion laptop running STT, LLM, and TTS.
+
+## Video and implementation findings
+
+### BMO local AI agent
+
+The BMO reference uses a Raspberry Pi as the main computer, not an ESP32. It runs a local pipeline with OpenWakeWord, Whisper, Ollama/Gemma, Moondream, Piper, and a direct LCD GUI for reactive face animations.
+
+Applicable ideas:
+
+- State-driven face animations with folders like `idle`, `listening`, `thinking`, and `speaking`.
+- Randomized or looped expression frames so the robot feels alive.
+- Startup/warmup behavior that preloads models and gives feedback while waiting.
+
+Not directly applicable:
+
+- Misty cannot run a desktop GUI on her face display.
+- We should not copy BMO/Adventure Time assets, voice, or identity.
+- The Raspberry Pi compute profile is much closer to a backpack computer than to an ESP32.
+
+### Pixel / OmniBot ESP32 assistant
+
+The Pixel video and OmniBot repo are the better ESP32 reference. Pixel uses a Seeed XIAO ESP32S3 Sense with camera, mic, round display, touch/gesture UI, and Wi-Fi.
+
+Important distinction: Pixel does **not** run the LLM locally on the ESP32. The ESP32 streams mic/camera/display events to an OmniBot hub over Wi-Fi, and the hub connects to Gemini. The transcript explicitly rejects local LLM inference after choosing ESP32 over Raspberry Pi.
+
+Applicable ideas:
+
+- ESP32 as a cheap physical interface for mic, camera, buttons, touch, LEDs, and small display.
+- Hub-managed persona files such as `SOUL.md`, `IDENTITY.md`, `USER.md`, and `MEMORY.md`.
+- Daily logs plus periodic memory consolidation for longer-term personality continuity.
+- Face/emotion tools that let the model request expressions.
+
+Not directly applicable:
+
+- Gemini Live / cloud API use conflicts with this repo's local/offline demo goal.
+- ESP32 cannot replace the Windows companion device for Phi/Whisper/Kokoro-class inference.
+- Pixel is a purpose-built robot shell; Misty already has motors, sensors, speakers, display, and REST/WebSocket APIs.
+
+## Misty + ESP32 feasibility
+
+Misty can be wired to an ESP32 through the backpack area. Misty's hardware extensibility docs expose UART serial and USB/power:
+
+- UART serial supports external microcontrollers.
+- Logic level is 3.3V.
+- Serial settings for the Arduino backpack are 9600 baud, 8-N-1.
+- Misty can provide 3.3V power up to 1A.
+- USB can provide up to 500mA power.
+- Misty can send data to attached hardware via `POST /api/serial`.
+- Incoming UART data appears as `SerialMessage` events.
+
+This makes ESP32 feasible for a Misty backpack peripheral, especially for:
+
+- hardware buttons or touch wake
+- extra LEDs or expressive accessories
+- environmental sensors
+- small auxiliary display
+- physical controls for demos
+- a dedicated sensor/microphone/camera module that reports events to the companion controller
+
+## Recommended architecture
+
+Use ESP32 as an optional **Misty backpack peripheral**, not an AI host.
+
+Recommended flow:
+
+```text
+ESP32 backpack peripheral
+  -> UART / Wi-Fi events
+  -> Windows companion controller
+  -> Foundry Local / faster-whisper / Kokoro
+  -> Misty REST + WebSocket behavior
+```
+
+This keeps the AI stack local and reliable while allowing cheaper, swappable hardware experiments.
+
+## Candidate future issues
+
+- Add ESP32 backpack feasibility spike for Misty UART communication.
+- Add a physical touch/button wake accessory.
+- Add external LEDs or expressive accessory control synchronized with Misty's state machine.
+- Explore markdown persona/memory files inspired by OmniBot, but implemented in the orchestration service rather than on ESP32.
+
+## Decision guidance
+
+Choose ESP32 when the task is physical I/O, low-power sensing, buttons, LEDs, or simple display behavior.
+
+Choose Raspberry Pi, Jetson, or the existing Windows companion device when the task involves local LLM inference, STT, TTS, vision models, or rich GUI rendering.

--- a/logs/log_2026-06-27.md
+++ b/logs/log_2026-06-27.md
@@ -14,6 +14,7 @@
 - Created GitHub issue #75 and PR #76, which merged the initial skill files into `Phi-3.5-mini`.
 - Verified that `main` did not contain `.github\skills\` and that no `.github\agents\` profile had been added.
 - Created a clean branch from `main` and added a repository custom agent profile plus the required project skill files.
+- Opened PR #77 against `main` so the agent and skills are visible from the default branch after merge.
 - Queried recorded AIC usage from session history for this log update.
 
 ## AIC usage snapshot
@@ -43,6 +44,7 @@ Additional usage lookup:
 - Added `.github\skills\feature-planning\SKILL.md`.
 - Added `.github\skills\issue-implementation-loop\SKILL.md`.
 - Added `logs\log_2026-06-27.md`.
+- Created PR #77, "Add issue implementation loop agent and skills".
 
 ## Logging convention
 

--- a/logs/log_2026-06-27.md
+++ b/logs/log_2026-06-27.md
@@ -1,0 +1,76 @@
+# Log - 2026-06-27
+
+## Requests
+
+1. Review the codebase and understand its intent.
+2. Determine whether the README reflects the codebase intent.
+3. Refresh the README so it matches the current architecture and implementation.
+4. Review whether the repository instructions are adequate.
+5. Identify efficiency improvements that could be gained.
+6. Create GitHub issues for the identified efficiency improvements and prioritize them with priority labels.
+7. Install GitHub CLI and continue creating the issues.
+8. Add this markdown log under `logs\`, including requests and AI/Copilot usage.
+9. Explain yesterday's AIC usage.
+10. Explain month-to-date AIC usage.
+11. Create a reusable skill for future log updates because the original log did not include an AIC snapshot.
+12. Read the day's request sequence, evaluate prompt efficiency, and write the results to a new markdown file under `docs\`.
+
+## AI/Copilot usage
+
+- Reviewed repository structure, source files, tests, documentation, and existing Copilot instructions.
+- Rewrote `README.md` to emphasize the current laptop-first Misty II + Foundry Local architecture.
+- Identified efficiency opportunities around laptop-mode re-arm, Misty recording churn, TTS prewarming, test organization, direct audio return, shared configuration defaults, and documentation duplication.
+- Installed GitHub CLI with `winget`, authenticated with GitHub device login, and verified admin access to `tammym-demos/misty_upgrade`.
+- Created priority labels:
+  - `priority: high`
+  - `priority: medium`
+  - `priority: low`
+- Created prioritized GitHub issues:
+  - #65 - Optimize laptop wake-word re-arm path by keeping WebSocket alive (`priority: high`)
+  - #66 - Make Misty recording/tally-light fallback configurable in laptop mode (`priority: high`)
+  - #67 - Prewarm greeting and thinking TTS phrases at orchestration startup (`priority: medium`)
+  - #68 - Split fast mocked tests from live service and hardware integration tests (`priority: medium`)
+  - #69 - Optionally return response WAV bytes directly from `/api/orchestrate` (`priority: medium`)
+  - #70 - Centralize shared configuration defaults to prevent drift (`priority: low`)
+  - #71 - Reduce documentation duplication by defining a canonical architecture reference (`priority: low`)
+- Queried recorded AIC usage from session history.
+- Added the project skill `.github\skills\log-updates\SKILL.md` to standardize daily log updates and require AIC snapshots.
+- Analyzed the request sequence for prompt efficiency and documented the findings in `docs\prompt-efficiency-evaluation-2026-06-27.md`.
+
+## AIC usage snapshot
+
+Snapshot time: 2026-06-27 10:06 -04:00
+
+Scope: day-to-date recorded usage for 2026-06-27. Current-session usage was not available by session ID in the session store, so this uses the best available recorded daily totals.
+
+Source: `session_store_sql` over `events.usage_cost`.
+
+| Model | AICs | Usage events |
+|---|---:|---:|
+| `gpt-5.5` | 75.00 | 10 |
+| `gpt-5.4-mini` | 7.92 | 24 |
+| `gpt-5.3-codex` | 2.00 | 2 |
+| **Total** | **84.92** | **36** |
+
+Additional usage lookups:
+
+| Scope | Total AICs |
+|---|---:|
+| 2026-06-26 | 802.26 |
+| June 2026 month-to-date | 5,211.97 |
+
+## Repository updates
+
+- Updated `README.md`.
+- Added `logs\log_2026-06-27.md`.
+- Added `.github\skills\log-updates\SKILL.md`.
+- Added `docs\prompt-efficiency-evaluation-2026-06-27.md`.
+- Updated `logs\log_2026-06-27.md`.
+
+## Logging convention
+
+Create one markdown log per day that repo updates are made, using:
+
+```text
+logs\log_YYYY-MM-DD.md
+```

--- a/logs/log_2026-06-27.md
+++ b/logs/log_2026-06-27.md
@@ -14,6 +14,9 @@
 10. Explain month-to-date AIC usage.
 11. Create a reusable skill for future log updates because the original log did not include an AIC snapshot.
 12. Read the day's request sequence, evaluate prompt efficiency, and write the results to a new markdown file under `docs\`.
+13. Identify whether an issue-reviewing automation loop should be an agent, a skill, or both.
+14. Decide whether the loop should use the `feature-planning` skill during implementation.
+15. Generate a GitHub issue for the skill-backed agent implementation loop, then execute it.
 
 ## AI/Copilot usage
 
@@ -36,10 +39,13 @@
 - Queried recorded AIC usage from session history.
 - Added the project skill `.github\skills\log-updates\SKILL.md` to standardize daily log updates and require AIC snapshots.
 - Analyzed the request sequence for prompt efficiency and documented the findings in `docs\prompt-efficiency-evaluation-2026-06-27.md`.
+- Used the `feature-planning` skill to shape issue #75 for a skill-backed issue implementation loop.
+- Created GitHub issue #75, created branch `issue-75-implementation-loop-skill`, and added `.github\skills\issue-implementation-loop\SKILL.md` with the existing feature-planning skill included as its planning dependency.
+- Used the `log-updates` skill to update this daily log after repository changes.
 
 ## AIC usage snapshot
 
-Snapshot time: 2026-06-27 10:06 -04:00
+Snapshot time: 2026-06-27 11:12 -04:00
 
 Scope: day-to-date recorded usage for 2026-06-27. Current-session usage was not available by session ID in the session store, so this uses the best available recorded daily totals.
 
@@ -47,17 +53,17 @@ Source: `session_store_sql` over `events.usage_cost`.
 
 | Model | AICs | Usage events |
 |---|---:|---:|
-| `gpt-5.5` | 75.00 | 10 |
+| `gpt-5.5` | 1,320.00 | 176 |
 | `gpt-5.4-mini` | 7.92 | 24 |
 | `gpt-5.3-codex` | 2.00 | 2 |
-| **Total** | **84.92** | **36** |
+| **Total** | **1,329.92** | **202** |
 
 Additional usage lookups:
 
 | Scope | Total AICs |
 |---|---:|
 | 2026-06-26 | 802.26 |
-| June 2026 month-to-date | 5,211.97 |
+| June 2026 month-to-date | 6,456.97 |
 
 ## Repository updates
 
@@ -66,6 +72,10 @@ Additional usage lookups:
 - Added `.github\skills\log-updates\SKILL.md`.
 - Added `docs\prompt-efficiency-evaluation-2026-06-27.md`.
 - Updated `logs\log_2026-06-27.md`.
+- Created GitHub issue #75, "Add skill-backed agent workflow for issue implementation loops".
+- Added `.github\skills\feature-planning\SKILL.md`.
+- Added `.github\skills\issue-implementation-loop\SKILL.md`.
+- Updated `logs\log_2026-06-27.md` again.
 
 ## Logging convention
 

--- a/logs/log_2026-06-27.md
+++ b/logs/log_2026-06-27.md
@@ -1,0 +1,53 @@
+# Log - 2026-06-27
+
+## Requests
+
+1. Identify whether an issue-reviewing automation loop should be an agent, a skill, or both.
+2. Decide whether the loop should use the `feature-planning` skill during implementation.
+3. Generate a GitHub issue for the skill-backed agent implementation loop, then execute it.
+4. Check whether issue #75 was completed.
+5. Correct the implementation because the agent profile and skill files were not visible on `main`.
+
+## AI/Copilot usage
+
+- Used the `feature-planning` skill to shape issue #75 for a skill-backed issue implementation loop.
+- Created GitHub issue #75 and PR #76, which merged the initial skill files into `Phi-3.5-mini`.
+- Verified that `main` did not contain `.github\skills\` and that no `.github\agents\` profile had been added.
+- Created a clean branch from `main` and added a repository custom agent profile plus the required project skill files.
+- Queried recorded AIC usage from session history for this log update.
+
+## AIC usage snapshot
+
+Snapshot time: 2026-06-27 11:21 -04:00
+
+Scope: day-to-date recorded usage for 2026-06-27. Current-session usage was not available by session ID in the session store, so this uses the best available recorded daily totals.
+
+Source: `session_store_sql` over `events.usage_cost`.
+
+| Model | AICs | Usage events |
+|---|---:|---:|
+| `gpt-5.5` | 1,425.00 | 190 |
+| `gpt-5.4-mini` | 7.92 | 24 |
+| `gpt-5.3-codex` | 2.00 | 2 |
+| **Total** | **1,434.92** | **216** |
+
+Additional usage lookup:
+
+| Scope | Total AICs |
+|---|---:|
+| June 2026 month-to-date | 6,561.97 |
+
+## Repository updates
+
+- Added `.github\agents\issue-implementation-loop.md`.
+- Added `.github\skills\feature-planning\SKILL.md`.
+- Added `.github\skills\issue-implementation-loop\SKILL.md`.
+- Added `logs\log_2026-06-27.md`.
+
+## Logging convention
+
+Create one markdown log per day that repo updates are made, using:
+
+```text
+logs\log_YYYY-MM-DD.md
+```


### PR DESCRIPTION
## Summary

- add a repository custom agent profile at `.github/agents/issue-implementation-loop.md`
- add the project skills the agent depends on under `.github/skills/`
- add the daily repository log for this correction

## Why

The first implementation landed only on the `Phi-3.5-mini` branch and added skill files, but not a custom agent profile. This PR targets `main` directly and includes both the agent and skills so they are visible from the default branch after merge.

## Success criteria

- [x] Repository custom agent exists for the issue implementation loop.
- [x] Repository skill exists for the issue implementation loop.
- [x] The skill states that the executor is an agent and the reusable policy/runbook is a skill.
- [x] The skill explains when to invoke `feature-planning` instead of implementing immediately.
- [x] The skill defines label-based priority selection.
- [x] The skill requires implementation to be driven by issue success criteria.
- [x] The skill defines off-ramp behavior that either corrects agent behavior or logs/comments an issue for human review.
- [x] The skill requires loop performance monitoring.
- [x] The skill requires appropriate lint/test/build verification and clear reporting of unavailable checks.

## Verification

- `git diff --check`

Closes #75
