### PR TITLE
Implement laptop wake-word fast rearm

### DIFF
--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -2366,11 +2366,11 @@ class MistyController:
             logger.info("Fast re-arm: audio cleanup (2s) — laptop wake word mode")
             time.sleep(2.0)
             if self._ws_is_connected():
-                self._wake_word_listener.resume()
                 self.set_led(0, 255, 0)
                 self.display_image("e_DefaultContent.jpg")
                 self.last_activity_time = time.time()
                 self.set_state(State.IDLE)
+                self._wake_word_listener.resume()
                 logger.info("Fast re-arm complete — laptop wake word resumed; WebSocket kept open")
                 return
             logger.warning(

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -1791,7 +1791,8 @@ class MistyController:
     def _ws_is_connected(self) -> bool:
         """Return True when the current Misty WebSocket still appears usable."""
         sock = getattr(self.ws, "sock", None)
-        return bool(self.ws and sock and getattr(sock, "connected", False))
+        thread_alive = bool(self.ws_thread and self.ws_thread.is_alive())
+        return bool(self.ws and sock and getattr(sock, "connected", False) and thread_alive)
 
     # --- Laptop wake word listener (issue #44) ---
 

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -1788,6 +1788,11 @@ class MistyController:
         )
         self.ws_thread.start()
 
+    def _ws_is_connected(self) -> bool:
+        """Return True when the current Misty WebSocket still appears usable."""
+        sock = getattr(self.ws, "sock", None)
+        return bool(self.ws and sock and getattr(sock, "connected", False))
+
     # --- Laptop wake word listener (issue #44) ---
 
     def _start_laptop_wake_word(self):
@@ -2354,9 +2359,23 @@ class MistyController:
         # Normal re-arm: audio resource cleanup before re-arming.
         self.stop_recording()
         if self._wake_word_listener:
-            # Laptop mode — no keyphrase to restart, shorter cooldown needed
-            logger.info("Re-arm: audio cleanup (2s) — laptop wake word mode")
+            # Laptop mode — no keyphrase to restart, shorter cooldown needed.
+            # Keep the WebSocket open on the normal path; the laptop listener
+            # owns wake detection and the existing subscriptions remain valid.
+            logger.info("Fast re-arm: audio cleanup (2s) — laptop wake word mode")
             time.sleep(2.0)
+            if self._ws_is_connected():
+                self._wake_word_listener.resume()
+                self.set_led(0, 255, 0)
+                self.display_image("e_DefaultContent.jpg")
+                self.last_activity_time = time.time()
+                self.set_state(State.IDLE)
+                logger.info("Fast re-arm complete — laptop wake word resumed; WebSocket kept open")
+                return
+            logger.warning(
+                "Fast re-arm unavailable — WebSocket disconnected/unhealthy; "
+                "falling back to full reconnect"
+            )
         else:
             # Misty keyphrase mode — aggressive cleanup needed for Snapdragon 410
             # hardware to fully release resources before keyphrase restart (#22).

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -178,6 +178,8 @@ class TestLaptopFastRearm(unittest.TestCase):
         ws = SimpleNamespace(sock=SimpleNamespace(connected=True), close=unittest.mock.MagicMock())
         ctrl.ws = ws
         ctrl.ws_thread = SimpleNamespace(is_alive=lambda: True)
+        state_when_resumed = []
+        ctrl._wake_word_listener.resume.side_effect = lambda: state_when_resumed.append(ctrl.get_state())
 
         with unittest.mock.patch.object(self._controller_module.time, "sleep"):
             with self.assertLogs("misty_controller", level="INFO") as logs:
@@ -188,6 +190,7 @@ class TestLaptopFastRearm(unittest.TestCase):
         ctrl._connect_ws.assert_not_called()
         ctrl._wake_word_listener.resume.assert_called_once()
         self.assertEqual(ctrl.get_state(), self._controller_module.State.IDLE)
