### PR TITLE
Use PR closing keywords for issue loops

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- Briefly describe the change. -->
+
+## Linked issue
+
+Closes #<issue-number>
+
+## Verification
+<!-- List commands run and results. -->

--- a/.github/agents/issue-implementation-loop.md
+++ b/.github/agents/issue-implementation-loop.md
@@ -1,6 +1,6 @@
 ---
 name: issue-implementation-loop
-description: Autonomously implements user-identified issues through PRs, Copilot review, required checks, main tagging, issue closeout, and cleanup.
+description: Autonomously implements user-identified issues through PRs, Copilot review, required checks, GitHub auto-close, main tagging, and cleanup.
 ---
 
 You are the issue implementation loop agent for the Misty II + Foundry Local repository.
@@ -16,15 +16,15 @@ Your job is to run a bounded autonomous implementation loop over the GitHub issu
 7. Create an issue-scoped feature branch, using a worktree when useful for parallel isolation; never work directly on `main`.
 8. Make narrow changes that satisfy the selected issue. Count implementation attempts; after two unsuccessful attempts, stop before starting a third and create/comment a human-review off-ramp instead of continuing inefficiently.
 9. Run all applicable tests, lints, builds, and documentation checks for the changed scope; do not merge with failing or skipped required verification.
-10. Push the feature branch and open a pull request against `main` that links the issue without auto-closing keywords, includes acceptance or success criteria, and includes verification evidence.
+10. Push the feature branch and open a pull request against `main` that links the issue with a GitHub closing keyword such as `Closes #123`, includes acceptance or success criteria, and includes verification evidence. Use one closing-keyword line per linked issue so GitHub auto-closes issues when the PR merges.
 11. Request Copilot code review on the pull request, preferably with the review-request API: `gh api repos/:owner/:repo/pulls/<pull_number>/requested_reviewers -f reviewers[]='copilot-pull-request-reviewer[bot]'`; if the reviewer request fails, treat it as a blocker unless Copilot review is confirmed unsupported for the repository. Do not require owner review for autonomous issue loops unless current branch protection or the user explicitly requires it.
 12. Monitor the pull request until all required checks pass and Copilot code review is complete or explicitly unsupported. Address actionable review feedback on the same branch, re-run verification, and re-request review when needed. Stop before a third Copilot review round with actionable findings; create/comment a human-review off-ramp instead of continuing inefficiently. If a required check is not reported within 30 minutes, stop with a required-check timeout off-ramp.
 13. Record AI usage checkpoints after selection/preflight, implementation, PR creation, each Copilot review round, before merge, and at closeout or off-ramp. Report exact input tokens, output tokens, cache read tokens, cache write tokens, and AIC/AI Credits or usage cost when available; if unavailable, state the telemetry source checked and unavailable fields.
-14. Before merging, confirm the PR body links issues without closing keywords. If a closing keyword is present and cannot be removed, add the `AI usage` issue comment before merge so auto-close cannot happen without usage data.
+14. Before merging or queueing auto-merge, add or verify the `AI usage` issue comment with the pre-run prediction, actual input/output/cache read/cache write tokens available so far, AIC/AI Credits or usage cost when available, model breakdown, telemetry source or session IDs when available, and prediction-vs-actual lesson or an explicit unavailable note. Then confirm the PR body contains the intended closing keywords so issue closure happens automatically on merge.
 15. Merge the pull request into `main` only after all applicable tests/lints/checks pass, required code review has completed, no actionable review comments remain unresolved, and current repository policy allows the merge. Never queue auto-merge while Copilot review is requested but incomplete; if auto-merge is used after review completion, poll until the PR is actually merged before tagging or cleanup.
 16. After a successful merge, refresh `main`, verify the merge commit is present, then create and push a corresponding annotated main-branch tag. Include PR metadata in the tag name, such as `issue-66-pr-78-laptop-recording-config` or `pr-78-title-slug`; if the tag exists, append the short merge SHA.
 17. After the tag is pushed, remove associated worktrees and delete merged feature branches locally and remotely when permissions allow. GitHub may auto-delete the remote branch at merge time; that is acceptable because the main merge commit remains taggable. Never delete dirty worktrees or unmerged local branches.
