### PR TITLE
Persistent, replaceable, emotion-aware Misty face (#116)

### DIFF
--- a/docs/design-animated-face-expressions.md
+++ b/docs/design-animated-face-expressions.md
@@ -349,3 +349,82 @@ No native sequence/animation API exists. Animation must be driven via repeated
 | Design includes a hardware validation step for frame rate and supported animation formats | §7, §10 (results) |
 | Animation can be disabled without affecting wake word, recording, playback, movement safety, shutdown cleanup | §5.4 (flag), §6.2, §6.3, §6.4 |
 | Documentation notes BMO assets are not included or copied | §2 (asset boundary), §9 |
+
+---
+
+## 12. Persistent, replaceable, emotion-aware face (#116)
+
+Issue #116 builds on the custom face system merged in #110 / PR #115. It makes
+the custom face identity persistent (never silently reverting to a firmware
+face), centralizes display through one resolver, adds an explicit face
+replacement workflow, and adds optional emotion-aware talking head motion.
+
+### 12.1 Single resolver / always-available `FaceAnimator`
+
+The controller now **always constructs** a `FaceAnimator`. `USE_FACE_ANIMATION`
+scopes only the continuous frame-loop thread: when it is `false`, the thread is
+not started, but `set_state()`, `set_emotion()`, and `show_asset()` still resolve
+and push the correct frame synchronously. This guarantees custom face identity,
+emotion selection, and built-in fallback work regardless of the flag.
+
+All controller face changes route through the resolver:
+
+- State-driven faces use `set_state()` / `set_emotion()` (already wired through
+  `MistyController.set_state()` / `try_set_state()`).
+- One-off / transient faces (movement acknowledgment, error blips) use
+  `MistyController.show_face(filename)` → `FaceAnimator.show_asset()`, which
+  applies fallback but does **not** change the animation state.
+
+No controller path calls `display_image("face_*")` directly any more.
+
+### 12.2 Deterministic built-in fallback
+
+When required assets are missing locally, an upload fails, the inventory is
+unreliable, or a custom display would fail, the controller marks custom faces
+unavailable (`set_custom_faces_available(False)`). Every custom asset then
+resolves to a built-in firmware face (`e_*.jpg`) via
+`face_animator.ASSET_BUILTIN_FALLBACK` / `builtin_fallback_for_asset()`. Built-in
+faces ship with every Misty II, so a display never fails on a missing file, and
+the fallback is display-only (no per-frame error logging).
+
+### 12.3 Face replacement workflow
+
+Custom face assets are uploaded at startup by `ensure_face_assets()`, controlled
+by two settings (see `config_defaults.py` / `.env.example`):
+
+| Setting | Values | Effect |
+|---------|--------|--------|
+| `FACE_ASSETS_DIR` | path | Directory holding the `face_*` assets to upload. Point at a new folder that reuses the required filenames to swap the face. |
+| `FACE_ASSETS_SYNC_MODE` | `missing` (default) / `overwrite` | `missing` uploads only assets not already on the device (idempotent startup). `overwrite` force re-uploads every required asset even if a same-named file exists. |
+| `FACE_ASSETS_FORCE_UPLOAD` | `true` / unset | Convenience alias that forces `overwrite` for a single run. |
+
+**To replace the face:** put the new assets (same required filenames) in
+`FACE_ASSETS_DIR`, set `FACE_ASSETS_SYNC_MODE=overwrite` (or
+`FACE_ASSETS_FORCE_UPLOAD=true`), start the controller once so the new assets
+overwrite Misty's stored images, then set the mode back to `missing` so normal
+startup stays idempotent.
+
+### 12.4 Emotion-aware talking head motion
+
+`USE_TALKING_HEAD_MOTION` (default `false`) enables subtle, emotion-aware head
+motion while Misty speaks. Implemented by `talking_head_motion.TalkingHeadMotion`:
+
+- Starts only for state `PLAYING` (normal responses, follow-ups, movement
+  acknowledgments, and movement-failure speech) and stops + re-centers the head
+  when playback ends.
+- `MistyController.set_state()` / `try_set_state()` stop the motion on **any**
+  transition away from `PLAYING`, so it never runs during
+  `MOVING`/`CHARGING`/`ERROR`/reboot/re-arm; `_shutdown()` also stops it.
+- All movements stay within a safe head envelope (configurable in
+  `config_defaults.py`) and are hard-clamped to Misty's mechanical limits
+  (pitch -40..26, roll -40..40, yaw -81..81).
+- It only ever issues `/api/head` commands — never drive/arm/audio/keyphrase —
+  keeping it decoupled from movement/drive safety.
+
+### 12.5 Verification (cloud-safe)
+
+`tests/test_face_resolver.py` covers the resolver, `show_asset`, disabled-animation
+identity/fallback, and `ensure_face_assets` sync modes.
+`tests/test_talking_head_motion.py` covers gating, safe-envelope clamping, emotion
+scaling, and stop/center behavior. Live visual tuning on Misty hardware is a
+separate manual step and is not required for these unit tests.

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -80,10 +80,35 @@ USE_FACE_RECOGNITION=false
 FACE_RECOGNITION_TIMEOUT_S=3.0
 
 # Face Animation (#73)
-# Enable state-driven animated face expressions. When false, face behaves exactly
-# as before (single static image per state). When true, FaceAnimator loops frames.
+# Enable the continuous animation frame-loop for face expressions. This flag now
+# scopes ONLY the frame-loop thread: even when false, Misty still shows her custom
+# face identity, emotion-aware talking faces, and built-in fallback (#116). Set
+# true only if you add multi-frame animation specs that need companion-side looping.
 USE_FACE_ANIMATION=false
 # Maximum frames per second for animation (hardware-validated safe limit).
 FACE_ANIMATION_MAX_FPS=4.0
 # Minimum seconds between REST frame pushes (rate-limit guard).
 FACE_ANIMATION_MIN_INTERVAL_S=0.25
+
+# Custom Face Assets (#110 / #116)
+# Directory holding the custom face_*.gif/.png assets uploaded to Misty at startup.
+# Defaults to the repo-level assets/ directory. Point this at a new folder (using
+# the SAME required filenames) to swap in a replacement face.
+# FACE_ASSETS_DIR=./assets
+# Asset sync mode:
+#   missing   = idempotent startup — upload only assets not already on the device
+#               (default; safe to run every boot).
+#   overwrite = force re-upload every required asset even if a same-named file is
+#               already on Misty. Use this ONCE to replace the face with a new set
+#               that reuses the same filenames, then set back to missing.
+FACE_ASSETS_SYNC_MODE=missing
+# Convenience alias: set true to force overwrite mode for a single run without
+# changing FACE_ASSETS_SYNC_MODE.
+# FACE_ASSETS_FORCE_UPLOAD=false
+
+# Talking Head Motion (#116)
+# Enable subtle, emotion-aware head movement while Misty speaks (state PLAYING
+# only). Off by default. Motion always stays within safe head limits and never
+# runs during MOVING/CHARGING/ERROR/shutdown or drive commands; the head is
+# re-centered when playback ends or the state leaves PLAYING.
+USE_TALKING_HEAD_MOTION=false

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -93,3 +93,29 @@ REQUIRED_FACE_ASSETS: tuple = (
     "face_talking_sad.gif",
     "face_talking_curious.gif",
 )
+
+# Face asset replacement / sync behavior (issue #116).
+#   "missing"   = idempotent startup — only upload required assets that are not
+#                 already present on the device (default; safe to run every boot).
+#   "overwrite" = force re-upload of every required asset even if a file with the
+#                 same name already exists on Misty. Use this to replace the
+#                 custom face with a new set that reuses the same filenames, then
+#                 return to "missing" for normal idempotent startup.
+# The FACE_ASSETS_FORCE_UPLOAD=true environment flag is a convenience alias that
+# forces "overwrite" mode for a single run.
+FACE_ASSETS_SYNC_MODE: str = "missing"
+
+# Emotion-aware subtle talking head motion (issue #116). Off by default and
+# gated by config. When enabled, Misty makes small, safe head movements while
+# speaking (state PLAYING only) and re-centers when playback ends or the state
+# leaves PLAYING. Never runs during MOVING/CHARGING/ERROR/shutdown or drive
+# commands, and always stays within the safe head limits below.
+USE_TALKING_HEAD_MOTION: bool = False
+# Safe head-motion envelope for talking motion (degrees). These stay well inside
+# Misty's mechanical limits (pitch -40..26, roll -40..40, yaw -81..81).
+TALKING_HEAD_PITCH_CENTER: float = -10.0   # slight up-tilt = eye contact
+TALKING_HEAD_PITCH_RANGE: float = 4.0      # +/- pitch wobble
+TALKING_HEAD_YAW_RANGE: float = 6.0        # +/- yaw wobble
+TALKING_HEAD_ROLL_RANGE: float = 3.0       # +/- roll wobble
+TALKING_HEAD_VELOCITY: float = 30.0        # gentle move velocity
+TALKING_HEAD_INTERVAL_S: float = 0.8       # seconds between micro-movements

--- a/src/windows-orchestration/face_animator.py
+++ b/src/windows-orchestration/face_animator.py
@@ -322,8 +322,23 @@ class FaceAnimator:
         state transition. It applies built-in firmware fallback resolution but
         does **not** change the target animation state, so it will not disturb
         the state-driven animation loop. Best-effort; never raises.
+
+        Deterministic display-failure fallback (#116): if a custom ``face_*``
+        asset fails to display while custom faces were believed available, mark
+        custom faces unavailable and immediately retry with the built-in
+        firmware fallback so the display never gets stuck on a stale frame and
+        subsequent calls resolve to built-ins.
         """
-        return self._push_frame(self.resolve_asset(filename))
+        frame = self.resolve_asset(filename)
+        if self._push_frame(frame):
+            return True
+
+        with self._lock:
+            was_available = self._custom_faces_available
+        if was_available and isinstance(filename, str) and filename.startswith("face_"):
+            self.set_custom_faces_available(False)
+            return self._push_frame(builtin_fallback_for_asset(filename))
+        return False
 
     def start(self):
         """Start the animation thread."""

--- a/src/windows-orchestration/face_animator.py
+++ b/src/windows-orchestration/face_animator.py
@@ -175,6 +175,39 @@ BUILTIN_EMOTION_FALLBACK: dict[str, str] = {
     "curious": "e_Surprise.jpg",
 }
 
+# Direct map from each custom face asset filename to the built-in firmware face
+# (e_*.jpg) used when custom assets are unavailable on the device. Every custom
+# asset that a controller might display directly must appear here so the resolver
+# can always degrade to a face that ships with the firmware (never a missing
+# file). Keyed by the custom asset filename.
+ASSET_BUILTIN_FALLBACK: dict[str, str] = {
+    "face_idle.gif": "e_DefaultContent.jpg",
+    "face_listening.png": "e_Surprise.jpg",
+    "face_processing.gif": "e_Contempt.jpg",
+    "face_talking_neutral.gif": "e_DefaultContent.jpg",
+    "face_talking_happy.gif": "e_Joy.jpg",
+    "face_talking_excited.gif": "e_Joy2.jpg",
+    "face_talking_sad.gif": "e_Sadness.jpg",
+    "face_talking_curious.gif": "e_Surprise.jpg",
+}
+# Built-in face shown when an unknown custom asset is requested.
+DEFAULT_BUILTIN_FALLBACK = "e_DefaultContent.jpg"
+
+
+def builtin_fallback_for_asset(filename: str) -> str:
+    """Return the built-in firmware face to use in place of a custom asset.
+
+    Built-in ``e_*.jpg`` faces ship with every Misty II, so they never fail on a
+    missing file. Custom assets already keyed on their built-in map pass through
+    that mapping; anything else degrades to the default content face.
+    """
+    if not filename:
+        return DEFAULT_BUILTIN_FALLBACK
+    if not filename.startswith("face_"):
+        # Already a built-in / non-custom asset — display as-is.
+        return filename
+    return ASSET_BUILTIN_FALLBACK.get(filename, DEFAULT_BUILTIN_FALLBACK)
+
 
 class FaceAnimator:
     """Companion-side face animation driver for Misty II.
@@ -266,6 +299,31 @@ class FaceAnimator:
             return
 
         self._state_changed.set()
+
+    def resolve_asset(self, filename: str) -> str:
+        """Resolve a custom face asset filename to the frame to actually display.
+
+        When custom face assets are unavailable on the device, the built-in
+        firmware fallback (``e_*.jpg``) is substituted so a display never fails
+        on a missing file. Otherwise the custom asset is returned unchanged.
+        Never raises.
+        """
+        with self._lock:
+            custom_available = self._custom_faces_available
+        if custom_available:
+            return filename
+        return builtin_fallback_for_asset(filename)
+
+    def show_asset(self, filename: str) -> bool:
+        """Display an arbitrary custom face asset immediately, with fallback.
+
+        This is the single entry point for one-off / transient face displays
+        (e.g., movement acknowledgment, error blips) that are not tied to a
+        state transition. It applies built-in firmware fallback resolution but
+        does **not** change the target animation state, so it will not disturb
+        the state-driven animation loop. Best-effort; never raises.
+        """
+        return self._push_frame(self.resolve_asset(filename))
 
     def start(self):
         """Start the animation thread."""

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -83,6 +83,29 @@ FACE_ANIMATION_MIN_INTERVAL_S = float(os.getenv("FACE_ANIMATION_MIN_INTERVAL_S",
 FACE_ASSETS_DIR = os.getenv("FACE_ASSETS_DIR", config_defaults.FACE_ASSETS_DIR)
 REQUIRED_FACE_ASSETS = config_defaults.REQUIRED_FACE_ASSETS
 
+# Face asset replacement / sync behavior (#116). "missing" (default) uploads
+# only assets not already on the device (idempotent startup); "overwrite" force
+# re-uploads every required asset so a new face reusing the same filenames
+# replaces Misty's stored assets. FACE_ASSETS_FORCE_UPLOAD=true is a convenience
+# alias that forces overwrite for a single run.
+_RAW_FACE_ASSETS_SYNC_MODE = os.getenv(
+    "FACE_ASSETS_SYNC_MODE", config_defaults.FACE_ASSETS_SYNC_MODE
+).strip().lower()
+FACE_ASSETS_SYNC_MODE = (
+    _RAW_FACE_ASSETS_SYNC_MODE
+    if _RAW_FACE_ASSETS_SYNC_MODE in ("missing", "overwrite")
+    else "missing"
+)
+if os.getenv("FACE_ASSETS_FORCE_UPLOAD", "").lower() in ("1", "true", "yes"):
+    FACE_ASSETS_SYNC_MODE = "overwrite"
+
+# Emotion-aware subtle talking head motion (#116) — off by default, gated here.
+# Only active during PLAYING and always within safe head limits; never runs
+# during MOVING/CHARGING/ERROR/shutdown or drive commands.
+USE_TALKING_HEAD_MOTION = os.getenv(
+    "USE_TALKING_HEAD_MOTION", str(config_defaults.USE_TALKING_HEAD_MOTION)
+).lower() in ("1", "true", "yes")
+
 # Keyphrase watchdog — detects silent failures and auto-recovers
 WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", str(config_defaults.WATCHDOG_IDLE_TIMEOUT_S)))  # 90s after rearm with no wake event
 WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", str(config_defaults.WATCHDOG_ESCALATE_TIMEOUT_S)))  # 60s after recovery attempt
@@ -283,17 +306,37 @@ class MistyController:
         self._face_event_name: str | None = None  # WebSocket event name for face recognition
         self._trained_faces: list[str] = []  # cached list of trained face IDs
 
-        # Face animation (#73) — state-driven animated expressions
-        self._face_animator = None
+        # Face animation (#73) — state-driven animated expressions.
+        # The FaceAnimator is ALWAYS constructed so custom face identity, emotion
+        # selection, and built-in fallback are available regardless of
+        # USE_FACE_ANIMATION. That flag now scopes ONLY the continuous frame-loop
+        # thread: when disabled, set_state()/set_emotion()/show_asset() still
+        # resolve and push the correct frame synchronously (#116).
+        from face_animator import FaceAnimator
+        self._face_animator = FaceAnimator(
+            misty_base_url=MISTY_BASE,
+            enabled=USE_FACE_ANIMATION,
+            max_fps=FACE_ANIMATION_MAX_FPS,
+            min_interval_s=FACE_ANIMATION_MIN_INTERVAL_S,
+        )
+        # Only run the frame-loop thread when animation is enabled; identity,
+        # emotion and fallback resolution work without the thread when disabled.
         if USE_FACE_ANIMATION:
-            from face_animator import FaceAnimator
-            self._face_animator = FaceAnimator(
-                misty_base_url=MISTY_BASE,
-                enabled=True,
-                max_fps=FACE_ANIMATION_MAX_FPS,
-                min_interval_s=FACE_ANIMATION_MIN_INTERVAL_S,
-            )
             self._face_animator.start()
+
+        # Emotion-aware talking head motion (#116) — gently moves the head while
+        # speaking (PLAYING only). Always constructed; a no-op when disabled.
+        from talking_head_motion import TalkingHeadMotion
+        self._talking_head = TalkingHeadMotion(
+            move_head=self.move_head,
+            enabled=USE_TALKING_HEAD_MOTION,
+            pitch_center=config_defaults.TALKING_HEAD_PITCH_CENTER,
+            pitch_range=config_defaults.TALKING_HEAD_PITCH_RANGE,
+            yaw_range=config_defaults.TALKING_HEAD_YAW_RANGE,
+            roll_range=config_defaults.TALKING_HEAD_ROLL_RANGE,
+            velocity=config_defaults.TALKING_HEAD_VELOCITY,
+            interval_s=config_defaults.TALKING_HEAD_INTERVAL_S,
+        )
 
     # --- State transitions ---
 
@@ -305,6 +348,11 @@ class MistyController:
             logger.info(f"State: {old.value} -> {new_state.value}")
             if self._face_animator:
                 self._face_animator.set_state(new_state)
+            # Stop (and re-center) talking head motion whenever we leave PLAYING.
+            # This guarantees motion never persists into MOVING/CHARGING/ERROR/
+            # reboot/re-arm or any other state (#116).
+            if new_state != State.PLAYING and getattr(self, "_talking_head", None):
+                self._talking_head.stop()
 
     def try_set_state(self, expected: State, new_state: State) -> bool:
         """Atomic compare-and-swap for state transitions. Returns True if successful."""
@@ -315,6 +363,8 @@ class MistyController:
                 logger.info(f"State: {old.value} -> {new_state.value}")
                 if self._face_animator:
                     self._face_animator.set_state(new_state)
+                if new_state != State.PLAYING and getattr(self, "_talking_head", None):
+                    self._talking_head.stop()
                 return True
             return False
 
@@ -349,6 +399,21 @@ class MistyController:
 
     def display_image(self, filename: str):
         self.misty_post("/api/images/display", {"FileName": filename, "Alpha": 1})
+
+    def show_face(self, filename: str):
+        """Single entry point for direct/transient custom-face display (#116).
+
+        Routes through the always-available FaceAnimator so built-in firmware
+        fallback (e_*.jpg) applies automatically when custom assets are missing
+        or failed to upload. Does not change the animation state, so it is safe
+        for one-off faces (movement acknowledgment, error blips). Prefer
+        ``set_state()``/``set_emotion()`` for state-driven faces; use this only
+        where a specific asset must be shown outside a normal state transition.
+        """
+        if self._face_animator is not None:
+            self._face_animator.show_asset(filename)
+        else:  # pragma: no cover - animator is always constructed in __init__
+            self.display_image(filename)
 
     def move_head(self, pitch: float = 0, roll: float = 0, yaw: float = 0, velocity: float = 50):
         """Move Misty's head. Pitch: -40(up) to 26(down). Roll: -40 to 40. Yaw: -81(right) to 81(left)."""
@@ -619,7 +684,7 @@ class MistyController:
 
         # Visual feedback — orange LED + adventurous face
         self.set_led(255, 165, 0)  # orange = moving
-        self.display_image("face_talking_excited.gif")
+        self.show_face("face_talking_excited.gif")
 
         try:
             if command in ("forward", "backward"):
@@ -684,9 +749,11 @@ class MistyController:
             if response.status_code == 200 and len(response.content) > 100:
                 self.set_state(State.PLAYING)
                 self.set_led(255, 255, 0)  # yellow = warning
-                self.display_image("face_talking_sad.gif")
+                self.show_face("face_talking_sad.gif")
+                self._talking_head.start("sad")  # emotion-aware talking motion (#116)
                 play_duration = self.upload_and_play_audio(response.content, RESPONSE_FILENAME)
                 time.sleep(play_duration + 1.0)
+                self._talking_head.stop()  # halt + re-center head (#116)
         except Exception as e:
             logger.warning(f"[Turn {turn}] Movement failure speech failed: {e}")
 
@@ -959,22 +1026,29 @@ class MistyController:
     def ensure_face_assets(self) -> bool:
         """Idempotently ensure custom face assets are present on Misty (#110).
 
-        Skips assets already on the device (checked via the image inventory),
-        uploads any that are missing from the local ``assets`` directory, and
-        informs the FaceAnimator whether all required custom faces are
-        available. When some are unavailable, the animator falls back to
-        built-in firmware faces.
+        In the default ``missing`` sync mode, assets already on the device
+        (checked via the image inventory) are skipped and only missing ones are
+        uploaded — safe to run every startup. In ``overwrite`` sync mode
+        (``FACE_ASSETS_SYNC_MODE=overwrite`` or ``FACE_ASSETS_FORCE_UPLOAD=true``),
+        every required asset is re-uploaded even if a file with the same name
+        already exists, so a replacement face reusing the same filenames updates
+        Misty's stored assets (#116).
+
+        Informs the FaceAnimator whether all required custom faces are available;
+        when some are unavailable the animator falls back to built-in firmware
+        faces.
 
         Returns True if every required custom face is available on the device
         (already present or successfully uploaded); False otherwise.
         """
-        inventory = self._get_misty_image_names()
+        overwrite = FACE_ASSETS_SYNC_MODE == "overwrite"
+        inventory = set() if overwrite else self._get_misty_image_names()
         uploaded = 0
         skipped = 0
         all_available = True
 
         for filename in REQUIRED_FACE_ASSETS:
-            if filename in inventory:
+            if not overwrite and filename in inventory:
                 skipped += 1
                 continue
             local_path = os.path.join(FACE_ASSETS_DIR, filename)
@@ -991,8 +1065,8 @@ class MistyController:
                 all_available = False
 
         logger.info(
-            f"Face assets: {skipped} already present, {uploaded} uploaded, "
-            f"custom_available={all_available}"
+            f"Face assets [{FACE_ASSETS_SYNC_MODE}]: {skipped} already present, "
+            f"{uploaded} uploaded, custom_available={all_available}"
         )
 
         if self._face_animator:
@@ -1546,7 +1620,7 @@ class MistyController:
         self.misty_post("/api/audio/keyphrase/stop")
         self.misty_post("/api/skills/cancel")
         self.set_led(0, 0, 0)
-        self.display_image("face_idle.gif")
+        self.show_face("face_idle.gif")
         logger.info("Charging mode active — keyphrase off, LED off, display sleeping")
 
     def exit_charging_mode(self):
@@ -1555,14 +1629,14 @@ class MistyController:
         if self._wake_word_listener:
             self._wake_word_listener.resume()
             self.set_led(0, 255, 0)
-            self.display_image("face_idle.gif")
+            self.show_face("face_idle.gif")
             self.last_activity_time = time.time()
             self._is_dimmed = False
             self.set_state(State.IDLE)
             logger.info("Exited charging mode — resumed laptop wake word listener")
         elif self.start_keyphrase(force_restart=True):
             self.set_led(0, 255, 0)
-            self.display_image("face_idle.gif")
+            self.show_face("face_idle.gif")
             self.last_activity_time = time.time()
             self._is_dimmed = False
             self.set_state(State.IDLE)
@@ -1580,6 +1654,8 @@ class MistyController:
         logger.info("Shutting down...")
         self.running = False
         # Stop face animator first (§6.3 — before existing cleanup sequence)
+        if self._talking_head:
+            self._talking_head.stop()  # halt + re-center head motion (#116)
         if self._face_animator:
             self._face_animator.stop()
         # Stop laptop wake word listener
@@ -1768,7 +1844,7 @@ class MistyController:
             # Explicitly stop keyphrase to ensure mic is free
             self.misty_post("/api/audio/keyphrase/stop")
             self.set_led(0, 255, 0)
-            self.display_image("face_idle.gif")
+            self.show_face("face_idle.gif")
             if current_state in (State.REARMING, State.REBOOTING):
                 self.last_activity_time = time.time()
                 self.set_state(State.IDLE)
@@ -1779,7 +1855,7 @@ class MistyController:
                 self.set_state(State.IDLE)
         elif self.start_keyphrase(force_restart=True):
             self.set_led(0, 255, 0)
-            self.display_image("face_idle.gif")
+            self.show_face("face_idle.gif")
             if current_state in (State.REARMING, State.REBOOTING):
                 # Re-arm or post-reboot reconnect — no grace period, go straight to IDLE
                 self.last_activity_time = time.time()
@@ -1850,7 +1926,7 @@ class MistyController:
             if self._is_dimmed and self.get_state() == State.IDLE:
                 self._is_dimmed = False
                 self.set_led(0, 255, 0)
-                self.display_image("face_idle.gif")
+                self.show_face("face_idle.gif")
                 logger.info("Restored from idle-dim on wake word")
 
             if self.get_state() == State.IDLE and time.time() >= self.ready_time:
@@ -2024,7 +2100,7 @@ class MistyController:
         if self._is_dimmed and self.get_state() == State.IDLE:
             self._is_dimmed = False
             self.set_led(0, 255, 0)
-            self.display_image("face_idle.gif")
+            self.show_face("face_idle.gif")
             logger.info("Restored from idle-dim on laptop wake word")
 
         if self.get_state() == State.IDLE and time.time() >= self.ready_time:
@@ -2119,7 +2195,7 @@ class MistyController:
         except Exception as e:
             logger.error(f"[Turn {turn}] Error: {e}", exc_info=True)
             self.set_led(255, 0, 0)  # red = error
-            self.display_image("face_talking_sad.gif")
+            self.show_face("face_talking_sad.gif")
             time.sleep(2)
 
         finally:
@@ -2135,7 +2211,7 @@ class MistyController:
         # 1. Visual feedback — listening attentively
         self.set_state(State.RECORDING)
         self.set_led(255, 140, 0)  # orange
-        self.display_image("face_listening.png")  # wide-eyed, attentive
+        self.show_face("face_listening.png")  # wide-eyed, attentive
         self.move_head(pitch=-10, roll=0, yaw=0, velocity=60)  # look up slightly — eye contact
 
         # Start face recognition concurrently with recording (#16)
@@ -2248,7 +2324,7 @@ class MistyController:
         # 3. Retrieve recorded audio — wondering face + thinking sound
         self.set_state(State.PROCESSING)
         self.set_led(0, 0, 255)  # blue = processing
-        self.display_image("face_processing.gif")  # one eyebrow raised — "hmm, let me think..."
+        self.show_face("face_processing.gif")  # one eyebrow raised — "hmm, let me think..."
         self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)  # tilt head — pondering
 
         # Play thinking phrase so the user knows Misty heard them
@@ -2357,9 +2433,11 @@ class MistyController:
                     try:
                         self.set_state(State.PLAYING)
                         self.set_led(148, 0, 211)  # purple = speaking
-                        self.display_image("face_talking_happy.gif")
+                        self.show_face("face_talking_happy.gif")
+                        self._talking_head.start("happy")  # talking motion (#116)
                         play_duration = self.upload_and_play_audio(response_wav, RESPONSE_FILENAME)
                         time.sleep(play_duration + 1.0)
+                        self._talking_head.stop()  # halt + re-center head (#116)
                     except Exception as e:
                         logger.warning(f"[Turn {turn}] Movement ack playback failed: {e}")
 
@@ -2399,21 +2477,20 @@ class MistyController:
 
         # Upload to Misty and play — animated, looking at user
         emotion = result.get("emotion", "neutral")
-        # Route emotion through the animator so it selects the matching talking
-        # face (and applies built-in fallback if custom assets are unavailable).
-        if self._face_animator:
-            self._face_animator.set_emotion(emotion)
+        # Route emotion through the always-available animator so it selects the
+        # matching talking face (and applies built-in fallback when custom assets
+        # are unavailable) — works whether or not the frame-loop is enabled (#116).
+        self._face_animator.set_emotion(emotion)
         self.set_state(State.PLAYING)
         self.set_led(148, 0, 211)  # purple = speaking
-        if not self._face_animator:
-            from face_animator import talking_face_for_emotion  # noqa: PLC0415
-            self.display_image(talking_face_for_emotion(emotion))
         self.move_head(pitch=-10, roll=0, yaw=0, velocity=60)  # face forward — eye contact
+        self._talking_head.start(emotion)  # gentle emotion-aware motion while speaking (#116)
 
         play_duration = self.upload_and_play_audio(response_wav, RESPONSE_FILENAME)
 
         # Wait for playback to finish (generous buffer — no completion callback from Misty)
         time.sleep(play_duration + 2.0)
+        self._talking_head.stop()  # halt + re-center head when playback ends (#116)
 
         elapsed = time.time() - turn_start
         logger.info(f"[Turn {turn}] Exchange complete in {elapsed:.1f}s")
@@ -2423,7 +2500,7 @@ class MistyController:
         """Listen briefly for follow-up speech. Returns True if speech was detected and responded to."""
         self.set_state(State.LISTENING)
         self.set_led(0, 200, 200)  # cyan = listening for follow-up
-        self.display_image("face_listening.png")  # warm, expectant — "go on..."
+        self.show_face("face_listening.png")  # warm, expectant — "go on..."
         self.move_head(pitch=-10, roll=-3, yaw=-10, velocity=40)  # slight head tilt — attentive
 
         # Record a short clip — use VAD if available
@@ -2495,7 +2572,7 @@ class MistyController:
         # Show thinking face while processing follow-up
         self.set_state(State.PROCESSING)
         self.set_led(0, 0, 255)  # blue = processing
-        self.display_image("face_processing.gif")  # wondering face
+        self.show_face("face_processing.gif")  # wondering face
         self.move_head(pitch=-5, roll=5, yaw=20, velocity=40)
 
         # Send through the full pipeline — orchestration returns empty_stt error
@@ -2535,8 +2612,11 @@ class MistyController:
                         audio_resp.raise_for_status()
                         self.set_state(State.PLAYING)
                         self.set_led(148, 0, 211)
+                        self.show_face("face_talking_happy.gif")  # consistent ack face (#116)
+                        self._talking_head.start("happy")  # talking motion (#116)
                         play_duration = self.upload_and_play_audio(audio_resp.content, RESPONSE_FILENAME)
                         time.sleep(play_duration + 1.0)
+                        self._talking_head.stop()  # halt + re-center head (#116)
                     except Exception as e:
                         logger.warning(f"[Turn {turn}] Follow-up movement ack audio failed: {e}")
 
@@ -2564,17 +2644,15 @@ class MistyController:
 
             # Play the response
             emotion = result.get("emotion", "neutral")
-            if self._face_animator:
-                self._face_animator.set_emotion(emotion)
+            self._face_animator.set_emotion(emotion)
             self.set_state(State.PLAYING)
             self.set_led(148, 0, 211)  # purple = speaking
-            if not self._face_animator:
-                from face_animator import talking_face_for_emotion  # noqa: PLC0415
-                self.display_image(talking_face_for_emotion(emotion))
             self.move_head(pitch=-10, roll=0, yaw=0, velocity=60)  # face forward
+            self._talking_head.start(emotion)  # emotion-aware talking motion (#116)
 
             play_duration = self.upload_and_play_audio(response_wav, RESPONSE_FILENAME)
             time.sleep(play_duration + 0.5)
+            self._talking_head.stop()  # halt + re-center head when playback ends (#116)
             return True
 
         except Exception as e:
@@ -2615,7 +2693,7 @@ class MistyController:
 
                 self.set_led(0, 255, 0)
 
-                self.display_image("face_idle.gif")
+                self.show_face("face_idle.gif")
 
                 self.last_activity_time = time.time()
 
@@ -2692,7 +2770,7 @@ class MistyController:
 
         # Announce the reboot to the user
         self.set_led(255, 200, 0)  # yellow = maintenance
-        self.display_image("face_idle.gif")  # calm face
+        self.show_face("face_idle.gif")  # calm face
         self._play_reboot_announcement()
 
         # Stop all audio before reboot

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -407,7 +407,8 @@ class MistyController:
         fallback (e_*.jpg) applies automatically when custom assets are missing
         or failed to upload. Does not change the animation state, so it is safe
         for one-off faces (movement acknowledgment, error blips). Prefer
-        ``set_state()``/``set_emotion()`` for state-driven faces; use this only
+        ``set_state()`` for state-driven faces (emotion is applied via the
+        FaceAnimator, e.g. ``self._face_animator.set_emotion()``); use this only
         where a specific asset must be shown outside a normal state transition.
         """
         if self._face_animator is not None:

--- a/src/windows-orchestration/talking_head_motion.py
+++ b/src/windows-orchestration/talking_head_motion.py
@@ -111,7 +111,7 @@ class TalkingHeadMotion:
         """
         if not self._enabled:
             return
-        e = (emotion or "").strip().lower() if isinstance(emotion, str) else "neutral"
+        e = emotion.strip().lower() if isinstance(emotion, str) and emotion.strip() else "neutral"
         # Restart cleanly if already running so the emotion/scale updates.
         self.stop(center=False)
         with self._lock:

--- a/src/windows-orchestration/talking_head_motion.py
+++ b/src/windows-orchestration/talking_head_motion.py
@@ -1,0 +1,184 @@
+"""
+Emotion-aware subtle talking head motion for Misty II (issue #116).
+
+Provides a small, self-contained ``TalkingHeadMotion`` driver that makes gentle
+head movements while Misty is speaking (controller state ``PLAYING``) and
+re-centers the head when speech ends. It is intentionally decoupled from the
+drive/locomotion safety subsystem:
+
+- It only ever issues ``/api/head`` commands through a caller-supplied
+  ``move_head`` callable — never drive, arm, audio, or keyphrase commands.
+- It runs only while explicitly started, and the controller starts it only for
+  the ``PLAYING`` state and stops it on any transition away from ``PLAYING``
+  (including MOVING, CHARGING, ERROR, reboot, re-arm, and shutdown).
+- All movements stay within a safe head envelope well inside Misty's mechanical
+  limits (pitch -40..26, roll -40..40, yaw -81..81).
+- It is gated by config (``USE_TALKING_HEAD_MOTION``); when disabled it is a
+  no-op so head behavior is identical to today.
+
+Usage:
+    motion = TalkingHeadMotion(controller.move_head, enabled=USE_TALKING_HEAD_MOTION)
+    motion.start("happy")   # begin gentle motion for the PLAYING turn
+    ...                     # audio plays
+    motion.stop()           # halt + re-center head
+"""
+
+import logging
+import random
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Per-emotion amplitude scale for the talking head wobble. Excited is livelier;
+# sad is calmer. Unknown emotions use the neutral scale.
+EMOTION_MOTION_SCALE: dict[str, float] = {
+    "neutral": 1.0,
+    "happy": 1.15,
+    "excited": 1.4,
+    "sad": 0.6,
+    "curious": 1.1,
+}
+DEFAULT_MOTION_SCALE = 1.0
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+class TalkingHeadMotion:
+    """Gentle, emotion-aware head motion during speech. Thread-based, bounded.
+
+    Args:
+        move_head: Callable ``(pitch, roll, yaw, velocity)`` that issues a head
+            move (typically ``MistyController.move_head``). Never called with
+            values outside the configured safe envelope.
+        enabled: If False, ``start()``/``stop()`` are no-ops (head behavior is
+            unchanged from the no-motion baseline).
+        pitch_center/pitch_range/yaw_range/roll_range: Safe motion envelope in
+            degrees. Movements are centered on ``pitch_center`` and wobble within
+            the ranges.
+        velocity: Gentle move velocity for each micro-movement.
+        interval_s: Seconds between micro-movements.
+    """
+
+    STOP_TIMEOUT_S = 2.0
+
+    # Hard safety clamps — even if misconfigured, never exceed these bounds.
+    PITCH_MIN, PITCH_MAX = -40.0, 26.0
+    ROLL_MIN, ROLL_MAX = -40.0, 40.0
+    YAW_MIN, YAW_MAX = -81.0, 81.0
+
+    def __init__(
+        self,
+        move_head: Callable[..., None],
+        enabled: bool = False,
+        pitch_center: float = -10.0,
+        pitch_range: float = 4.0,
+        yaw_range: float = 6.0,
+        roll_range: float = 3.0,
+        velocity: float = 30.0,
+        interval_s: float = 0.8,
+    ):
+        self._move_head = move_head
+        self._enabled = bool(enabled)
+        self._pitch_center = pitch_center
+        self._pitch_range = abs(pitch_range)
+        self._yaw_range = abs(yaw_range)
+        self._roll_range = abs(roll_range)
+        self._velocity = velocity
+        self._interval_s = max(0.2, interval_s)
+
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._emotion = "neutral"
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def is_active(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self, emotion: str = "neutral") -> None:
+        """Begin gentle talking head motion. No-op if disabled.
+
+        Safe to call repeatedly; a running motion is restarted with the new
+        emotion. Non-blocking.
+        """
+        if not self._enabled:
+            return
+        e = (emotion or "").strip().lower() if isinstance(emotion, str) else "neutral"
+        # Restart cleanly if already running so the emotion/scale updates.
+        self.stop(center=False)
+        with self._lock:
+            self._emotion = e
+            self._stop_event = threading.Event()
+            self._thread = threading.Thread(
+                target=self._motion_loop,
+                name="TalkingHeadMotion",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, center: bool = True) -> None:
+        """Stop talking head motion and (by default) re-center the head.
+
+        Bounded join. No-op if disabled or not running. Best-effort; never
+        raises. ``center=False`` is used internally when restarting.
+        """
+        if not self._enabled:
+            return
+        with self._lock:
+            thread = self._thread
+            stop_event = self._stop_event
+            self._thread = None
+        if stop_event is not None:
+            stop_event.set()
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=self.STOP_TIMEOUT_S)
+            if thread.is_alive():
+                logger.debug("TalkingHeadMotion thread did not stop within timeout")
+        if center:
+            self._center_head()
+
+    def _scaled(self, base_range: float) -> float:
+        scale = EMOTION_MOTION_SCALE.get(self._emotion, DEFAULT_MOTION_SCALE)
+        return base_range * scale
+
+    def _center_head(self) -> None:
+        """Re-center the head to the neutral talking pitch. Best-effort."""
+        try:
+            pitch = _clamp(self._pitch_center, self.PITCH_MIN, self.PITCH_MAX)
+            self._move_head(pitch=pitch, roll=0, yaw=0, velocity=self._velocity)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"TalkingHeadMotion center failed: {e}")
+
+    def _motion_loop(self) -> None:
+        stop_event = self._stop_event
+        while not stop_event.is_set():
+            try:
+                pitch = _clamp(
+                    self._pitch_center
+                    + random.uniform(-self._scaled(self._pitch_range),
+                                     self._scaled(self._pitch_range)),
+                    self.PITCH_MIN, self.PITCH_MAX,
+                )
+                yaw = _clamp(
+                    random.uniform(-self._scaled(self._yaw_range),
+                                   self._scaled(self._yaw_range)),
+                    self.YAW_MIN, self.YAW_MAX,
+                )
+                roll = _clamp(
+                    random.uniform(-self._scaled(self._roll_range),
+                                   self._scaled(self._roll_range)),
+                    self.ROLL_MIN, self.ROLL_MAX,
+                )
+                self._move_head(pitch=pitch, roll=roll, yaw=yaw, velocity=self._velocity)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"TalkingHeadMotion move failed: {e}")
+            # Interruptible wait so stop() is responsive.
+            stop_event.wait(timeout=self._interval_s)

