### PR TITLE
feat: FaceAnimator — state-driven animated face expressions (Phase 2, #104)

### DIFF
--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -78,3 +78,12 @@ MAX_CONTEXT_CHARS=5000
 USE_FACE_RECOGNITION=false
 # Timeout in seconds for face recognition attempt during each conversation turn.
 FACE_RECOGNITION_TIMEOUT_S=3.0
+
+# Face Animation (#73)
+# Enable state-driven animated face expressions. When false, face behaves exactly
+# as before (single static image per state). When true, FaceAnimator loops frames.
+USE_FACE_ANIMATION=false
+# Maximum frames per second for animation (hardware-validated safe limit).
+FACE_ANIMATION_MAX_FPS=4.0
+# Minimum seconds between REST frame pushes (rate-limit guard).
+FACE_ANIMATION_MIN_INTERVAL_S=0.25

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -67,3 +67,8 @@ LAPTOP_MISTY_TALLY_RECORDING_S: float = 1.0
 
 # Face recognition (issue #16)
 FACE_RECOGNITION_TIMEOUT_S: float = 3.0
+
+# Face animation (issue #73, Phase 2)
+USE_FACE_ANIMATION: bool = False
+FACE_ANIMATION_MAX_FPS: float = 4.0
+FACE_ANIMATION_MIN_INTERVAL_S: float = 0.25

--- a/src/windows-orchestration/face_animator.py
+++ b/src/windows-orchestration/face_animator.py
@@ -1,0 +1,296 @@
+"""
+State-driven face animation for Misty II.
+
+Provides a FaceAnimator class that maps controller states to animated
+face expressions. Runs a single daemon thread that pushes frames to
+Misty's display via REST at a configurable FPS.
+
+Design: docs/design-animated-face-expressions.md §5
+Phase 1 validation: tools/face_display_probe.py (max ~10 FPS, 4 FPS recommended)
+
+Usage:
+    animator = FaceAnimator(misty_base_url, enabled=True)
+    animator.start()
+    animator.set_state(State.IDLE)       # non-blocking
+    animator.set_state(State.LISTENING)  # switches immediately
+    animator.stop()                      # bounded join
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+# Re-declare State locally to avoid circular import with misty_controller.
+# The animator accepts any enum with matching .value strings.
+class AnimationState(Enum):
+    """Animation states that map to controller states."""
+    DISCONNECTED = "DISCONNECTED"
+    IDLE = "IDLE"
+    RECORDING = "RECORDING"
+    PROCESSING = "PROCESSING"
+    PLAYING = "PLAYING"
+    LISTENING = "LISTENING"
+    MOVING = "MOVING"
+    REARMING = "REARMING"
+    REBOOTING = "REBOOTING"
+    CHARGING = "CHARGING"
+    ERROR = "ERROR"
+
+
+@dataclass(frozen=True)
+class AnimationSpec:
+    """Defines how a state's face animation behaves.
+
+    Attributes:
+        frames: Ordered tuple of Misty image filenames. Length >= 1.
+        fps: Target frames per second (clamped to max_fps at runtime).
+        loop: If True, loop frames continuously. If False, play once and hold last.
+        static_fallback: Single image used when animation is disabled or fails.
+    """
+    frames: tuple
+    fps: float = 1.0
+    loop: bool = True
+    static_fallback: str = ""
+
+    @property
+    def is_single_frame(self) -> bool:
+        return len(self.frames) <= 1
+
+
+# Default animation specs — single-frame to match today's behavior.
+# Multi-frame animations will be added in Phase 3 after tuning.
+DEFAULT_ANIMATION_MAP: dict[str, AnimationSpec] = {
+    "DISCONNECTED": AnimationSpec(
+        frames=("e_Sadness.jpg",),
+        static_fallback="e_Sadness.jpg",
+    ),
+    "IDLE": AnimationSpec(
+        frames=("e_DefaultContent.jpg",),
+        fps=0.5,
+        static_fallback="e_DefaultContent.jpg",
+    ),
+    "RECORDING": AnimationSpec(
+        frames=("e_Admiration.jpg",),
+        static_fallback="e_Admiration.jpg",
+    ),
+    "PROCESSING": AnimationSpec(
+        frames=("e_Contempt.jpg",),
+        static_fallback="e_Contempt.jpg",
+    ),
+    "PLAYING": AnimationSpec(
+        frames=("e_EcstacyHilarious.jpg",),
+        static_fallback="e_EcstacyHilarious.jpg",
+    ),
+    "LISTENING": AnimationSpec(
+        frames=("e_Joy.jpg",),
+        static_fallback="e_Joy.jpg",
+    ),
+    "MOVING": AnimationSpec(
+        frames=("e_Joy2.jpg",),
+        static_fallback="e_Joy2.jpg",
+    ),
+    "REARMING": AnimationSpec(
+        frames=("e_DefaultContent.jpg",),
+        static_fallback="e_DefaultContent.jpg",
+    ),
+    "REBOOTING": AnimationSpec(
+        frames=("e_ContentLeft.jpg",),
+        static_fallback="e_ContentLeft.jpg",
+    ),
+    "CHARGING": AnimationSpec(
+        frames=("e_Sleeping.jpg",),
+        static_fallback="e_Sleeping.jpg",
+    ),
+    "ERROR": AnimationSpec(
+        frames=("e_Sadness.jpg",),
+        static_fallback="e_Sadness.jpg",
+    ),
+}
+
+
+class FaceAnimator:
+    """Companion-side face animation driver for Misty II.
+
+    Runs a single daemon thread that pushes display frames to Misty via REST.
+    The controller interacts only through set_state() (non-blocking) and
+    stop() (bounded join). The animator never touches audio, LED, motors,
+    or keyphrase endpoints.
+
+    Args:
+        misty_base_url: Base URL for Misty REST API (e.g., "http://10.0.0.23").
+        enabled: If False, set_state() pushes static_fallback only (no looping).
+        max_fps: Upper bound on animation FPS (from hardware validation).
+        min_interval_s: Minimum seconds between REST frame pushes (rate limit).
+        animation_map: State-to-AnimationSpec mapping. Defaults to single-frame.
+    """
+
+    STOP_TIMEOUT_S = 3.0  # max seconds to wait for thread join on stop()
+
+    def __init__(
+        self,
+        misty_base_url: str,
+        enabled: bool = False,
+        max_fps: float = 4.0,
+        min_interval_s: float = 0.25,
+        animation_map: Optional[dict[str, AnimationSpec]] = None,
+    ):
+        self._base_url = misty_base_url.rstrip("/")
+        self._enabled = enabled
+        self._max_fps = max_fps
+        self._min_interval_s = min_interval_s
+        self._animation_map = animation_map or DEFAULT_ANIMATION_MAP
+
+        self._lock = threading.Lock()
+        self._state_changed = threading.Event()
+        self._target_state: Optional[str] = None
+        self._running = False
+        self._thread: Optional[threading.Thread] = None
+        self._last_displayed: Optional[str] = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def is_running(self) -> bool:
+        return self._running and self._thread is not None and self._thread.is_alive()
+
+    def start(self):
+        """Start the animation thread."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._animation_loop,
+            name="FaceAnimator",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(f"FaceAnimator started (enabled={self._enabled}, max_fps={self._max_fps})")
+
+    def stop(self):
+        """Stop the animation thread with bounded timeout."""
+        self._running = False
+        self._state_changed.set()  # wake the thread if sleeping
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=self.STOP_TIMEOUT_S)
+            if self._thread.is_alive():
+                logger.warning("FaceAnimator thread did not stop within timeout")
+        self._thread = None
+        logger.info("FaceAnimator stopped")
+
+    def set_state(self, state) -> None:
+        """Update the target animation state. Non-blocking.
+
+        Args:
+            state: A State enum value or string matching a key in animation_map.
+        """
+        # Accept both enum and string
+        state_key = state.value if hasattr(state, "value") else str(state)
+
+        with self._lock:
+            if self._target_state == state_key:
+                return  # no change
+            self._target_state = state_key
+
+        # If animation is disabled, push static fallback immediately
+        if not self._enabled:
+            spec = self._animation_map.get(state_key)
+            if spec and spec.static_fallback:
+                self._push_frame(spec.static_fallback)
+            return
+
+        # Wake the animation thread to switch states
+        self._state_changed.set()
+
+    def _animation_loop(self):
+        """Main animation thread loop."""
+        current_state: Optional[str] = None
+        frame_idx = 0
+
+        while self._running:
+            # Check for state change
+            with self._lock:
+                new_state = self._target_state
+
+            if new_state != current_state:
+                current_state = new_state
+                frame_idx = 0
+                self._state_changed.clear()
+
+            if current_state is None:
+                # No state set yet — wait for one
+                self._state_changed.wait(timeout=1.0)
+                continue
+
+            spec = self._animation_map.get(current_state)
+            if spec is None:
+                # Unknown state — wait for next change
+                self._state_changed.wait(timeout=1.0)
+                continue
+
+            # Single-frame: push once and wait for state change
+            if spec.is_single_frame:
+                frame = spec.frames[0]
+                if self._last_displayed != frame:
+                    self._push_frame(frame)
+                self._state_changed.wait(timeout=5.0)
+                self._state_changed.clear()
+                continue
+
+            # Multi-frame animation
+            if frame_idx >= len(spec.frames):
+                if spec.loop:
+                    frame_idx = 0
+                else:
+                    # Hold last frame, wait for state change
+                    self._state_changed.wait(timeout=5.0)
+                    self._state_changed.clear()
+                    continue
+
+            frame = spec.frames[frame_idx]
+            self._push_frame(frame)
+            frame_idx += 1
+
+            # Sleep for the frame interval (clamped to min_interval)
+            clamped_fps = min(spec.fps, self._max_fps)
+            interval = max(1.0 / clamped_fps, self._min_interval_s)
+
+            # Interruptible sleep — wake on state change
+            self._state_changed.wait(timeout=interval)
+            if self._state_changed.is_set():
+                self._state_changed.clear()
+
+    def _push_frame(self, filename: str) -> bool:
+        """Push a single display frame to Misty. Best-effort, never raises.
+
+        Uses a short timeout and logs failures at debug level only.
+        Returns True on success, False on failure.
+        """
+        if self._last_displayed == filename:
+            return True  # already showing this frame
+
+        url = f"{self._base_url}/api/images/display"
+        try:
+            resp = requests.post(
+                url,
+                json={"FileName": filename, "Alpha": 1},
+                timeout=self._min_interval_s + 0.5,
+            )
+            if resp.status_code == 200:
+                self._last_displayed = filename
+                return True
+            else:
+                logger.debug(f"FaceAnimator frame push HTTP {resp.status_code}: {filename}")
+                return False
+        except Exception as e:
+            logger.debug(f"FaceAnimator frame push failed: {filename} — {e}")
+            return False

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -67,6 +67,11 @@ LAPTOP_MISTY_TALLY_RECORDING_S = float(os.getenv("LAPTOP_MISTY_TALLY_RECORDING_S
 USE_FACE_RECOGNITION = os.getenv("USE_FACE_RECOGNITION", "").lower() in ("1", "true", "yes")
 FACE_RECOGNITION_TIMEOUT_S = float(os.getenv("FACE_RECOGNITION_TIMEOUT_S", str(config_defaults.FACE_RECOGNITION_TIMEOUT_S)))
 
+# Face animation (#73) — state-driven animated expressions
+USE_FACE_ANIMATION = os.getenv("USE_FACE_ANIMATION", "").lower() in ("1", "true", "yes")
+FACE_ANIMATION_MAX_FPS = float(os.getenv("FACE_ANIMATION_MAX_FPS", str(config_defaults.FACE_ANIMATION_MAX_FPS)))
+FACE_ANIMATION_MIN_INTERVAL_S = float(os.getenv("FACE_ANIMATION_MIN_INTERVAL_S", str(config_defaults.FACE_ANIMATION_MIN_INTERVAL_S)))
+
 # Keyphrase watchdog — detects silent failures and auto-recovers
 WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", str(config_defaults.WATCHDOG_IDLE_TIMEOUT_S)))  # 90s after rearm with no wake event
 WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", str(config_defaults.WATCHDOG_ESCALATE_TIMEOUT_S)))  # 60s after recovery attempt
@@ -267,6 +272,18 @@ class MistyController:
         self._face_event_name: str | None = None  # WebSocket event name for face recognition
         self._trained_faces: list[str] = []  # cached list of trained face IDs
 
+        # Face animation (#73) — state-driven animated expressions
+        self._face_animator = None
+        if USE_FACE_ANIMATION:
+            from face_animator import FaceAnimator
+            self._face_animator = FaceAnimator(
+                misty_base_url=MISTY_BASE,
+                enabled=True,
+                max_fps=FACE_ANIMATION_MAX_FPS,
+                min_interval_s=FACE_ANIMATION_MIN_INTERVAL_S,
+            )
+            self._face_animator.start()
+
     # --- State transitions ---
 
     def set_state(self, new_state: State):
@@ -275,6 +292,8 @@ class MistyController:
             self.state = new_state
         if old != new_state:
             logger.info(f"State: {old.value} -> {new_state.value}")
+            if self._face_animator:
+                self._face_animator.set_state(new_state)
 
     def try_set_state(self, expected: State, new_state: State) -> bool:
         """Atomic compare-and-swap for state transitions. Returns True if successful."""
@@ -283,6 +302,8 @@ class MistyController:
                 old = self.state
                 self.state = new_state
                 logger.info(f"State: {old.value} -> {new_state.value}")
+                if self._face_animator:
+                    self._face_animator.set_state(new_state)
                 return True
             return False
 
@@ -1458,6 +1479,9 @@ class MistyController:
             return  # Already shut down
         logger.info("Shutting down...")
         self.running = False
+        # Stop face animator first (§6.3 — before existing cleanup sequence)
+        if self._face_animator:
+            self._face_animator.stop()
         # Stop laptop wake word listener
         if self._wake_word_listener:
             self._wake_word_listener.stop()

--- a/tests/test_face_animator.py
+++ b/tests/test_face_animator.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for FaceAnimator.
+
+Tests the animation engine in isolation with mocked REST calls.
+Validates threading behavior, state transitions, disable-regression contract,
+and the safety guarantees from docs/design-animated-face-expressions.md §6.
+"""
+
+import sys
+import os
+import time
+import threading
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Add source directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration"))
+
+from face_animator import FaceAnimator, AnimationSpec, DEFAULT_ANIMATION_MAP
+
+
+class TestAnimationSpec:
+    """Test AnimationSpec dataclass behavior."""
+
+    def test_single_frame_detection(self):
+        spec = AnimationSpec(frames=("e_Joy.jpg",))
+        assert spec.is_single_frame is True
+
+    def test_multi_frame_detection(self):
+        spec = AnimationSpec(frames=("e_Joy.jpg", "e_Sadness.jpg"))
+        assert spec.is_single_frame is False
+
+    def test_frozen_immutable(self):
+        spec = AnimationSpec(frames=("e_Joy.jpg",), fps=2.0)
+        with pytest.raises(Exception):
+            spec.fps = 3.0
+
+    def test_default_values(self):
+        spec = AnimationSpec(frames=("e_Joy.jpg",))
+        assert spec.fps == 1.0
+        assert spec.loop is True
+        assert spec.static_fallback == ""
+
+
+class TestFaceAnimatorDisabled:
+    """Tests with animation disabled (USE_FACE_ANIMATION=false equivalent)."""
+
+    @patch("face_animator.requests.post")
+    def test_set_state_pushes_static_fallback(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.1)
+
+        # Should push the static fallback image
+        mock_post.assert_called_with(
+            "http://10.0.0.23/api/images/display",
+            json={"FileName": "e_DefaultContent.jpg", "Alpha": 1},
+            timeout=pytest.approx(0.75, abs=0.1),
+        )
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_disabled_no_animation_loop(self, mock_post):
+        """When disabled, no continuous frame pushing happens."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.5)
+
+        # Should only push once (static fallback), not loop
+        call_count = mock_post.call_count
+        assert call_count == 1, f"Expected 1 call, got {call_count}"
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_disabled_state_change_pushes_new_fallback(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.1)
+        animator.set_state("PROCESSING")
+        time.sleep(0.1)
+
+        # Should have pushed two different images
+        calls = mock_post.call_args_list
+        filenames = [c.kwargs["json"]["FileName"] for c in calls]
+        assert "e_DefaultContent.jpg" in filenames
+        assert "e_Contempt.jpg" in filenames
+        animator.stop()
+
+
+class TestFaceAnimatorEnabled:
+    """Tests with animation enabled."""
+
+    @patch("face_animator.requests.post")
+    def test_single_frame_pushes_once(self, mock_post):
+        """Single-frame specs push once and wait (no repeated calls)."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=True, max_fps=4.0)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.5)
+
+        # Single-frame: push once, then idle
+        assert mock_post.call_count == 1
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_multi_frame_loops(self, mock_post):
+        """Multi-frame specs loop frames at configured FPS."""
+        mock_post.return_value = MagicMock(status_code=200)
+
+        custom_map = {
+            "IDLE": AnimationSpec(
+                frames=("e_DefaultContent.jpg", "e_ContentLeft.jpg", "e_ContentRight.jpg"),
+                fps=4.0,
+                loop=True,
+                static_fallback="e_DefaultContent.jpg",
+            ),
+        }
+        animator = FaceAnimator(
+            "http://10.0.0.23", enabled=True, max_fps=4.0,
+            min_interval_s=0.25, animation_map=custom_map,
+        )
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(1.5)  # At 4 FPS, should get ~6 frames in 1.5s
+
+        assert mock_post.call_count >= 4  # At least several frames
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_state_change_resets_frame_index(self, mock_post):
+        """Changing state starts new animation from frame 0."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=True)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.2)
+        animator.set_state("PROCESSING")
+        time.sleep(0.2)
+
+        # Verify both states' images were pushed
+        calls = mock_post.call_args_list
+        filenames = [c.kwargs["json"]["FileName"] for c in calls]
+        assert "e_DefaultContent.jpg" in filenames
+        assert "e_Contempt.jpg" in filenames
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_same_state_no_duplicate_push(self, mock_post):
+        """Setting same state twice doesn't trigger extra push."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=True)
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(0.2)
+        call_count_1 = mock_post.call_count
+
+        animator.set_state("IDLE")  # same state again
+        time.sleep(0.2)
+        call_count_2 = mock_post.call_count
+
+        assert call_count_2 == call_count_1  # no extra push
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_fps_clamped_to_max(self, mock_post):
+        """FPS is clamped to max_fps regardless of spec."""
+        mock_post.return_value = MagicMock(status_code=200)
+
+        custom_map = {
+            "IDLE": AnimationSpec(
+                frames=("a.jpg", "b.jpg"),
+                fps=100.0,  # absurdly high
+                static_fallback="a.jpg",
+            ),
+        }
+        animator = FaceAnimator(
+            "http://10.0.0.23", enabled=True, max_fps=2.0,
+            min_interval_s=0.25, animation_map=custom_map,
+        )
+        animator.start()
+
+        animator.set_state("IDLE")
+        time.sleep(1.0)
+
+        # At max 2 FPS (but min_interval 0.25s), should be ~4 calls max in 1s
+        assert mock_post.call_count <= 6
+        animator.stop()
+
+
+class TestFaceAnimatorThreadSafety:
+    """Tests for threading and lifecycle."""
+
+    @patch("face_animator.requests.post")
+    def test_stop_joins_within_timeout(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=True)
+        animator.start()
+        animator.set_state("IDLE")
+        time.sleep(0.1)
+
+        t0 = time.perf_counter()
+        animator.stop()
+        elapsed = time.perf_counter() - t0
+
+        assert elapsed < FaceAnimator.STOP_TIMEOUT_S + 0.5
+        assert not animator.is_running
+
+    @patch("face_animator.requests.post")
+    def test_start_idempotent(self, mock_post):
+        """Calling start() twice doesn't create extra threads."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=True)
+        animator.start()
+        thread1 = animator._thread
+        animator.start()  # second call
+        thread2 = animator._thread
+
+        assert thread1 is thread2
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_accepts_enum_state(self, mock_post):
+        """set_state accepts enum values (like controller's State)."""
+        mock_post.return_value = MagicMock(status_code=200)
+        from face_animator import AnimationState
+        animator = FaceAnimator("http://10.0.0.23", enabled=True)
+        animator.start()
+
+        animator.set_state(AnimationState.IDLE)
+        time.sleep(0.2)
+
+        assert mock_post.call_count >= 1
+        animator.stop()
+
+    @patch("face_animator.requests.post")
+    def test_frame_push_failure_continues_loop(self, mock_post):
+        """REST failures don't crash the animation thread."""
+        mock_post.side_effect = Exception("Connection refused")
+
+        custom_map = {
+            "IDLE": AnimationSpec(
+                frames=("a.jpg", "b.jpg"),
+                fps=4.0,
+                static_fallback="a.jpg",
+            ),
+        }
+        animator = FaceAnimator(
+            "http://10.0.0.23", enabled=True, max_fps=4.0,
+            min_interval_s=0.25, animation_map=custom_map,
+        )
+        animator.start()
+        animator.set_state("IDLE")
+        time.sleep(1.0)
+
+        # Thread should still be alive despite failures
+        assert animator.is_running
+        animator.stop()
+
+
+class TestDefaultAnimationMap:
+    """Validate the default animation map covers all states."""
+
+    def test_all_states_mapped(self):
+        from face_animator import AnimationState
+        for state in AnimationState:
+            assert state.value in DEFAULT_ANIMATION_MAP, (
+                f"State {state.value} missing from DEFAULT_ANIMATION_MAP"
+            )
+
+    def test_all_specs_have_fallback(self):
+        for state_key, spec in DEFAULT_ANIMATION_MAP.items():
+            assert spec.static_fallback, (
+                f"State {state_key} has no static_fallback"
+            )
+
+    def test_all_initial_specs_are_single_frame(self):
+        """Phase 2 requirement: initial specs match today's single-image behavior."""
+        for state_key, spec in DEFAULT_ANIMATION_MAP.items():
+            assert spec.is_single_frame, (
+                f"State {state_key} should be single-frame in Phase 2 (got {len(spec.frames)} frames)"
+            )
+
+
+class TestDisableRegression:
+    """
+    Disable-regression test (§6.4): with USE_FACE_ANIMATION=false,
+    the controller's display behavior must be identical to pre-animation.
+    """
+
+    @patch("face_animator.requests.post")
+    def test_disabled_animator_only_pushes_on_state_change(self, mock_post):
+        """Disabled animator pushes static images only on state transitions."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.start()
+
+        # Simulate a typical conversation flow
+        states = ["IDLE", "RECORDING", "PROCESSING", "PLAYING", "LISTENING", "IDLE"]
+        for s in states:
+            animator.set_state(s)
+            time.sleep(0.05)
+
+        time.sleep(0.2)
+
+        # Should have exactly one push per unique consecutive state
+        calls = mock_post.call_args_list
+        filenames = [c.kwargs["json"]["FileName"] for c in calls]
+
+        expected = [
+            "e_DefaultContent.jpg",  # IDLE
+            "e_Admiration.jpg",      # RECORDING
+            "e_Contempt.jpg",        # PROCESSING
+            "e_EcstacyHilarious.jpg",  # PLAYING
+            "e_Joy.jpg",             # LISTENING
+            "e_DefaultContent.jpg",  # IDLE (back)
+        ]
+        assert filenames == expected
+        animator.stop()


### PR DESCRIPTION
## Summary

Implements the FaceAnimator class from docs/design-animated-face-expressions.md §5 and wires it into the controller. This is **Phase 2** of the animated face rollout.

## What's included

### src/windows-orchestration/face_animator.py (new)
- FaceAnimator class with a single daemon thread
- AnimationSpec dataclass (frames, fps, loop, static_fallback)
- Default animation map: single-frame specs matching today's exact static behavior
- set_state(state) — non-blocking, accepts enum or string
- stop() — bounded join within 3s
- Best-effort REST frame pushes (debug-level log on failure, never blocks)

### Controller integration
- Animator notified on every set_state() / 	ry_set_state() transition
- Stopped **before** shutdown cleanup (§6.3 safety contract preserved)
- Fully gated by USE_FACE_ANIMATION env var

### Configuration
| Variable | Default | Notes |
|----------|---------|-------|
| USE_FACE_ANIMATION | alse | Default off — zero behavioral change |
| FACE_ANIMATION_MAX_FPS | 4.0 | Hardware-validated safe limit |
| FACE_ANIMATION_MIN_INTERVAL_S | 