-18. After merge, tag, and cleanup steps are complete, add or verify an issue comment titled `AI usage` with the pre-run prediction, actual input/output/cache read/cache write tokens, AIC/AI Credits or usage cost when available, model breakdown, telemetry source or session IDs when available, prediction-vs-actual lesson, or an explicit unavailable note with the source checked. Then close the issue explicitly. Do not rely on PR closing keywords for issue closure. If merge, tag, close, worktree cleanup, or branch cleanup cannot be completed, report the required follow-up.
+18. After merge, tag, and cleanup steps are complete, verify GitHub auto-closed every linked issue from the PR closing keywords. If auto-close did not happen, close the issue explicitly only after confirming the `AI usage` comment exists. If merge, tag, auto-close verification, worktree cleanup, or branch cleanup cannot be completed, report the required follow-up.
 
 When running in fleet mode, treat the parent agent as the coordinator and shard work by issue:
 
@@ -32,9 +32,9 @@ When running in fleet mode, treat the parent agent as the coordinator and shard 
 - Use a separate feature branch or worktree branch per issue/subagent.
 - Avoid assigning issues that are likely to touch the same files or tightly coupled subsystems.
 - Stop and report a coordination conflict if two subagents select overlapping work.
-- Require each subagent to report its issue number, branch, PR, Copilot review status, merge/close status, main-branch tag, cleanup status, files changed, verification, and any unavailable checks.
+- Require each subagent to report its issue number, branch, PR, Copilot review status, merge/auto-close verification status, main-branch tag, cleanup status, files changed, verification, and any unavailable checks.
 
-When monitoring repository issue and PR status, refresh issue state, labels, comments, linked PRs, check runs, reviews, branch protection blockers, and existing feature branches before selecting, merging, tagging, cleanup, or closing work. Skip issues that are closed, blocked, assigned to unclear ownership, already have active in-progress branches, or already have linked in-flight PRs unless the user explicitly asks to take them over.
+When monitoring repository issue and PR status, refresh issue state, labels, comments, linked PRs, check runs, reviews, branch protection blockers, and existing feature branches before selecting, merging, tagging, cleanup, or verifying auto-close. Skip issues that are closed, blocked, assigned to unclear ownership, already have active in-progress branches, or already have linked in-flight PRs unless the user explicitly asks to take them over.
 
 Use `.github/skills/issue-implementation-loop/SKILL.md` as the policy for the loop. Use `.github/skills/feature-planning/SKILL.md` before implementation when an issue is vague, duplicated, missing criteria, blocked, or needs a human-review off-ramp.
 
@@ -42,4 +42,4 @@ Stop the loop instead of continuing inefficiently when acceptance criteria are a
 
 When stopping, leave a clear off-ramp record with the issue number, what was attempted, why the loop stopped, evidence from commands or code review, the pre-run AI usage prediction, actual usage to date including cache read/write tokens when available, prediction-vs-actual lesson or the usage source checked, and the next human decision needed.
 
-Never close an issue without either an exact AI usage comment or an explicit AI usage unavailable comment. Always report completed work separately from unavailable checks, unavailable Copilot review, unavailable merge/tag/close/worktree-cleanup/branch-cleanup steps, unavailable cached-token metrics, unavailable AI usage metrics, or follow-up needed.
+Never merge a PR that will auto-close an issue without either an exact AI usage comment or an explicit AI usage unavailable comment already on the issue. Always report completed work separately from unavailable checks, unavailable Copilot review, unavailable merge/tag/auto-close verification/worktree-cleanup/branch-cleanup steps, unavailable cached-token metrics, unavailable AI usage metrics, or follow-up needed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ The robot's hardware (Snapdragon 820 + 410, 2 GB RAM) cannot run inference — 2
 
 - **Never push directly to `main`.** All changes must go through a pull request.
 - For normal manual work, request repository-owner review when branch protection or the user requires it.
-- For autonomous issue-implementation-loop work, require a PR, passing required status checks, Copilot code review, issue AI-usage closeout, a main-branch tag named with issue/PR metadata, and branch/worktree cleanup. Owner review is not required unless current branch protection or the user explicitly requires it.
+- For autonomous issue-implementation-loop work, require a PR with GitHub issue-closing keywords, passing required status checks, Copilot code review, issue AI-usage closeout before merge, a main-branch tag named with issue/PR metadata, auto-close verification, and branch/worktree cleanup. Owner review is not required unless current branch protection or the user explicitly requires it.
 - When working on changes, create a feature branch and open a PR.
 
 ## Build & Run

--- a/.github/prompts/cloud-issue-implementation-loop.prompt.md
+++ b/.github/prompts/cloud-issue-implementation-loop.prompt.md
@@ -10,6 +10,6 @@ Work through open issues labeled `cloud-ready` that can be safely executed in th
 
 Prefer documentation, repository policy/automation, and other work that can be verified entirely from the cloud runner.
 
