### PR TITLE
Add Misty services CLI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ curl http://localhost:5000/api/health
 
 **Foundry Local** runs on a dynamic port (not 5000). The orchestration service auto-discovers it via `foundry service status` and strips the path to get the base URL. Override with `FOUNDRY_LOCAL_HOST` env var if needed.
 
-**Misty controller** connects to Misty via WebSocket (`ws://<MISTY_IP>/pubsub`) for wake word events and REST API for all commands. Configure via env vars: `MISTY_IP` (default: `10.0.0.44`), `ORCHESTRATION_URL` (default: `http://10.0.0.58:5000`).
+**Misty controller** connects to Misty via WebSocket (`ws://<MISTY_IP>/pubsub`) for robot telemetry/events and REST API for all commands. Wake-word detection is laptop-side OpenWakeWord only. Configure via env vars: `MISTY_IP` (default: `10.0.0.44`), `ORCHESTRATION_URL` (default: `http://10.0.0.58:5000`), and `OWW_CUSTOM_MODEL_PATH` for the trained "Hey Misty" model.
 
 ## Tests
 
@@ -113,8 +113,8 @@ Key endpoints used by the controller (all at `http://<MISTY_IP>/api/`):
 
 | Method | Endpoint | Purpose |
 |--------|----------|---------|
-| POST | `/api/audio/keyphrase/start` | Start listening for "Hey Misty" (no params) |
-| POST | `/api/audio/keyphrase/stop` | Stop listening for wake word |
+| POST | `/api/audio/keyphrase/start` | Legacy built-in keyphrase start (unsupported; do not use for normal operation) |
+| POST | `/api/audio/keyphrase/stop` | Stop legacy keyphrase / release audio resources during cleanup |
 | POST | `/api/audio/record/start` | Start recording (`{"FileName": "name.wav"}`) |
 | POST | `/api/audio/record/stop` | Stop recording |
 | GET | `/api/audio?FileName=X&Base64=true` | Get recorded audio as base64 |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 # Logs
 *.log
+logs/services/
+.misty-services.json
 
 # Generated response audio
 src/windows-orchestration/responses/

--- a/README.md
+++ b/README.md
@@ -133,6 +133,27 @@ plans\                         # Historical planning prompts and notes
 
 Run these from the Windows companion device.
 
+One-command local startup/shutdown is available through the repo-local npm CLI:
+
+```powershell
+# Start Foundry Local, load Phi-3.5-mini, the orchestration service, and the Misty controller
+npx . start
+
+# Check service status
+npx . status
+
+# Gracefully stop the controller, release Misty audio/LED resources, and stop owned services
+npx . stop
+```
+
+The CLI reads `src\windows-orchestration\.env` when present. Startup loads `Phi-3.5-mini-instruct-openvino-gpu:2` into Foundry Local with a 1-hour TTL before starting the controller, so the first chat does not pay model-load latency. Before starting the controller, it checks Misty's REST API at `http://<MISTY_IP>/api/device`. If the configured IP is stale, it scans local private IPv4 `/24` networks for Misty's device API, stores the discovered IP and broadcast/reverse-DNS name in `.misty-services.json`, and reuses that address next time. You can override the common runtime settings inline:
+
+```powershell
+npx . start --misty-ip 10.0.0.44 --orchestration-url http://10.0.0.58:5000
+```
+
+Manual startup is still supported:
+
 ```powershell
 # 1. Start Foundry Local
 python -m pip install foundry-local
@@ -338,7 +359,6 @@ For unattended physical testing, see `tests\autonomous_test_harness.py`.
 - `docs\ADR-002-non-blocking-audio-pattern.md` - Laptop-mic callback/queue/worker pattern.
 - `docs\lessons-learned.md` - Operational findings from real hardware testing.
 - `docs\keyphrase-debugging.md` - Keyphrase failure history and recovery notes (historical reference).
-- `docs\design-animated-face-expressions.md` - State-driven animated face design (proposed, #73; no BMO assets).
 
 ---
 

--- a/docs/test-questions-richer-responses.md
+++ b/docs/test-questions-richer-responses.md
@@ -12,7 +12,7 @@ Updated for the richer responses changes in PR #45 and adaptive conversations (i
 | Follow-up window | 60s | 90s |
 | Follow-up turn cap | unlimited | 12 turns |
 | Conversation history | 4 messages (2 turns) | 8 messages (4 turns) |
-| Wake word (laptop mode) | "Hey Misty" on robot | "Hey Jarvis" on laptop mic |
+| Wake word | Misty built-in keyphrase | "Hey Misty" custom OpenWakeWord model on laptop mic |
 | Intent detection | None | Story/recipe/explain/continuation patterns |
 
 ---
@@ -22,9 +22,10 @@ Updated for the richer responses changes in PR #45 and adaptive conversations (i
 **Start the controller:**
 ```powershell
 cd src\windows-orchestration