+        self.assertEqual(state_when_resumed, [self._controller_module.State.IDLE])
         self.assertTrue(
             any("Fast re-arm complete" in message and "WebSocket kept open" in message for message in logs.output)
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -177,6 +177,7 @@ class TestLaptopFastRearm(unittest.TestCase):
         ctrl._wake_word_listener = unittest.mock.MagicMock()
         ws = SimpleNamespace(sock=SimpleNamespace(connected=True), close=unittest.mock.MagicMock())
         ctrl.ws = ws
+        ctrl.ws_thread = SimpleNamespace(is_alive=lambda: True)
 
         with unittest.mock.patch.object(self._controller_module.time, "sleep"):
             with self.assertLogs("misty_controller", level="INFO") as logs:
@@ -197,6 +198,7 @@ class TestLaptopFastRearm(unittest.TestCase):
         ctrl._wake_word_listener = unittest.mock.MagicMock()
         ws = SimpleNamespace(sock=SimpleNamespace(connected=False), close=unittest.mock.MagicMock())
         ctrl.ws = ws
+        ctrl.ws_thread = SimpleNamespace(is_alive=lambda: True)
 
         with unittest.mock.patch.object(self._controller_module.time, "sleep"):
             with self.assertLogs("misty_controller", level="WARNING") as logs:
@@ -206,6 +208,21 @@ class TestLaptopFastRearm(unittest.TestCase):
         ctrl._connect_ws.assert_called_once()
         ctrl._wake_word_listener.resume.assert_called_once()
         self.assertTrue(any("falling back to full reconnect" in message for message in logs.output))
+
+    def test_laptop_rearm_reconnects_when_websocket_thread_is_stopped(self):
+        """Laptop mode must reconnect if the WebSocket loop is no longer alive."""
+        ctrl = self._controller_with_mocks()
+        ctrl._wake_word_listener = unittest.mock.MagicMock()
+        ws = SimpleNamespace(sock=SimpleNamespace(connected=True), close=unittest.mock.MagicMock())
+        ctrl.ws = ws
+        ctrl.ws_thread = SimpleNamespace(is_alive=lambda: False)
+
+        with unittest.mock.patch.object(self._controller_module.time, "sleep"):
+            ctrl._rearm()
+
+        ws.close.assert_called_once()
+        ctrl._connect_ws.assert_called_once()
+        ctrl._wake_word_listener.resume.assert_called_once()
 
     def test_misty_keyphrase_rearm_still_reconnects_websocket(self):
         """Non-laptop keyphrase mode keeps the existing full re-arm path."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,6 +14,7 @@ import time
 import os
 import threading
 from io import BytesIO
+from types import SimpleNamespace
 from urllib.parse import urlparse, urlunparse
 
 # ---------------------------------------------------------------------------
@@ -131,6 +132,94 @@ class TestLaptopMistyRecordingConfig(unittest.TestCase):
                 phase="initial recording",
                 misty_fallback_available=False,
             )
+
+class TestLaptopFastRearm(unittest.TestCase):
+    """Unit tests for laptop wake-word re-arm behavior (#65)."""
+
+    _controller_module = None
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import misty_controller  # noqa: PLC0415
+            cls._controller_module = misty_controller
+        except ModuleNotFoundError as exc:
+            if exc.name != "websocket":  # pragma: no cover
+                cls._controller_module = None
+                print(f"[TestLaptopFastRearm] Could not import misty_controller: {exc}")
+                return
+            websocket_stub = unittest.mock.MagicMock()
+            websocket_stub.WebSocketApp = unittest.mock.MagicMock()
+            with unittest.mock.patch.dict(sys.modules, {"websocket": websocket_stub}):
+                import misty_controller  # noqa: PLC0415
+                cls._controller_module = misty_controller
+        except Exception as exc:  # pragma: no cover
+            cls._controller_module = None
+            print(f"[TestLaptopFastRearm] Could not import misty_controller: {exc}")
+
+    def setUp(self):
+        if self._controller_module is None:
+            self.skipTest("misty_controller could not be imported")
+
+    def _controller_with_mocks(self):
+        ctrl = self._controller_module.MistyController()
+        ctrl.move_head = unittest.mock.MagicMock()
+        ctrl.stop_recording = unittest.mock.MagicMock(return_value={"status": "Success"})
+        ctrl.misty_post = unittest.mock.MagicMock()
+        ctrl.set_led = unittest.mock.MagicMock()
+        ctrl.display_image = unittest.mock.MagicMock()
+        ctrl._connect_ws = unittest.mock.MagicMock()
+        return ctrl
+
+    def test_laptop_rearm_keeps_healthy_websocket_open(self):
+        """Normal laptop-mode re-arm must resume listening without reconnecting."""
+        ctrl = self._controller_with_mocks()
+        ctrl._wake_word_listener = unittest.mock.MagicMock()
+        ws = SimpleNamespace(sock=SimpleNamespace(connected=True), close=unittest.mock.MagicMock())
+        ctrl.ws = ws
+
+        with unittest.mock.patch.object(self._controller_module.time, "sleep"):
+            with self.assertLogs("misty_controller", level="INFO") as logs:
+                ctrl._rearm()
+
+        ctrl.stop_recording.assert_called_once()
+        ws.close.assert_not_called()
+        ctrl._connect_ws.assert_not_called()
+        ctrl._wake_word_listener.resume.assert_called_once()
+        self.assertEqual(ctrl.get_state(), self._controller_module.State.IDLE)
+        self.assertTrue(
+            any("Fast re-arm complete" in message and "WebSocket kept open" in message for message in logs.output)
+        )
+
+    def test_laptop_rearm_reconnects_when_websocket_unhealthy(self):
+        """Laptop mode must fall back to full reconnect when the socket is unhealthy."""
+        ctrl = self._controller_with_mocks()
+        ctrl._wake_word_listener = unittest.mock.MagicMock()
+        ws = SimpleNamespace(sock=SimpleNamespace(connected=False), close=unittest.mock.MagicMock())
+        ctrl.ws = ws
+
+        with unittest.mock.patch.object(self._controller_module.time, "sleep"):
+            with self.assertLogs("misty_controller", level="WARNING") as logs:
+                ctrl._rearm()
+
+        ws.close.assert_called_once()
+        ctrl._connect_ws.assert_called_once()
+        ctrl._wake_word_listener.resume.assert_called_once()
+        self.assertTrue(any("falling back to full reconnect" in message for message in logs.output))
+
+    def test_misty_keyphrase_rearm_still_reconnects_websocket(self):
+        """Non-laptop keyphrase mode keeps the existing full re-arm path."""
+        ctrl = self._controller_with_mocks()
+        ctrl._wake_word_listener = None
+        ws = SimpleNamespace(sock=SimpleNamespace(connected=True), close=unittest.mock.MagicMock())
+        ctrl.ws = ws
+
+        with unittest.mock.patch.object(self._controller_module.time, "sleep"):
+            ctrl._rearm()
+
+        ctrl.misty_post.assert_any_call("/api/audio/keyphrase/stop")
+        ws.close.assert_called_once()
+        ctrl._connect_ws.assert_called_once()
 
 class TestWindowsOrchestration(unittest.TestCase):
     """Test Windows orchestration service."""


### PR DESCRIPTION
## Summary

Implements the laptop wake-word fast re-arm path for issue #65.

Related issue: #65

## Acceptance criteria

- [x] Laptop wake-word mode returns to `IDLE` without closing/reopening WebSocket on the normal path.
- [x] Misty keyphrase mode behavior is unchanged.
- [x] A fallback reconnect still occurs if the WebSocket is disconnected or unhealthy.
- [x] Logs clearly distinguish fast re-arm from full re-arm.

## Verification

- `python -m py_compile src/windows-orchestration/misty_controller.py tests/test_integration.py` — passed
- `python -m pytest tests/test_integration.py -k "LaptopFastRearm or LaptopMistyRecordingConfig"` — 7 passed, 187 deselected
- `git diff --check -- src/windows-orchestration/misty_controller.py tests/test_integration.py` — passed

## Review follow-up

- Addressed Copilot review by requiring both `ws.sock.connected` and a live `ws_thread` before taking the fast re-arm path.
- Addressed Copilot review by transitioning to `IDLE` before resuming laptop wake-word detection.

## Workflow review

Reviewed `.github/agents/issue-implementation-loop.md` and `.github/skills/issue-implementation-loop/SKILL.md` during the run; no workflow policy changes were needed for this issue.