-Open PRs, request Copilot review, wait for required checks, merge when allowed by branch protection, tag `main`, add AI usage closeout, close issues explicitly, and clean up branches/worktrees.
+Open PRs with GitHub closing keywords such as `Closes #123`, request Copilot review, wait for required checks, add AI usage closeout before merge or auto-merge, merge when allowed by branch protection, tag `main`, verify GitHub auto-closed linked issues, and clean up branches/worktrees.
 
 Off-ramp issues that require Misty hardware, Foundry Local, Windows-only audio/SAPI5, product decisions, unclear criteria, or unavailable required verification.

--- a/.github/skills/issue-implementation-loop/SKILL.md
+++ b/.github/skills/issue-implementation-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-implementation-loop
-description: Use when asked to run or define an autonomous issue loop that opens PRs, requests Copilot review, merges, tags main, closes issues, and cleans up.
+description: Use when asked to run or define an autonomous issue loop that opens PRs, requests Copilot review, merges, tags main, verifies GitHub issue auto-close, and cleans up.
 ---
 
 # Issue Implementation Loop Skill
@@ -9,7 +9,7 @@ Use this skill when the user asks an agent to review GitHub issues, monitor issu
 
 This workflow is **both agent and skill**:
 
-- The **agent** is the autonomous executor. It reads issues, chooses ready work, edits files, runs commands, opens PRs, requests Copilot code review, merges verified PRs when allowed, tags `main`, updates and closes issues, and reports results.
+- The **agent** is the autonomous executor. It reads issues, chooses ready work, edits files, runs commands, opens PRs with GitHub closing keywords, requests Copilot code review, merges verified PRs when allowed, tags `main`, verifies issue auto-close, and reports results.
 - This **skill** is the reusable policy and runbook. It defines selection rules, guardrails, verification, metrics, and off-ramp behavior.
 
 ## Core rule
@@ -48,18 +48,18 @@ When this loop runs under `/fleet`, use parallelism only for independent issue w
 - Give every subagent a distinct issue number, acceptance criteria, branch name, and verification expectation.
 - Do not run multiple subagents on issues that likely touch the same files, runtime state, hardware path, or GitHub artifact.
 - If issue ownership, file overlap, branch conflicts, or PR conflicts appear, stop the affected subagents and record a coordination off-ramp.
-- Require each subagent to report the issue number, title, branch, PR, Copilot review status, merge/close status, main-branch tag, cleanup status, files changed, commands run, verification result, unavailable checks, and off-ramp reason when applicable.
+- Require each subagent to report the issue number, title, branch, PR, Copilot review status, merge/auto-close verification status, main-branch tag, cleanup status, files changed, commands run, verification result, unavailable checks, and off-ramp reason when applicable.
 
 ## Repository monitoring
 
-When asked to monitor issue and PR status, refresh repository state before selecting, assigning, merging, tagging, cleanup, or closing work:
+When asked to monitor issue and PR status, refresh repository state before selecting, assigning, merging, tagging, cleanup, or verifying auto-close:
 
 - Check current issue state, labels, assignees, comments, linked PRs, PR reviews, check runs, branch protection blockers, and existing feature branches.
 - Skip issues that are closed, blocked, deferred, assigned to unclear ownership, already being handled by an active branch, active worktree, `Agent claim` comment, or already linked to an in-flight PR unless the user explicitly asks to take over.
-- Re-check the selected issue and linked PR before merging, tagging, cleanup, or closing to ensure the scope, labels, ownership, reviews, and check status did not change during implementation.
+- Re-check the selected issue and linked PR before merging, tagging, cleanup, or auto-close verification to ensure the scope, labels, ownership, reviews, and check status did not change during implementation.
 - In fleet mode, the parent agent owns monitoring and assignment; subagents own only their assigned issue.
 
-Before starting work, leave an `Agent claim` comment on the issue with the branch name, worktree path when used, agent/session ID when available, and timestamp. Before merging or closing, refresh the issue and PR to confirm the claim is still current.
+Before starting work, leave an `Agent claim` comment on the issue with the branch name, worktree path when used, agent/session ID when available, and timestamp. Before merging or verifying closure, refresh the issue and PR to confirm the claim is still current.
 
 ## Permission and repository preflight
 
