### PR TITLE
feat: multi-frame face animations for active states (Phase 3, #106)

### DIFF
--- a/src/windows-orchestration/face_animator.py
+++ b/src/windows-orchestration/face_animator.py
@@ -65,32 +65,74 @@ class AnimationSpec:
         return len(self.frames) <= 1
 
 
-# Default animation specs — single-frame to match today's behavior.
-# Multi-frame animations will be added in Phase 3 after tuning.
+# Default animation specs — multi-frame for active states (Phase 3).
+# States that benefit from animation use 2-4 frame loops at validated FPS.
+# States that should remain calm/static keep single-frame specs.
 DEFAULT_ANIMATION_MAP: dict[str, AnimationSpec] = {
     "DISCONNECTED": AnimationSpec(
         frames=("e_Sadness.jpg",),
         static_fallback="e_Sadness.jpg",
     ),
     "IDLE": AnimationSpec(
-        frames=("e_DefaultContent.jpg",),
+        # Slow content eye-shift — Misty looks alive while waiting
+        frames=(
+            "e_DefaultContent.jpg",
+            "e_DefaultContent.jpg",  # hold center longer
+            "e_ContentLeft.jpg",
+            "e_DefaultContent.jpg",
+            "e_DefaultContent.jpg",  # hold center longer
+            "e_ContentRight.jpg",
+        ),
         fps=0.5,
+        loop=True,
         static_fallback="e_DefaultContent.jpg",
     ),
     "RECORDING": AnimationSpec(
-        frames=("e_Admiration.jpg",),
+        # Wide-eyed attentive — slight blink cycle while listening to speech
+        frames=(
+            "e_Admiration.jpg",
+            "e_Admiration.jpg",
+            "e_SystemBlinkLarge.jpg",
+            "e_Admiration.jpg",
+        ),
+        fps=1.0,
+        loop=True,
         static_fallback="e_Admiration.jpg",
     ),
     "PROCESSING": AnimationSpec(
-        frames=("e_Contempt.jpg",),
+        # Thinking — eyebrow shift suggesting pondering
+        frames=(
+            "e_Contempt.jpg",
+            "e_ContentLeft.jpg",
+            "e_Contempt.jpg",
+            "e_ContentRight.jpg",
+        ),
+        fps=1.0,
+        loop=True,
         static_fallback="e_Contempt.jpg",
     ),
     "PLAYING": AnimationSpec(
-        frames=("e_EcstacyHilarious.jpg",),
+        # Expressive speaking — animated joyful expressions
+        frames=(
+            "e_EcstacyHilarious.jpg",
+            "e_Joy.jpg",
+            "e_EcstacyHilarious.jpg",
+            "e_JoyGoofy.jpg",
+        ),
+        fps=2.0,
+        loop=True,
         static_fallback="e_EcstacyHilarious.jpg",
     ),
     "LISTENING": AnimationSpec(
-        frames=("e_Joy.jpg",),
+        # Warm, attentive — subtle shifts showing engagement
+        frames=(
+            "e_Joy.jpg",
+            "e_Joy.jpg",
+            "e_Admiration.jpg",
+            "e_Joy.jpg",
+        ),
+        fps=0.75,
+        loop=True,
         static_fallback="e_Joy.jpg",
     ),
     "MOVING": AnimationSpec(
@@ -102,11 +144,26 @@ DEFAULT_ANIMATION_MAP: dict[str, AnimationSpec] = {
         static_fallback="e_DefaultContent.jpg",
     ),
     "REBOOTING": AnimationSpec(
-        frames=("e_ContentLeft.jpg",),
+        # Sleepy transition — going to sleep for reboot
+        frames=(
+            "e_Sleepy.jpg",
+            "e_Sleepy2.jpg",
+            "e_SleepingZZZ.jpg",
+        ),
+        fps=0.5,
+        loop=True,
         static_fallback="e_ContentLeft.jpg",
     ),
     "CHARGING": AnimationSpec(
-        frames=("e_Sleeping.jpg",),
+        # Gentle sleeping cycle
+        frames=(
+            "e_Sleeping.jpg",
+            "e_SleepingZZZ.jpg",
+            "e_Sleeping.jpg",
+            "e_Sleepy4.jpg",
+        ),
+        fps=0.3,
+        loop=True,
         static_fallback="e_Sleeping.jpg",
     ),
     "ERROR": AnimationSpec(

--- a/tests/test_face_animator.py
+++ b/tests/test_face_animator.py
@@ -289,11 +289,19 @@ class TestDefaultAnimationMap:
             )
 
     def test_all_initial_specs_are_single_frame(self):
-        """Phase 2 requirement: initial specs match today's single-image behavior."""
+        """Phase 3: active states should be multi-frame, others single-frame."""
+        multi_frame_states = {"IDLE", "RECORDING", "PROCESSING", "PLAYING", "LISTENING", "REBOOTING", "CHARGING"}
+        single_frame_states = {"DISCONNECTED", "MOVING", "REARMING", "ERROR"}
+
         for state_key, spec in DEFAULT_ANIMATION_MAP.items():
-            assert spec.is_single_frame, (
-                f"State {state_key} should be single-frame in Phase 2 (got {len(spec.frames)} frames)"
-            )
+            if state_key in multi_frame_states:
+                assert not spec.is_single_frame, (
+                    f"State {state_key} should be multi-frame in Phase 3"
+                )
+            elif state_key in single_frame_states:
+                assert spec.is_single_frame, (
+                    f"State {state_key} should remain single-frame"
+                )
 
 
 class TestDisableRegression:


### PR DESCRIPTION
## Summary

Enables multi-frame looped face animations for Misty's active states, making her feel alive between state transitions. Phase 3 of the animated face rollout.

## Animation specs

| State | Frames | FPS | Effect |
|-------|--------|-----|--------|
| **IDLE** | DefaultContent → ContentLeft → ContentRight | 0.5 | Slow eye-shift, looks alive while waiting |
| **RECORDING** | Admiration + BlinkLarge | 1.0 | Attentive with natural blink |
| **PROCESSING** | Contempt → ContentLeft → ContentRight | 1.0 | Thinking/pondering shift |
| **PLAYING** | Ecstacy → Joy → JoyGoofy | 2.0 | Expressive animated speaking |
| **LISTENING** | Joy → Admiration | 0.75 | Warm engagement, \"go on...\" |
| **REBOOTING** | Sleepy → SleepingZZZ | 0.5 | Falling asleep for reboot |
| **CHARGING** | Sleeping → SleepingZZZ → Sleepy4 | 0.3 | Gentle sleep breathing |

**Unchanged** (single-frame): DISCONNECTED, MOVING, REARMING, ERROR

## Safety preserved

- Still gated by \USE_FACE_ANIMATION=false\ (default off)
- All \static_fallback\ values match today's exact images
- Disable-regression test passes — disabled behavior is byte-identical to pre-animation
- All FPS values within hardware-validated 4 FPS limit
- 20 tests passing

## To try it

Set \USE_FACE_ANIMATION=true\ in your \.env\ and restart the controller.

Closes #106