--- a/tests/test_face_resolver.py
+++ b/tests/test_face_resolver.py
@@ -86,6 +86,27 @@ class TestShowAsset:
         # Target state stays IDLE even though a talking face was shown one-off.
         assert animator._target_state == "IDLE"
 
+    @patch("face_animator.requests.post")
+    def test_show_asset_display_failure_triggers_builtin_fallback(self, mock_post):
+        """A failed custom display flips availability and retries with a built-in."""
+        def _resp(url, json=None, timeout=None):
+            fn = json["FileName"]
+            # Custom face_* pushes fail; built-in e_* pushes succeed.
+            return MagicMock(status_code=500 if fn.startswith("face_") else 200)
+
+        mock_post.side_effect = _resp
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        assert animator.custom_faces_available is True
+
+        ok = animator.show_asset("face_talking_sad.gif")
+
+        assert ok is True  # built-in fallback push succeeded
+        # Availability flipped so subsequent resolves use built-ins.
+        assert animator.custom_faces_available is False
+        filenames = [c.kwargs["json"]["FileName"] for c in mock_post.call_args_list]
+        assert "face_talking_sad.gif" in filenames  # attempted custom first
+        assert "e_Sadness.jpg" in filenames  # then built-in fallback
+
 
 class TestDisabledIdentityAndFallback:
     """USE_FACE_ANIMATION=false equivalent: identity + fallback still work."""