@@ -67,7 +67,7 @@ Before entering an autonomous loop, verify the current GitHub identity can perfo
 
 - `gh auth status` succeeds for the target repository.
 - The identity can push feature branches and tags.
-- The identity can open PRs, request Copilot review, merge PRs, and close issues.
+- The identity can open PRs, request Copilot review, merge PRs, and verify or explicitly close issues when GitHub auto-close does not complete.
 - The identity can delete merged remote branches, or repository branch auto-delete is enabled. If neither is true, continue the loop but report branch cleanup as unavailable after merge/tag.
 - Branch protection for `main` does not require human approval for autonomous issue loops. If current branch protection or the user explicitly requires owner approval, request that review and treat missing approval as a merge blocker.
 - Required status checks are configured and expected to run for PRs. Query `main` branch protection with the GitHub API/CLI and treat the returned contexts as the source of truth.
@@ -134,9 +134,9 @@ Cached tokens must be reported separately from ordinary input/output tokens beca
    PR-level required checks from `main` branch protection must also pass before merge. Query the required contexts at runtime instead of hardcoding check names.
    For cloud-safe issue-loop runs in this repository, treat verification that depends on Misty hardware, Foundry Local, or Windows-only audio/SAPI5 as unavailable and off-ramp the issue unless the issue already defines a credible cloud substitute.
 
-6. **Open, review, merge, close, or hand off**
+6. **Open, review, merge, auto-close, or hand off**
    - Push the issue-scoped feature branch and open a pull request against `main` for completed issue work.
-   - Link the issue from the PR body without closing keywords such as `closes`, `fixes`, or `resolves`; include the completed success-criteria checklist and commands run with verification results.
+   - Link the issue from the PR body with a GitHub closing keyword such as `Closes #123`, `Fixes #123`, or `Resolves #123`; include the completed success-criteria checklist and commands run with verification results. Use one closing-keyword line per linked issue so GitHub auto-closes issues when the PR merges.
    - Request Copilot code review on the PR, preferably with the review-request API: `gh api repos/:owner/:repo/pulls/<pull_number>/requested_reviewers -f reviewers[]='copilot-pull-request-reviewer[bot]'`; if the request fails, treat it as a blocker/off-ramp unless Copilot review is confirmed unsupported for the repository.
    - Do not require owner approval for autonomous issue loops unless current branch protection or the user explicitly requires it. If owner approval is required, request it and block merge until it is granted.
    - Monitor the PR until all required checks pass and Copilot code review is complete or explicitly unsupported.
@@ -146,24 +146,23 @@ Cached tokens must be reported separately from ordinary input/output tokens beca
    - Count Copilot review rounds that produce actionable findings. If two actionable rounds have been addressed and another actionable round would be required, stop and create/comment the human-review off-ramp instead of continuing inefficiently.
    - Record an AI usage checkpoint after PR creation and after each Copilot review round.
    - If a Copilot comment is unclear, incorrect, or not safely actionable, leave a PR comment explaining the disposition and continue only when no material risk remains.
-   - Before merging, verify the PR body links issues without closing keywords. If closing keywords are present, remove them; if they cannot be removed, add the `AI usage` issue comment before merge so auto-close cannot happen without usage data.
+   - Before merging or queueing auto-merge, add or verify the issue comment titled `AI usage` with the pre-run prediction, actual input tokens, output tokens, cache read tokens, cache write tokens, AIC/AI Credits or usage cost when available, and the prediction-vs-actual lesson for that issue. Then verify the PR body has the intended closing keywords. If closing keywords are missing, update the PR body before merge.
    - After all applicable tests/lints/checks pass and required code review completes, merge the PR into `main` only when repository policy, branch protection, and run authorization permit it. Use `gh pr merge --auto --merge --delete-branch` only after Copilot review is complete and any remaining checks are still pending; otherwise merge only after checks pass.
-   - If auto-merge is queued, poll the PR until `state=MERGED` before tagging, cleanup, or issue closure. If it does not merge within 30 minutes after all required checks pass, stop with a merge-timeout off-ramp.
+   - If auto-merge is queued, poll the PR until `state=MERGED` before tagging, cleanup, or auto-close verification. If it does not merge within 30 minutes after all required checks pass, stop with a merge-timeout off-ramp.
    - If merge is not permitted or cannot be completed, leave the issue open and report the ready PR, branch, or worktree plus the exact blocker.
    - After a successful merge, refresh `main`, verify the merge commit is present, then create and push a corresponding main-branch tag so the merged code can be correlated to the issue and PR.
    - Use a safe, lowercase tag name derived from the issue and PR, such as `issue-66-pr-78-laptop-recording-config`, or `pr-78-title-slug` when no single issue applies.
    - If the intended tag already exists, append the short merge SHA, for example `issue-66-pr-78-laptop-recording-config-68204b6`.
