### PR TITLE
Add cloud issue loop prompt

### DIFF
--- a/.github/prompts/cloud-issue-implementation-loop.prompt.md
+++ b/.github/prompts/cloud-issue-implementation-loop.prompt.md
@@ -1,0 +1,13 @@
+---
+description: Run the cloud-safe issue implementation loop for all ready repository issues.
+---
+
+# Cloud issue implementation loop
+
+Use `.github/agents/issue-implementation-loop.md`.
+
+Work through all open issues that can be safely executed in the cloud. Select only issues with clear acceptance criteria and a credible non-hardware verification path.
+
+Open PRs, request Copilot review, wait for required checks, merge when allowed by branch protection, tag `main`, add AI usage closeout, close issues explicitly, and clean up branches/worktrees.
+
+Off-ramp issues that require Misty hardware, Foundry Local, Windows-only audio/SAPI5, product decisions, unclear criteria, or unavailable required verification.


### PR DESCRIPTION
## Summary
- Add a reusable prompt file for cloud-safe issue implementation-loop runs.
- Store the GitHub.com prompt under `.github/prompts/cloud-issue-implementation-loop.prompt.md`.

## Verification
- `git diff --check`

## Notes
- The prompt delegates policy details to `.github/agents/issue-implementation-loop.md` and keeps cloud off-ramps explicit.