+$env:OWW_CUSTOM_MODEL_PATH = "C:\path\to\hey_misty.onnx"
 python misty_controller.py
 ```
-Say **"Hey Jarvis"** near the laptop mic, then speak after the orange LED.
+Say **"Hey Misty"** near the laptop mic, then speak after the orange LED. Misty's built-in keyphrase path is unsupported; if the custom model path is missing, the controller should fail fast instead of falling back.
 
 
 ---
@@ -140,11 +141,11 @@ Run these as a continuous follow-up chain to test pipeline stability under the 9
 
 Tests unique to the laptop mic wake word mode:
 
-41. *(Walk across the room and say "Hey Jarvis" — test laptop mic range)*
-42. *(Say "Hey Jarvis" during Misty's response — self-wake prevention should block it)*
-43. *(Say "Hey Jarvis" immediately after conversation ends — should re-arm within 2s)*
+41. *(Walk across the room and say "Hey Misty" — test laptop mic range)*
+42. *(Say "Hey Misty" during Misty's response — self-wake prevention should block it)*
+43. *(Say "Hey Misty" immediately after conversation ends — should re-arm within 2s)*
 44. *(Play music near laptop — test false positive rate)*
-45. *(Say "Hey Jarvis" while facing away from laptop — test directional sensitivity)*
+45. *(Say "Hey Misty" while facing away from laptop — test directional sensitivity)*
 
 ---
 
@@ -157,10 +158,10 @@ Tests unique to the laptop mic wake word mode:
 | 🔵 Blue | Processing (STT → LLM → TTS) | ~2-5s |
 | 🟣 Purple | Playing response | Varies by response length |
 | 🩵 Cyan | Follow-up listening | Up to 90s / 12 turns |
-| 🟡 Yellow | Watchdog soft reset | ~5s |
+| 🟡 Yellow | Low battery warning / recovery notice | Varies |
 | 🔴 Red | Error | Check logs |
 
-**Response time**: ~2s for follow-ups, ~5s for first turn (TTS cold start)
+**Response time**: depends mostly on TTS generation; check `[Pipeline ...]` logs for STT/LLM/TTS breakdown
 **Response length (short)**: 1-2 sentences, ~35 words (max_tokens=60, truncation at 35 words)
 **Response length (summary/continuation)**: 2-3 sentences, ~40 words (max_tokens=80, truncation at 50 words)
 **Recording duration**: VAD-controlled — 6s minimum (RECORDING_DURATION_S), up to 15s for long utterances
@@ -171,7 +172,7 @@ Tests unique to the laptop mic wake word mode:
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| No response to wake word | Laptop mic issue or openWakeWord threshold | Check logs; verify `sounddevice` mic selection |
+| No response to wake word | Missing/incorrect custom "Hey Misty" model, laptop mic issue, or OpenWakeWord threshold | Check logs; verify `OWW_CUSTOM_MODEL_PATH` and `sounddevice` mic selection |
 | 44-byte recording (empty) | Mic or recording pipeline issue | Check `misty_controller.log` for recording errors |
 | Response too long/wordy | Brevity drift past 35 words | Post-truncation should catch this; check max_tokens=60 |
 | Response too short | Old behavior persisted | Verify running updated code; check system prompt |

--- a/docs/test-questions.md
+++ b/docs/test-questions.md
@@ -1,6 +1,6 @@
 # Misty Test Questions
 
-Questions to ask Misty during testing. Say **"Hey Misty"** first, then ask your question after the beep. For follow-up questions, just speak — no wake word needed within the 60-second follow-up window.
+Questions to ask Misty during testing. In the supported path, say **"Hey Misty"** near the laptop microphone using the configured custom OpenWakeWord model, then ask your question after the cue. For follow-up questions, just speak — no wake word needed within the 90-second follow-up window.
 
 ## Quick Check (Single Turn)
 
@@ -76,7 +76,7 @@ Run these back-to-back as follow-ups to test pipeline stability:
 
 | Symptom | Likely Cause | Issue |
 |---------|-------------|-------|
-| No response to "Hey Misty" | Keyphrase silent failure — watchdog auto-recovers in ~3.5min, or reboot | #22 |
+| No response to "Hey Misty" | Laptop OpenWakeWord model/config issue — check `OWW_CUSTOM_MODEL_PATH`, microphone access, and controller logs | #72 |
 | Response cuts off your question | Recording window is 6s — speak promptly after beep | #20 |
 | Long pause before response | LLM/TTS latency | #21 |
 | Misty misheard your words | STT accuracy | #27 |
@@ -86,10 +86,10 @@ Run these back-to-back as follow-ups to test pipeline stability:
 
 ## Expected Behavior
 
-- **Green LED** = Ready, listening for "Hey Misty"
+- **Green LED** = Ready, laptop mic listening for the configured OpenWakeWord phrase
 - **Orange LED** = Recording your question
 - **Blue LED** = Processing (STT → LLM → TTS)
 - **Purple LED** = Playing response
-- **Response time**: ~2s for follow-ups, ~5s for first turn (TTS cold start)
-- **Response length**: ≤10 words (brief, conversational)
-- **Follow-up window**: 60 seconds after last response
+- **Response time**: depends mostly on TTS generation; check `[Pipeline ...]` logs for STT/LLM/TTS breakdown
+- **Response length**: short mode targets ~35 words / up to 3 sentences
+- **Follow-up window**: 90 seconds after last response, capped at 12 follow-up turns

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "misty-services",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Local CLI for starting and stopping the Misty II companion services.",
+  "bin": {
+    "misty-services": "./tools/misty-services.mjs"
+  },
+  "scripts": {
+    "misty:start": "node tools/misty-services.mjs start",
+    "misty:stop": "node tools/misty-services.mjs stop",
+    "misty:status": "node tools/misty-services.mjs status"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -2941,6 +2941,22 @@ class ControllerAPIHandler(BaseHTTPRequestHandler):
             snapshot = ctrl.get_hazard_snapshot()
             self._send_json(200, {"status": "ok", **snapshot})
 
+        elif self.path == "/api/shutdown":
+            ctrl = self.controller
+            logger.info("[Test API] Shutdown requested")
+            self._send_json(200, {"status": "ok", "message": "Controller shutdown requested"})
+
+            def _shutdown_after_response():
+                time.sleep(0.2)
+                ctrl._shutdown()
+                os._exit(0)
+
+            threading.Thread(
+                target=_shutdown_after_response,
+                name="api-shutdown",
+                daemon=True,
+            ).start()
+
         else:
             self._send_json(404, {"error": "not_found"})
 

--- a/tools/misty-services.mjs
+++ b/tools/misty-services.mjs
@@ -204,6 +204,12 @@ function ensureCommand(command, args) {
   }
 }
 
+function redactSensitive(value) {
+  return String(value ?? "")
+    .replace(/(token|key|secret|password|pwd)=([^&\s]+)/gi, "$1=<redacted>")
+    .replace(/(https?:\/\/[^:\s]+:)[^@\s]+@/gi, "$1<redacted>@");
+}
+
 function foundryIsRunning() {
   const result = run("foundry", ["service", "status"], { timeout: 15000 });
   const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
@@ -470,7 +476,7 @@ async function pingMisty(env, state, options) {
     if (discovered) {
       env.MISTY_IP = discovered.ipAddress;
       state.misty = discovered;
-      console.log(`Misty robot: reachable at ${discovered.ipAddress} (${discovered.broadcastName})`);
+      console.log("Misty robot: reachable");
       return;
     }
 
@@ -488,9 +494,9 @@ async function pingMisty(env, state, options) {
     }
 
     throw new Error(
-      `Misty robot is not reachable at ${mistyIp}; not starting the controller.\n` +
+      "Misty robot is not reachable; not starting the controller.\n" +
       `Check power, Wi-Fi, pass the correct address with --misty-ip <ip>, or allow network scanning.\n` +
-      `Details: ${error.message}`,
+      `Details: ${redactSensitive(error.message)}`,
     );
   }
 }
@@ -711,6 +717,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error(error.message);
+  console.error(redactSensitive(error.message));
   process.exitCode = 1;
 });

--- a/tools/misty-services.mjs
+++ b/tools/misty-services.mjs
@@ -1,0 +1,716 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import dns from "node:dns/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const ORCH_DIR = path.join(REPO_ROOT, "src", "windows-orchestration");
+const STATE_PATH = path.join(REPO_ROOT, ".misty-services.json");
+const LOG_DIR = path.join(REPO_ROOT, "logs", "services");
+
+const DEFAULTS = {
+  controllerPort: 5001,
+  orchestrationHealthUrl: "http://127.0.0.1:5000/api/health",
+  controllerStatusUrl: "http://127.0.0.1:5001/api/status",
+  mistyIp: "10.0.0.44",
+  chatModelId: "Phi-3.5-mini-instruct-openvino-gpu:2",
+  chatModelAlias: "phi-3.5-mini",
+  modelTtlSeconds: 3600,
+};
+
+function usage() {
+  console.log(`Usage: npx . <command> [options]
+
+Commands:
+  start     Start Foundry Local, orchestration_service.py, and misty_controller.py
+  stop      Gracefully stop the controller, orchestration service, and owned Foundry service
+  restart   Stop then start all services
+  status    Show service status
+
+Options:
+  --skip-foundry          Do not start or stop Foundry Local
+  --skip-model-load       Do not load the chat model into Foundry Local
+  --keep-foundry          Leave Foundry Local running on stop
+  --misty-ip <ip>         Override MISTY_IP for controller and cleanup calls
+  --no-scan               Do not scan local networks when Misty is unreachable
+  --orchestration-url <url>
+                          Override ORCHESTRATION_URL for the controller
+  --controller-port <n>   Override controller API port (default: 5001)
+  --python <command>      Python executable to use (default: python)
+  -h, --help              Show this help
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    command: argv[2] ?? "help",
+    skipFoundry: false,
+    skipModelLoad: false,
+    keepFoundry: false,
+    scan: true,
+    controllerPort: DEFAULTS.controllerPort,
+    python: "python",
+  };
+  if (options.command === "-h" || options.command === "--help") {
+    options.command = "help";
+  }
+
+  for (let index = 3; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--skip-foundry") {
+      options.skipFoundry = true;
+    } else if (arg === "--skip-model-load") {
+      options.skipModelLoad = true;
+    } else if (arg === "--keep-foundry") {
+      options.keepFoundry = true;
+    } else if (arg === "--misty-ip") {
+      options.mistyIp = argv[++index];
+    } else if (arg === "--no-scan") {
+      options.scan = false;
+    } else if (arg === "--orchestration-url") {
+      options.orchestrationUrl = argv[++index];
+    } else if (arg === "--controller-port") {
+      options.controllerPort = Number(argv[++index]);
+    } else if (arg === "--python") {
+      options.python = argv[++index];
+    } else if (arg === "-h" || arg === "--help") {
+      options.command = "help";
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(options.controllerPort) || options.controllerPort < 1 || options.controllerPort > 65535) {
+    throw new Error("--controller-port must be a valid TCP port");
+  }
+
+  return options;
+}
+
+function readDotEnv(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+
+  const env = {};
+  for (const rawLine of fs.readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+
+    const separator = line.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, separator).trim();
+    let value = line.slice(separator + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+function serviceEnv(options, state = {}) {
+  const env = {
+    ...process.env,
+    ...readDotEnv(path.join(ORCH_DIR, ".env")),
+  };
+
+  if (options.mistyIp) {
+    env.MISTY_IP = options.mistyIp;
+  } else if (!env.MISTY_IP && state.misty?.ipAddress) {
+    env.MISTY_IP = state.misty.ipAddress;
+  }
+  if (options.orchestrationUrl) {
+    env.ORCHESTRATION_URL = options.orchestrationUrl;
+  }
+  env.CONTROLLER_API_PORT = String(options.controllerPort);
+  env.USE_LAPTOP_WAKE_WORD = env.USE_LAPTOP_WAKE_WORD || "true";
+  return env;
+}
+
+function readState() {
+  if (!fs.existsSync(STATE_PATH)) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(STATE_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state) {
+  fs.writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function removeStateIfEmpty(state) {
+  const hasProcess = state.orchestration?.pid || state.controller?.pid || state.foundry?.managed;
+  if (!hasProcess && fs.existsSync(STATE_PATH)) {
+    fs.rmSync(STATE_PATH);
+  } else {
+    writeState(state);
+  }
+}
+
+function isPidRunning(pid) {
+  if (!pid) {
+    return false;
+  }
+
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? REPO_ROOT,
+    env: options.env ?? process.env,
+    encoding: "utf8",
+    timeout: options.timeout ?? 30000,
+    windowsHide: true,
+  });
+
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout?.trim() ?? "",
+    stderr: result.stderr?.trim() ?? "",
+    error: result.error,
+  };
+}
+
+function ensureCommand(command, args) {
+  const result = run(command, args);
+  if (!result.ok) {
+    const details = result.error?.message || result.stderr || result.stdout || `exit code ${result.status}`;
+    throw new Error(`Required command failed: ${command} ${args.join(" ")}\n${details}`);
+  }
+}
+
+function foundryIsRunning() {
+  const result = run("foundry", ["service", "status"], { timeout: 15000 });
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  if (!result.ok || output.includes("not running")) {
+    return false;
+  }
+  return output.includes("running") || output.includes("listening") || output.includes("http");
+}
+
+function startFoundry(state, options) {
+  if (options.skipFoundry) {
+    console.log("Foundry Local: skipped");
+    return;
+  }
+
+  const wasRunning = foundryIsRunning();
+  if (!wasRunning) {
+    console.log("Foundry Local: starting service");
+    const result = run("foundry", ["service", "start"], { timeout: 60000 });
+    if (!result.ok && !foundryIsRunning()) {
+      throw new Error(`Unable to start Foundry Local:\n${result.stderr || result.stdout}`);
+    }
+  } else {
+    console.log("Foundry Local: already running");
+  }
+
+  state.foundry = {
+    managed: !wasRunning,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+function stopFoundry(state, options) {
+  if (options.skipFoundry || options.keepFoundry) {
+    console.log("Foundry Local: left running");
+    return;
+  }
+
+  if (!state.foundry?.managed) {
+    console.log("Foundry Local: not owned by this CLI run; leaving it running");
+    return;
+  }
+
+  console.log("Foundry Local: stopping service");
+  const result = run("foundry", ["service", "stop"], { timeout: 60000 });
+  if (!result.ok) {
+    console.warn(`Foundry Local: stop command reported a problem:\n${result.stderr || result.stdout}`);
+  }
+  delete state.foundry;
+}
+
+function chatModelIsLoaded() {
+  const result = run("foundry", ["service", "ps"], { timeout: 30000 });
+  return result.ok && (
+    result.stdout.includes(DEFAULTS.chatModelId)
+    || result.stdout.includes(DEFAULTS.chatModelAlias)
+  );
+}
+
+function loadChatModel(state, options) {
+  if (options.skipFoundry || options.skipModelLoad) {
+    console.log("Foundry chat model: skipped");
+    return;
+  }
+
+  if (chatModelIsLoaded()) {
+    console.log(`Foundry chat model: already loaded (${DEFAULTS.chatModelAlias})`);
+    state.chatModel = {
+      alias: DEFAULTS.chatModelAlias,
+      modelId: DEFAULTS.chatModelId,
+      loadedAt: state.chatModel?.loadedAt || new Date().toISOString(),
+    };
+    return;
+  }
+
+  console.log(`Foundry chat model: loading ${DEFAULTS.chatModelAlias}`);
+  const result = run("foundry", [
+    "model",
+    "load",
+    DEFAULTS.chatModelId,
+    "--ttl",
+    String(DEFAULTS.modelTtlSeconds),
+  ], { timeout: 180000 });
+
+  if (!result.ok && !chatModelIsLoaded()) {
+    throw new Error(`Unable to load Foundry chat model:\n${result.stderr || result.stdout}`);
+  }
+
+  state.chatModel = {
+    alias: DEFAULTS.chatModelAlias,
+    modelId: DEFAULTS.chatModelId,
+    ttlSeconds: DEFAULTS.modelTtlSeconds,
+    loadedAt: new Date().toISOString(),
+  };
+}
+
+function httpRequest(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const request = http.request(url, {
+      method: options.method ?? "GET",
+      timeout: options.timeoutMs ?? 3000,
+      headers: options.headers ?? {},
+    }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.on("end", () => {
+        resolve({ statusCode: response.statusCode ?? 0, body });
+      });
+    });
+
+    request.on("timeout", () => {
+      request.destroy(new Error(`Timed out requesting ${url}`));
+    });
+    request.on("error", reject);
+    if (options.body) {
+      request.write(options.body);
+    }
+    request.end();
+  });
+}
+
+async function waitForHttp(url, acceptedStatusCodes, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await httpRequest(url, { timeoutMs: 3000 });
+      if (acceptedStatusCodes.includes(response.statusCode)) {
+        return response;
+      }
+      lastError = `HTTP ${response.statusCode}`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`${label} did not become ready within ${Math.round(timeoutMs / 1000)}s (${lastError})`);
+}
+
+function parseJsonObject(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function isMistyDevice(payload) {
+  const result = payload?.result;
+  return payload?.status === "Success"
+    && typeof result?.robotId === "string"
+    && typeof result?.robotVersion === "string"
+    && typeof result?.serialNumber === "string";
+}
+
+function getPrivateIpv4Prefixes() {
+  const prefixes = new Set();
+  for (const adapter of Object.values(os.networkInterfaces())) {
+    for (const address of adapter ?? []) {
+      if (address.family !== "IPv4" || address.internal) {
+        continue;
+      }
+
+      const octets = address.address.split(".").map(Number);
+      const isPrivate = octets[0] === 10
+        || (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+        || (octets[0] === 192 && octets[1] === 168);
+      if (isPrivate) {
+        prefixes.add(octets.slice(0, 3).join("."));
+      }
+    }
+  }
+  return [...prefixes];
+}
+
+async function reverseName(ipAddress) {
+  try {
+    const names = await dns.reverse(ipAddress);
+    return names[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function mistyIdentity(ipAddress, payload, broadcastName) {
+  const result = payload.result;
+  const macSuffix = (result.macAddress || "").split(":").slice(-3).join("").toUpperCase();
+  const fallbackName = result.serialNumber ? `misty-${result.serialNumber}` : `misty-${macSuffix || ipAddress}`;
+  return {
+    ipAddress: result.ipAddress || ipAddress,
+    broadcastName: broadcastName || fallbackName,
+    serialNumber: result.serialNumber || null,
+    macAddress: result.macAddress || null,
+    robotId: result.robotId || null,
+    robotVersion: result.robotVersion || null,
+    networkProfileName: result.currentProfileName || null,
+    discoveredAt: new Date().toISOString(),
+  };
+}
+
+async function probeMisty(ipAddress, timeoutMs = 1500) {
+  const response = await httpRequest(`http://${ipAddress}/api/device`, { timeoutMs });
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    return null;
+  }
+
+  const payload = parseJsonObject(response.body);
+  if (!isMistyDevice(payload)) {
+    return null;
+  }
+
+  return mistyIdentity(ipAddress, payload, await reverseName(ipAddress));
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = [];
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await mapper(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+async function scanForMisty() {
+  const prefixes = getPrivateIpv4Prefixes();
+  if (prefixes.length === 0) {
+    return null;
+  }
+
+  console.log(`Misty robot: scanning ${prefixes.map((prefix) => `${prefix}.0/24`).join(", ")}`);
+  const addresses = prefixes.flatMap((prefix) => (
+    Array.from({ length: 254 }, (_, index) => `${prefix}.${index + 1}`)
+  ));
+
+  const matches = (await mapWithConcurrency(addresses, 96, async (ipAddress) => {
+    try {
+      return await probeMisty(ipAddress);
+    } catch {
+      return null;
+    }
+  })).filter(Boolean);
+
+  return matches[0] || null;
+}
+
+async function pingMisty(env, state, options) {
+  const mistyIp = env.MISTY_IP || state.misty?.ipAddress || DEFAULTS.mistyIp;
+  const deviceUrl = `http://${mistyIp}/api/device`;
+
+  try {
+    const discovered = await probeMisty(mistyIp, 5000);
+    if (discovered) {
+      env.MISTY_IP = discovered.ipAddress;
+      state.misty = discovered;
+      console.log(`Misty robot: reachable at ${discovered.ipAddress} (${discovered.broadcastName})`);
+      return;
+    }
+
+    const response = await httpRequest(deviceUrl, { timeoutMs: 5000 });
+    throw new Error(`HTTP ${response.statusCode}`);
+  } catch (error) {
+    if (options.scan) {
+      const discovered = await scanForMisty();
+      if (discovered) {
+        env.MISTY_IP = discovered.ipAddress;
+        state.misty = discovered;
+        console.log(`Misty robot: discovered at ${discovered.ipAddress} (${discovered.broadcastName})`);
+        return;
+      }
+    }
+
+    throw new Error(
+      `Misty robot is not reachable at ${mistyIp}; not starting the controller.\n` +
+      `Check power, Wi-Fi, pass the correct address with --misty-ip <ip>, or allow network scanning.\n` +
+      `Details: ${error.message}`,
+    );
+  }
+}
+
+function spawnService(name, command, args, cwd, env) {
+  fs.mkdirSync(LOG_DIR, { recursive: true });
+  const stdoutPath = path.join(LOG_DIR, `${name}.log`);
+  const stderrPath = path.join(LOG_DIR, `${name}.err.log`);
+  const stdout = fs.openSync(stdoutPath, "a");
+  const stderr = fs.openSync(stderrPath, "a");
+
+  const child = spawn(command, args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: ["ignore", stdout, stderr],
+    windowsHide: false,
+  });
+
+  child.unref();
+  return {
+    pid: child.pid,
+    command: [command, ...args].join(" "),
+    cwd,
+    stdoutPath,
+    stderrPath,
+    startedAt: new Date().toISOString(),
+  };
+}
+
+async function start(options) {
+  ensureCommand(options.python, ["--version"]);
+  if (!options.skipFoundry) {
+    ensureCommand("foundry", ["--version"]);
+  }
+
+  const state = readState();
+  const env = serviceEnv(options, state);
+  state.version = 1;
+  state.startedAt = state.startedAt || new Date().toISOString();
+
+  startFoundry(state, options);
+  loadChatModel(state, options);
+
+  const orchestrationAlreadyRunning = await httpRequest(DEFAULTS.orchestrationHealthUrl, { timeoutMs: 1500 })
+    .then((response) => [200, 503].includes(response.statusCode))
+    .catch(() => false);
+  if (orchestrationAlreadyRunning) {
+    console.log("Orchestration service: already running");
+  } else {
+    console.log("Orchestration service: starting");
+    state.orchestration = spawnService(
+      "orchestration",
+      options.python,
+      ["orchestration_service.py"],
+      ORCH_DIR,
+      env,
+    );
+    writeState(state);
+    await waitForHttp(DEFAULTS.orchestrationHealthUrl, [200, 503], 180000, "Orchestration service");
+  }
+
+  const controllerStatusUrl = `http://127.0.0.1:${options.controllerPort}/api/status`;
+  const controllerAlreadyRunning = await httpRequest(controllerStatusUrl, { timeoutMs: 1500 })
+    .then((response) => response.statusCode === 200)
+    .catch(() => false);
+  if (controllerAlreadyRunning) {
+    console.log("Misty controller: already running");
+  } else {
+    await pingMisty(env, state, options);
+    console.log("Misty controller: starting");
+    state.controller = spawnService(
+      "misty-controller",
+      options.python,
+      ["misty_controller.py"],
+      ORCH_DIR,
+      env,
+    );
+    state.controller.port = options.controllerPort;
+    writeState(state);
+    await waitForHttp(controllerStatusUrl, [200], 90000, "Misty controller");
+  }
+
+  writeState(state);
+  console.log("Misty services are running");
+}
+
+async function gracefulControllerShutdown(state, options) {
+  const port = state.controller?.port ?? options.controllerPort;
+  const shutdownUrl = `http://127.0.0.1:${port}/api/shutdown`;
+  try {
+    const response = await httpRequest(shutdownUrl, { method: "POST", timeoutMs: 3000 });
+    if (response.statusCode === 200) {
+      console.log("Misty controller: graceful shutdown requested");
+    } else {
+      console.warn(`Misty controller: shutdown endpoint returned HTTP ${response.statusCode}`);
+    }
+  } catch (error) {
+    console.warn(`Misty controller: shutdown endpoint unavailable (${error.message})`);
+  }
+}
+
+async function waitForPidExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidRunning(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  return !isPidRunning(pid);
+}
+
+async function stopPid(label, pid, gracefulSignal = "SIGTERM") {
+  if (!pid || !isPidRunning(pid)) {
+    console.log(`${label}: not running`);
+    return;
+  }
+
+  try {
+    process.kill(pid, gracefulSignal);
+  } catch (error) {
+    console.warn(`${label}: failed to send ${gracefulSignal} to PID ${pid}: ${error.message}`);
+  }
+
+  if (await waitForPidExit(pid, 10000)) {
+    console.log(`${label}: stopped`);
+    return;
+  }
+
+  process.kill(pid, "SIGKILL");
+  console.log(`${label}: force-stopped`);
+}
+
+async function cleanupMisty(env) {
+  const mistyIp = env.MISTY_IP;
+  if (!mistyIp) {
+    return;
+  }
+
+  const baseUrl = `http://${mistyIp}`;
+  const calls = [
+    ["POST", "/api/audio/keyphrase/stop", undefined],
+    ["POST", "/api/audio/record/stop", undefined],
+    ["POST", "/api/skills/cancel", undefined],
+    ["POST", "/api/led", JSON.stringify({ red: 0, green: 0, blue: 0 })],
+  ];
+
+  for (const [method, endpoint, body] of calls) {
+    try {
+      await httpRequest(`${baseUrl}${endpoint}`, {
+        method,
+        body,
+        timeoutMs: 2500,
+        headers: body ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body) } : {},
+      });
+    } catch (error) {
+      console.warn(`Misty cleanup ${endpoint}: ${error.message}`);
+    }
+  }
+}
+
+async function stop(options) {
+  const state = readState();
+  const env = serviceEnv(options, state);
+
+  await gracefulControllerShutdown(state, options);
+  await waitForPidExit(state.controller?.pid, 10000);
+  await cleanupMisty(env);
+  await stopPid("Misty controller", state.controller?.pid, "SIGTERM");
+  delete state.controller;
+
+  await stopPid("Orchestration service", state.orchestration?.pid, "SIGTERM");
+  delete state.orchestration;
+
+  stopFoundry(state, options);
+  removeStateIfEmpty(state);
+  console.log("Misty services are stopped");
+}
+
+async function status(options) {
+  const state = readState();
+  const orchestration = await httpRequest(DEFAULTS.orchestrationHealthUrl, { timeoutMs: 1500 })
+    .then((response) => [200, 503].includes(response.statusCode) ? `running (HTTP ${response.statusCode})` : `unexpected HTTP ${response.statusCode}`)
+    .catch(() => "not reachable");
+  const controller = await httpRequest(`http://127.0.0.1:${options.controllerPort}/api/status`, { timeoutMs: 1500 })
+    .then((response) => response.statusCode === 200 ? "running" : `unexpected HTTP ${response.statusCode}`)
+    .catch(() => "not reachable");
+  const foundry = options.skipFoundry ? "skipped" : foundryIsRunning() ? "running" : "not running";
+
+  console.log(`Foundry Local: ${foundry}`);
+  console.log(`Orchestration service: ${orchestration}${state.orchestration?.pid ? ` (PID ${state.orchestration.pid})` : ""}`);
+  console.log(`Misty controller: ${controller}${state.controller?.pid ? ` (PID ${state.controller.pid})` : ""}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  switch (options.command) {
+    case "start":
+      await start(options);
+      break;
+    case "stop":
+      await stop(options);
+      break;
+    case "restart":
+      await stop(options);
+      await start(options);
+      break;
+    case "status":
+      await status(options);
+      break;
+    case "help":
+      usage();
+      break;
+    default:
+      throw new Error(`Unknown command: ${options.command}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add `npx . start|stop|restart|status` for the local Misty companion stack
- Start/verify Foundry Local, preload Phi-3.5-mini, start orchestration, discover/cache Misty's IP, and start the controller
- Add a controller `/api/shutdown` endpoint for graceful CLI stop
- Refresh wake-word test docs/instructions for laptop OpenWakeWord and the pending Hey Misty model artifact work

## Verification
- `node --check tools\misty-services.mjs`
- `npx . --help`
- `npx . status --skip-foundry`
- `python -m py_compile src\windows-orchestration\misty_controller.py`
- `python -m pytest tests\test_integration.py::TestWakeWordConfiguration -q`
- `git diff --check`

## Notes
- Follow-up #96 tracks the missing trained `hey_misty.onnx` artifact and live custom wake-word verification.