### PR TITLE
Add Copilot setup steps workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,48 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - src/windows-orchestration/requirements.txt
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+      - src/windows-orchestration/requirements.txt
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: src/windows-orchestration/requirements.txt
+
+      - name: Install Linux audio/runtime packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            espeak-ng \
+            ffmpeg \
+            libsndfile1 \
+            portaudio19-dev
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest psutil
+          python -m pip install -r src/windows-orchestration/requirements.txt
+
+      - name: Compile Python sources
+        run: python -m compileall src/windows-orchestration tests


### PR DESCRIPTION
## Summary
- Add `.github/workflows/copilot-setup-steps.yml` so Copilot cloud agents start with Python 3.13, pip caching, Linux audio/runtime packages, repo Python dependencies, pytest, and psutil.
- Compile Python sources during setup to catch syntax issues early without requiring Misty hardware, Foundry Local, or live services.

## Verification
- `git diff --cached --check`
- Verified the required `copilot-setup-steps` job name is present.

## Notes
- Live Misty, Foundry Local, Windows audio, and SAPI5 validation remain manual/off-ramp checks for cloud agents.