-   - Create the main-branch tag before explicitly closing the issue.
+   - Create the main-branch tag after merge even though GitHub may already have auto-closed the linked issue.
    - After the main-branch tag is pushed, remove associated worktrees and delete merged feature branches locally and remotely when permissions allow.
    - GitHub may auto-delete the remote branch at merge time; this is acceptable because the main merge commit remains available for tagging.
    - Never delete a dirty worktree or unmerged local branch.
    - Verify cleanup with `git worktree list --porcelain`, `git branch --merged main`, and `git branch --all --merged main`.
-   - Before closing or handing off the issue, add or verify an issue comment titled `AI usage` that reports the pre-run prediction, actual input tokens, output tokens, cache read tokens, cache write tokens, AIC/AI Credits or usage cost when available, and the prediction-vs-actual lesson for that issue.
-   - Include model breakdown, telemetry source or session IDs when available, subagent usage when applicable, and the issue/PR scope used for the usage query.
+   - The `AI usage` comment must include model breakdown, telemetry source or session IDs when available, subagent usage when applicable, and the issue/PR scope used for the usage query.
    - Use exact usage from available Copilot/session usage telemetry when available; if exact usage is unavailable, do not estimate. State which usage source was checked and that the metric was unavailable.
-   - Never close an issue without either an exact AI usage comment or an explicit AI usage unavailable comment.
-   - After merge, tag, and cleanup steps are complete, verify the issue is closed or close it explicitly with the AI usage closeout comment already present.
-   - Do not rely on PR closing keywords for issue closure; close explicitly after AI usage, merge, tag, and cleanup.
+   - Never merge a PR that will auto-close an issue without either an exact AI usage comment or an explicit AI usage unavailable comment already on the issue.
+   - After merge, tag, and cleanup steps are complete, verify GitHub auto-closed each linked issue from the PR closing keywords. If auto-close did not happen, close the issue explicitly with the AI usage closeout comment already present and report the fallback.
+   - Prefer PR closing keywords for issue closure; use explicit closure only as a fallback when GitHub auto-close does not complete.
    - Note any unavailable checks, residual risks, or manual validation needed.
 
 ## When to invoke `feature-planning`
@@ -231,7 +230,7 @@ Track these metrics for each loop run:
 - Pull request number and URL.
 - Copilot code review request and completion status.
 - Required check reporting and timeout status.
-- Merge and issue closure status.
+- Merge and issue auto-close verification status.
 - Main-branch tag name and push status after merge.
 - Worktree removal and merged branch deletion status after the main-branch tag is pushed.
 - Failures and retries.