--- a/tests/test_face_resolver.py
+++ b/tests/test_face_resolver.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for the centralized custom-face resolver and asset replacement (#116).
+
+Covers:
+- builtin_fallback_for_asset() mapping (custom asset -> firmware e_*.jpg)
+- FaceAnimator.resolve_asset()/show_asset() with custom-available vs unavailable
+- disabled-animation (USE_FACE_ANIMATION=false equivalent) custom identity and
+  fallback still resolve/push correctly
+- ensure_face_assets() overwrite vs missing sync mode behavior
+"""
+
+import sys
+import os
+import time
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration"))
+
+from face_animator import (
+    FaceAnimator,
+    ASSET_BUILTIN_FALLBACK,
+    DEFAULT_BUILTIN_FALLBACK,
+    builtin_fallback_for_asset,
+)
+import config_defaults
+
+
+class TestBuiltinFallbackForAsset:
+    def test_every_required_asset_has_builtin_fallback(self):
+        for asset in config_defaults.REQUIRED_FACE_ASSETS:
+            fb = builtin_fallback_for_asset(asset)
+            assert fb in ASSET_BUILTIN_FALLBACK.values()
+            assert not fb.startswith("face_")
+
+    def test_known_asset_maps_to_expected_builtin(self):
+        assert builtin_fallback_for_asset("face_talking_sad.gif") == "e_Sadness.jpg"
+        assert builtin_fallback_for_asset("face_idle.gif") == "e_DefaultContent.jpg"
+
+    def test_unknown_custom_asset_uses_default_builtin(self):
+        assert builtin_fallback_for_asset("face_unknown.gif") == DEFAULT_BUILTIN_FALLBACK
+
+    def test_non_custom_asset_passes_through(self):
+        # Already a firmware/built-in asset — displayed as-is.
+        assert builtin_fallback_for_asset("e_Joy.jpg") == "e_Joy.jpg"
+
+    def test_empty_filename_uses_default(self):
+        assert builtin_fallback_for_asset("") == DEFAULT_BUILTIN_FALLBACK
+
+
+class TestResolveAsset:
+    def test_custom_available_returns_custom(self):
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        assert animator.custom_faces_available is True
+        assert animator.resolve_asset("face_talking_happy.gif") == "face_talking_happy.gif"
+
+    def test_custom_unavailable_returns_builtin(self):
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.set_custom_faces_available(False)
+        assert animator.resolve_asset("face_talking_happy.gif") == "e_Joy.jpg"
+
+
+class TestShowAsset:
+    @patch("face_animator.requests.post")
+    def test_show_asset_pushes_custom_when_available(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.show_asset("face_listening.png")
+        filenames = [c.kwargs["json"]["FileName"] for c in mock_post.call_args_list]
+        assert filenames == ["face_listening.png"]
+
+    @patch("face_animator.requests.post")
+    def test_show_asset_pushes_builtin_when_unavailable(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.set_custom_faces_available(False)
+        animator.show_asset("face_processing.gif")
+        filenames = [c.kwargs["json"]["FileName"] for c in mock_post.call_args_list]
+        assert filenames == [ASSET_BUILTIN_FALLBACK["face_processing.gif"]]
+
+    @patch("face_animator.requests.post")
+    def test_show_asset_does_not_change_target_state(self, mock_post):
+        """show_asset is for one-off displays and must not alter animation state."""
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.set_state("IDLE")
+        animator.show_asset("face_talking_happy.gif")
+        # Target state stays IDLE even though a talking face was shown one-off.
+        assert animator._target_state == "IDLE"
+
+
+class TestDisabledIdentityAndFallback:
+    """USE_FACE_ANIMATION=false equivalent: identity + fallback still work."""
+
+    @patch("face_animator.requests.post")
+    def test_disabled_emotion_identity_resolves(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)  # no thread
+        animator.set_state("PLAYING", emotion="excited")
+        filenames = [c.kwargs["json"]["FileName"] for c in mock_post.call_args_list]
+        assert "face_talking_excited.gif" in filenames
+
+    @patch("face_animator.requests.post")
+    def test_disabled_fallback_resolves(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        animator = FaceAnimator("http://10.0.0.23", enabled=False)
+        animator.set_custom_faces_available(False)
+        animator.set_state("PLAYING", emotion="excited")
+        filenames = [c.kwargs["json"]["FileName"] for c in mock_post.call_args_list]
+        assert "e_Joy2.jpg" in filenames  # excited built-in fallback
+        assert not any(f.startswith("face_") for f in filenames)
+
+
+class TestEnsureFaceAssetsSyncMode:
+    """ensure_face_assets() respects missing vs overwrite sync mode (#116)."""
+
+    def _make_controller(self):
+        import misty_controller
+        # Instantiate without connecting to hardware (run() is not called).
+        ctrl = misty_controller.MistyController()
+        return misty_controller, ctrl
+
+    def test_missing_mode_skips_present_assets(self):
+        mc, ctrl = self._make_controller()
+        present = set(mc.REQUIRED_FACE_ASSETS)
+        with patch.object(mc, "FACE_ASSETS_SYNC_MODE", "missing"), \
+             patch.object(ctrl, "_get_misty_image_names", return_value=present), \
+             patch.object(ctrl, "_upload_face_image", return_value=True) as up, \
+             patch.object(os.path, "exists", return_value=True):
+            ok = ctrl.ensure_face_assets()
+        assert ok is True
+        assert up.call_count == 0  # all present -> nothing uploaded
+
+    def test_overwrite_mode_reuploads_all(self):
+        mc, ctrl = self._make_controller()
+        present = set(mc.REQUIRED_FACE_ASSETS)
+        with patch.object(mc, "FACE_ASSETS_SYNC_MODE", "overwrite"), \
+             patch.object(ctrl, "_get_misty_image_names", return_value=present) as inv, \
+             patch.object(ctrl, "_upload_face_image", return_value=True) as up, \
+             patch.object(os.path, "exists", return_value=True):
+            ok = ctrl.ensure_face_assets()
+        assert ok is True
+        # Overwrite ignores inventory and re-uploads every required asset.
+        assert up.call_count == len(mc.REQUIRED_FACE_ASSETS)
+        assert inv.call_count == 0  # inventory not consulted in overwrite mode
+
+    def test_missing_local_asset_triggers_fallback(self):
+        mc, ctrl = self._make_controller()
+        with patch.object(mc, "FACE_ASSETS_SYNC_MODE", "missing"), \
+             patch.object(ctrl, "_get_misty_image_names", return_value=set()), \
+             patch.object(ctrl, "_upload_face_image", return_value=True), \
+             patch.object(os.path, "exists", return_value=False):
+            ok = ctrl.ensure_face_assets()
+        assert ok is False  # missing local files -> not fully available
+        assert ctrl._face_animator.custom_faces_available is False

--- a/tests/test_face_resolver.py
+++ b/tests/test_face_resolver.py
@@ -11,10 +11,7 @@ Covers:
 
 import sys
 import os
-import time
 from unittest.mock import patch, MagicMock
-
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration"))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2281,7 +2281,8 @@ class TestSpeakMoveIntegration(unittest.TestCase):
         self.ctrl.hazard_lock = threading.Lock()
         self.ctrl.last_activity_time = time.time()
         self.ctrl._wake_word_listener = None
-        self.ctrl._face_animator = None
+        self.ctrl._face_animator = unittest.mock.MagicMock()
+        self.ctrl._talking_head = unittest.mock.MagicMock()
         self.ctrl.misty_post = mock_post
         self.ctrl.DRIVE_MAX_DURATION_MS = 3000
         self.ctrl.MOVEMENT_SETTLE_MS = 100  # fast for tests

--- a/tests/test_talking_head_motion.py
+++ b/tests/test_talking_head_motion.py
@@ -135,6 +135,16 @@ class TestEmotionScaling:
         motion.stop()
         assert EMOTION_MOTION_SCALE.get("furious", DEFAULT_MOTION_SCALE) == DEFAULT_MOTION_SCALE
 
+    def test_empty_emotion_normalized_to_neutral(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=True, interval_s=0.1)
+        motion.start("")
+        assert motion._emotion == "neutral"
+        motion.stop()
+        motion.start(None)
+        assert motion._emotion == "neutral"
+        motion.stop()
+
 
 class TestRestartAndSafety:
     def test_restart_updates_emotion(self):

--- a/tests/test_talking_head_motion.py
+++ b/tests/test_talking_head_motion.py
@@ -1,0 +1,159 @@
+"""
+Unit tests for TalkingHeadMotion (issue #116).
+
+Validates the gated emotion-aware talking head motion:
+- disabled = no-op (head behavior unchanged from baseline)
+- enabled = gentle head moves within the safe envelope, only while active
+- stop() halts and re-centers the head
+- emotion scales motion amplitude
+- all movements stay within Misty's mechanical head limits
+"""
+
+import sys
+import os
+import time
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration"))
+
+from talking_head_motion import (
+    TalkingHeadMotion,
+    EMOTION_MOTION_SCALE,
+    DEFAULT_MOTION_SCALE,
+)
+
+
+class _Recorder:
+    """Thread-safe recorder for move_head calls."""
+
+    def __init__(self):
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def __call__(self, pitch=0, roll=0, yaw=0, velocity=50):
+        with self._lock:
+            self.calls.append({"pitch": pitch, "roll": roll, "yaw": yaw, "velocity": velocity})
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.calls)
+
+
+class TestDisabledIsNoOp:
+    def test_start_does_nothing_when_disabled(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=False, interval_s=0.2)
+        motion.start("happy")
+        time.sleep(0.4)
+        motion.stop()
+        assert rec.snapshot() == []
+        assert motion.is_active is False
+
+    def test_disabled_property(self):
+        motion = TalkingHeadMotion(_Recorder(), enabled=False)
+        assert motion.enabled is False
+
+
+class TestEnabledMotion:
+    def test_start_moves_head_while_active(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=True, interval_s=0.1)
+        motion.start("neutral")
+        time.sleep(0.45)
+        motion.stop()
+        # Several micro-movements plus a final center.
+        assert len(rec.snapshot()) >= 2
+
+    def test_stop_recenters_head(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(
+            rec, enabled=True, interval_s=0.1, pitch_center=-10.0
+        )
+        motion.start("neutral")
+        time.sleep(0.25)
+        motion.stop()
+        last = rec.snapshot()[-1]
+        # Center pose: pitch at center, roll/yaw zero.
+        assert last["pitch"] == pytest.approx(-10.0)
+        assert last["roll"] == 0
+        assert last["yaw"] == 0
+
+    def test_not_active_after_stop(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=True, interval_s=0.1)
+        motion.start()
+        assert motion.is_active is True
+        motion.stop()
+        assert motion.is_active is False
+
+    def test_all_moves_within_safe_envelope(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(
+            rec, enabled=True, interval_s=0.05,
+            pitch_center=-10.0, pitch_range=4.0, yaw_range=6.0, roll_range=3.0,
+        )
+        motion.start("excited")  # largest amplitude scale
+        time.sleep(0.6)
+        motion.stop()
+        for c in rec.snapshot():
+            assert TalkingHeadMotion.PITCH_MIN <= c["pitch"] <= TalkingHeadMotion.PITCH_MAX
+            assert TalkingHeadMotion.ROLL_MIN <= c["roll"] <= TalkingHeadMotion.ROLL_MAX
+            assert TalkingHeadMotion.YAW_MIN <= c["yaw"] <= TalkingHeadMotion.YAW_MAX
+
+    def test_hard_clamp_beyond_mechanical_limits(self):
+        """Even a misconfigured envelope never exceeds mechanical limits."""
+        rec = _Recorder()
+        motion = TalkingHeadMotion(
+            rec, enabled=True, interval_s=0.05,
+            pitch_center=0.0, pitch_range=1000.0, yaw_range=1000.0, roll_range=1000.0,
+        )
+        motion.start("excited")
+        time.sleep(0.4)
+        motion.stop()
+        for c in rec.snapshot():
+            assert TalkingHeadMotion.PITCH_MIN <= c["pitch"] <= TalkingHeadMotion.PITCH_MAX
+            assert TalkingHeadMotion.ROLL_MIN <= c["roll"] <= TalkingHeadMotion.ROLL_MAX
+            assert TalkingHeadMotion.YAW_MIN <= c["yaw"] <= TalkingHeadMotion.YAW_MAX
+
+
+class TestEmotionScaling:
+    def test_known_emotions_have_scales(self):
+        for emotion in ("neutral", "happy", "excited", "sad", "curious"):
+            assert emotion in EMOTION_MOTION_SCALE
+
+    def test_excited_is_livelier_than_sad(self):
+        assert EMOTION_MOTION_SCALE["excited"] > EMOTION_MOTION_SCALE["sad"]
+
+    def test_unknown_emotion_uses_default_scale(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=True, interval_s=0.1)
+        # Unknown emotion should not raise; scale falls back to default.
+        motion.start("furious")
+        time.sleep(0.2)
+        motion.stop()
+        assert EMOTION_MOTION_SCALE.get("furious", DEFAULT_MOTION_SCALE) == DEFAULT_MOTION_SCALE
+
+
+class TestRestartAndSafety:
+    def test_restart_updates_emotion(self):
+        rec = _Recorder()
+        motion = TalkingHeadMotion(rec, enabled=True, interval_s=0.1)
+        motion.start("neutral")
+        time.sleep(0.15)
+        motion.start("excited")  # restart with new emotion
+        time.sleep(0.15)
+        motion.stop()
+        assert motion.is_active is False
+
+    def test_move_head_exception_does_not_crash_loop(self):
+        def boom(**kwargs):
+            raise RuntimeError("head unreachable")
+
+        motion = TalkingHeadMotion(boom, enabled=True, interval_s=0.05)
+        motion.start("neutral")
+        time.sleep(0.2)
+        # Should still be considered active despite errors, and stop cleanly.
+        motion.stop()
+        assert motion.is_active is False


### PR DESCRIPTION
Closes #116

Follows up the custom-face system from #110 / PR #115 to make Misty's face persistent, replaceable, and emotion-aware. Baselined on `origin/main` @ `e283fef` (tag `issue-110-pr-115-custom-face-system`).

## What changed

- **Always-available resolver.** `FaceAnimator` is now always constructed. `USE_FACE_ANIMATION` scopes **only** the continuous frame-loop thread; when disabled, `set_state()`/`set_emotion()`/`show_asset()` still resolve and push the correct frame synchronously — so custom identity, emotion selection, and built-in fallback work regardless of the flag.
- **Single resolver + no direct calls.** New `MistyController.show_face()` -> `FaceAnimator.show_asset()`; all 17 direct `display_image("face_*")` call sites now route through it. `show_asset()` applies fallback without changing animation state (safe for one-off faces).
- **Deterministic fallback.** New `ASSET_BUILTIN_FALLBACK` / `builtin_fallback_for_asset()` map every custom asset to a firmware `e_*.jpg` when custom faces are unavailable (missing local file, failed upload, unreliable inventory, or failed display). Display-only, no per-frame error logs.
- **Face replacement workflow.** `FACE_ASSETS_SYNC_MODE=missing|overwrite` (plus `FACE_ASSETS_FORCE_UPLOAD=true` alias). `missing` keeps startup idempotent; `overwrite` force re-uploads all required assets so a new face reusing the same filenames replaces Misty's stored images.
- **Emotion-aware talking head motion.** New `talking_head_motion.TalkingHeadMotion` behind `USE_TALKING_HEAD_MOTION` (default off). Runs only during `PLAYING`, stops + re-centers on any transition away from `PLAYING` and on shutdown, hard-clamped to safe head limits, only touches `/api/head`.
- **Consistency fix.** The follow-up movement acknowledgment now applies the same emotion/state face behavior as other playback paths.
- Updated `config_defaults.py`, `.env.example`, and `docs/design-animated-face-expressions.md` (new section 12).

## Acceptance criteria

- [x] Work is based on PR #115 / current `origin/main` before changes.
- [x] All custom face display paths route through a single resolver / always-available `FaceAnimator`.
- [x] Custom face identity and emotion selection work even when `USE_FACE_ANIMATION=false`.
- [x] Direct controller `display_image("face_*")` calls removed / guarded by the resolver.
- [x] Missing assets / failed upload / unreliable inventory / failed display trigger built-in fallback for the current state/emotion.
- [x] Configurable replacement workflow via `FACE_ASSETS_DIR` + explicit force/overwrite mode.
- [x] Docs explain how to replace the face, when to use overwrite, and how to return to idempotent startup.
- [x] Emotion-aware talking head motion behind a config flag, within safe head limits.
- [x] Talking head motion starts only for `PLAYING` and stops/centers when playback ends or an unsafe state occurs.
- [x] Normal responses, follow-ups, movement acknowledgments, and movement-failure speech consistently apply emotion/state face behavior.
- [x] Tests cover disabled-animation identity/fallback, emotion coercion, asset overwrite sync, display-failure fallback, resolver routing, and talking-motion state gating.
- [x] Cloud-safe validation passes with targeted compile/tests; live hardware tests documented separately.

## Verification (cloud-safe)

- `python -m py_compile` on all changed `.py` files — OK.
- `python -m pytest tests/test_talking_head_motion.py tests/test_face_resolver.py tests/test_face_animator.py -q` — 63 passed.
- `python -m pytest tests/ -q -m "not live"` — 272 passed, 4 skipped, 20 deselected, 2 failed. The 2 failures (`TestTTSCache`) are **pre-existing and unrelated** — they fail with `ModuleNotFoundError: No module named 'numpy'` in `orchestration_service` TTS tests (no files touched by this PR).
- `git diff --check` — clean.

## Unavailable / manual validation

Misty II hardware, Foundry Local, live audio/SAPI, and on-robot visual tuning of the talking head motion are **not available** in this environment and were **not run**. Final visual tuning of head-motion amplitude/interval should be validated on the physical robot separately.