@@ -253,10 +252,10 @@ Use these metrics to decide whether to continue, narrow scope, switch to `featur
 Report:
 
 - Issue number and title.
-- Branch or worktree, PR, Copilot review status, merge commit, main-branch tag, cleanup, or issue closure status, when available.
+- Branch or worktree, PR, Copilot review status, merge commit, main-branch tag, cleanup, or issue auto-close verification status, when available.
 - Success criteria completed.
 - Verification commands and results, including all applicable tests, lints, builds, and documentation checks.
 - AI usage issue update status, including prediction, actual input/output/cache read/cache write tokens, AIC/AI Credits or usage cost when available, model breakdown, telemetry source/session IDs, and prediction-vs-actual lesson when available.
-- Any off-ramp, unavailable check, unavailable Copilot review, unavailable merge/tag/close/worktree-cleanup/branch-cleanup step, or manual follow-up.
+- Any off-ramp, unavailable check, unavailable Copilot review, unavailable merge/tag/auto-close verification/worktree-cleanup/branch-cleanup step, or manual follow-up.
 
 Keep the response concise and distinguish completed work from planned or blocked work.

--- a/lessonsLearned/autonomous-issue-loop-lessons.md
+++ b/lessonsLearned/autonomous-issue-loop-lessons.md
@@ -11,7 +11,7 @@
 ## What worked
 
 - Preflight caught the important repository gates: authenticated admin user, protected `main`, required CodeQL checks, auto-merge support, and delete-branch-on-merge.
-- The PR body linked the issue without closing keywords, which kept issue closeout under agent control.
+- Earlier workflow kept issue closeout under agent control. This is superseded by the 2026-06-28 decision to use PR closing keywords for GitHub auto-close.
 - Copilot review was useful: it identified two race/health-check problems before merge.
 - Re-requesting Copilot review after each fix produced a final review with `0 new` comments.
 - Review threads can be resolved via GraphQL after the code changes address them.
@@ -23,6 +23,7 @@
 - Resume wake-word detection only after the controller has transitioned back to `IDLE`, otherwise an immediate detection can be dropped.
 - `git diff --check` can flag newly added CRLF lines as trailing whitespace in files already committed with CRLF; verify whitespace after patches.
 - AI usage closeout needs a clear unavailable note when the telemetry source exposes tokens but not AIC/AI Credits or fully up-to-date closeout totals.
+- Superseded 2026-06-28: future issue-loop PRs should use GitHub closing keywords so linked issues auto-close on merge, with AI usage closeout posted before merge or auto-merge is queued.
 
 ## Cost and safety guardrail lessons
 

--- a/lessonsLearned/cloud-autonomous-issue-loop-limits.md
+++ b/lessonsLearned/cloud-autonomous-issue-loop-limits.md
@@ -1,0 +1,38 @@
+# Cloud Autonomous Issue Loop Limits
+
+## Summary
+
+The goal of an autonomous loop that works through every GitHub issue until completion is not realistic for this repository. It is still useful, but it needs a hybrid model: cloud agents should complete issues that are clearly scoped and cloud-verifiable, while Misty-specific runtime and hardware work should be off-ramped for local validation.
+
+## What we learned
+
+- A fully autonomous loop over all open issues is unsafe because many issues require resources that cloud agents cannot access.
+- The user's laptop should not be the default execution environment for every issue because long-running local automation can create heat and resource pressure.
+- Cloud agents are best for documentation, repository policy, prompt/agent workflow updates, pure Python checks, and other changes that can be verified without live hardware.
+- Cloud agents are not enough for issues that require Misty hardware, Foundry Local, live model execution, Windows-only audio behavior, SAPI5 TTS, laptop microphone behavior, webcam validation, or local network access to the robot.
+- Vague issues or feature ideas should be refined into acceptance criteria before implementation begins.
+
+## Recommended operating model
+
+Use a hybrid autonomous issue loop:
+
+1. Label issues that are safe for cloud automation as `cloud-ready`.
+2. Require clear acceptance or success criteria before an issue enters the run queue.
+3. Require a credible verification path that avoids Misty hardware, Foundry Local, Windows-only audio/SAPI5 behavior, and unavailable local services.
+4. Let cloud agents implement, verify, open PRs, request Copilot review, merge when allowed, tag `main`, and close only those cloud-safe issues.
+5. Off-ramp hardware-dependent or runtime-dependent issues with a clear note that names the missing validation environment and the local check required.
+6. Reserve the laptop for Misty-specific validation rather than broad issue-loop execution.
+
+## Practical decision table
+
+| Issue type | Automation fit | Expected handling |
+|---|---|---|
+| Documentation, lessons learned, prompts, agent instructions, repo policy | Good | Cloud agent can implement and verify with `git diff --check` or GitHub CLI/API inspection |
+| Pure Python logic with narrow tests and no live service dependency | Good | Cloud agent can implement and run targeted compile/test checks |
+| Misty REST/WebSocket behavior requiring robot validation | Limited | Implement only if a credible non-hardware test exists; otherwise off-ramp for local Misty validation |
+| Foundry Local, STT, LLM, TTS, audio, SAPI5, webcam, or laptop microphone behavior | Poor | Off-ramp unless the issue defines a cloud-safe substitute test |
+| Broad feature ideas without acceptance criteria | Poor | Convert to a planning issue before implementation |
+
+## Key guardrail
+
+The loop should optimize for completed, verified issues rather than raw throughput. If verification cannot be performed credibly in the cloud, the correct autonomous outcome is an off-ramp with evidence and next local validation steps, not a merged change that only appears complete.


### PR DESCRIPTION
## Summary

- Update issue-loop agent, skill, and cloud prompt guidance to use GitHub closing keywords so linked issues auto-close when PRs merge.
- Require AI usage closeout before merge or auto-merge is queued, then verify auto-close after merge/tag/cleanup.
- Add a PR template with a `Closes #<issue-number>` linked-issue section for manual PRs.

## Linked issue

No linked issue; direct workflow update from maintainer request.

## Verification

- `git diff --check`
- searched workflow docs for old no-closing-keyword guidance
