### PR TITLE
Coordinate face, arms, head, LEDs, and sensors for embodied expressions (#74)

### DIFF
--- a/docs/embodied-expression-coordinator.md
+++ b/docs/embodied-expression-coordinator.md
@@ -1,0 +1,163 @@
+# Embodied Expression Coordinator (#74)
+
+**Related issue**: #74
+**Related feature**: #73 (state-driven animated face)
+**Related code**: `src/windows-orchestration/expression_coordinator.py`,
+`src/windows-orchestration/config_defaults.py`
+**Status**: Implemented, config-gated off, pending hardware validation
+
+---
+
+## 1. Summary
+
+The `ExpressionCoordinator` is an optional companion-side layer that maps
+high-level **expression intents** to bounded body choreography — face emotion,
+chest LED color, head pose, arm pose, and an optional sound cue — so Misty can
+show emotions like joy, curiosity, confusion, playful sass/annoyance, sadness,
+and surprise.
+
+It is intentionally separate from face rendering (#73):
+
+- **#73 (`FaceAnimator`)** owns *face rendering* (which frame/GIF is displayed).
+- **This feature (`ExpressionCoordinator`)** owns *expression selection and
+  body/sensor choreography* around the face layer.
+
+The coordinator **delegates** face rendering to the face layer rather than
+duplicating it, and falls back to a static built-in firmware face when the face
+layer is unavailable or disabled.
+
+## 2. Expression states
+
+The shared, constrained `Expression` enum (also intended for #73 alignment):
+
+| Intent | Base face emotion | LED | Notes |
+|---|---|---|---|
+| `joy` | happy | green | wake / recognized speaker / movement accepted |
+| `curious` | curious | cyan | wake / tilt to inspect |
+| `confused` | curious | amber | no speech / empty STT |
+| `thinking` | neutral | purple | processing |
+| `sassy` | happy | magenta | movement accepted (playful) |
+| `annoyed` | sad | orange | movement blocked / bump follow-up |
+| `angry` | sad | red | **playful/sassy only, never threatening** |
+| `sad` | sad | blue | movement blocked / error |
+| `startled` | curious | yellow | bump contact / hazard / close obstacle |
+| `sleepy` | neutral | indigo | low battery / charging |
+| `error` | sad | red | error state |
+
+Face emotions map onto the five base faces the #73 `FaceAnimator` supports
+(`neutral`, `happy`, `excited`, `sad`, `curious`); the static fallback uses a
+built-in `e_*.jpg` firmware face that ships with every Misty II so it never
+fails on a missing file.
+
+### Example triggers
+
+- wake detected → `joy` or `curious`
+- processing → `thinking`
+- no speech / empty STT → `confused`
+- recognized speaker → `joy` (+ small wave)
+- movement accepted → `joy` or `sassy`
+- movement blocked → `annoyed` or `sad`
+- bump contact → `startled` then `annoyed`
+- hazard / close obstacle → `startled` / cautious
+- low battery or charging → `sleepy`
+- error → `sad` / `error`
+
+## 3. Configuration flags
+
+All flags live in `config_defaults.py` (single source of truth) and are
+mirrored in `.env.example`.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `USE_EMBODIED_EXPRESSIONS` | `false` | Master gate. When false the coordinator is a **no-op**; body behavior is identical to today. |
+| `EXPRESSION_HEAD_VELOCITY` | `40.0` | Gentle head-move velocity (percent). |
+| `EXPRESSION_ARM_VELOCITY` | `40.0` | Gentle arm-move velocity (percent). |
+| `EXPRESSION_SENSOR_MIN_INTERVAL_S` | `3.0` | Minimum seconds between repeats of the *same* sensor-triggered expression (rate-limit guard). |
+
+## 4. Safety and constraints
+
+- **Config-gated off** (`USE_EMBODIED_EXPRESSIONS=false`) until hardware
+  validation passes.
+- **Cancellable and non-blocking.** Each intent runs on a short-lived daemon
+  thread that checks a stop event between steps; `cancel()` halts it promptly.
+  It never blocks audio, safety, reboot, charging, movement preemption, or
+  shutdown cleanup.
+- **Safety-gated motion.** Head/arm gestures are issued only when the injected
+  `safety_gate()` predicate returns `True`. During safety-critical states
+  (`MOVING`, `CHARGING`, `ERROR`, shutdown, reboot, movement preemption, and —
+  per the issue's audio caution — recording/listening) the gate returns `False`
+  and motor gestures are skipped. Non-motor face/LED cues may still apply.
+- **Sensor rate-limiting.** `express_for_sensor()` drops repeat expressions that
+  arrive faster than `EXPRESSION_SENSOR_MIN_INTERVAL_S` to avoid gesture spam.
+- **Bounded, conservative motion.** Head poses are clamped to the safe head
+  envelope (`pitch -40..26`, `roll -40..40`, `yaw -81..81`) and arms to
+  (`-29..90`), even if a spec is misconfigured. Velocities are gentle.
+- **Constrained enum only.** The LLM/callers select from the named `Expression`
+  intents; they cannot issue arbitrary arm/head commands through this class.
+- **Drive/tread movement stays separate.** The coordinator never issues drive
+  commands; locomotion safety remains authoritative and untouched.
+
+## 5. Integration
+
+The coordinator takes injected callables so it stays decoupled and testable
+without hardware:
+
+```python
+from expression_coordinator import ExpressionCoordinator, Expression
+import config_defaults as cfg
+
+coord = ExpressionCoordinator(
+    set_led=controller.set_led,
+    move_head=controller.move_head,
+    move_arms=controller.move_arms,
+    # Delegate face rendering to #73's FaceAnimator; static fallback used when
+    # the animator is unavailable.
+    face_callback=lambda emotion, fallback: (
+        face_animator.set_emotion(emotion)
+        if face_animator is not None else controller.show_face(fallback)
+    ),
+    safety_gate=lambda: controller.state not in UNSAFE_STATES,
+    enabled=cfg.USE_EMBODIED_EXPRESSIONS,
+    head_velocity=cfg.EXPRESSION_HEAD_VELOCITY,
+    arm_velocity=cfg.EXPRESSION_ARM_VELOCITY,
+    sensor_min_interval_s=cfg.EXPRESSION_SENSOR_MIN_INTERVAL_S,
+)
+
+coord.express(Expression.JOY)                 # direct intent
+coord.express_for_sensor(Expression.STARTLED) # rate-limited sensor intent
+coord.cancel()                                # halt + re-center (safe states only)
+```
+
+When the face layer is disabled or `#73` is not available, the `face_callback`
+displays the static built-in fallback face, so static face/LED behavior remains
+the fallback path (acceptance criterion).
+
+## 6. Hardware validation steps
+
+Because motor motion cannot be validated in CI, run these on a physical Misty II
+before enabling in production:
+
+1. Set `USE_EMBODIED_EXPRESSIONS=true` in `.env`.
+2. On a charged, clear, flat surface, trigger each `Expression` intent and
+   confirm head/arm poses are gentle, bounded, and non-jarring.
+3. Confirm gestures are **skipped** during `MOVING`, `CHARGING`, `ERROR`,
+   reboot, shutdown, and movement preemption.
+4. **Audio check**: verify arm/head motor noise during a gesture does not
+   corrupt STT while recording/listening. If it does, keep motion gated off
+   during recording/listening (the default safety gate already suppresses it).
+5. Confirm `cancel()` promptly stops motion and re-centers the head/arms.
+6. Confirm sensor-triggered expressions (bump/ToF/hazard) are rate-limited and
+   do not spam gestures.
+7. Confirm the face falls back to a built-in `e_*.jpg` face when custom face
+   assets are unavailable.
+
+## 7. Testing
+
+Hardware-free unit tests live in `tests/test_expression_coordinator.py` and
+cover mapping, disabled-mode no-op, cancellation, safety gating, sensor
+rate-limiting, mechanical-limit clamping, and defensive actuator-failure
+handling. Run:
+
+```bash
+python -m pytest tests/test_expression_coordinator.py -q
+```

--- a/docs/embodied-expression-coordinator.md
+++ b/docs/embodied-expression-coordinator.md
@@ -100,7 +100,23 @@ mirrored in `.env.example`.
 ## 5. Integration
 
 The coordinator takes injected callables so it stays decoupled and testable
-without hardware:
+without hardware. It is wired into `MistyController.__init__`: always
+constructed (a no-op when `USE_EMBODIED_EXPRESSIONS=false`), with
+
+- `set_led` / `move_head` / `move_arms` bound to the controller helpers,
+- a `face_callback` that delegates to the #73 `FaceAnimator.set_emotion(...)`
+  and falls back to `controller.show_face(static_fallback)` when the animator is
+  unavailable,
+- a `safety_gate` (`MistyController._expressions_safe_to_move`) that permits
+  motor gestures only in the safe states
+  (`SAFE_EXPRESSION_STATES = {IDLE, PROCESSING, PLAYING}`) and only while the
+  controller is running, and
+- cancellation on shutdown (`_shutdown()` calls `cancel()` before other cleanup).
+
+State transitions drive a small, unambiguous subset of expressions via
+`STATE_EXPRESSION_MAP` (`PROCESSING → thinking`, `CHARGING → sleepy`,
+`ERROR → error`); richer triggers (wake, sensors, movement outcomes) can build
+on the same `express()` / `express_for_sensor()` API:
 
 ```python
 from expression_coordinator import ExpressionCoordinator, Expression
@@ -116,7 +132,7 @@ coord = ExpressionCoordinator(
         face_animator.set_emotion(emotion)
         if face_animator is not None else controller.show_face(fallback)
     ),
-    safety_gate=lambda: controller.state not in UNSAFE_STATES,
+    safety_gate=controller._expressions_safe_to_move,
     enabled=cfg.USE_EMBODIED_EXPRESSIONS,
     head_velocity=cfg.EXPRESSION_HEAD_VELOCITY,
     arm_velocity=cfg.EXPRESSION_ARM_VELOCITY,

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -132,9 +132,11 @@ USE_TALKING_HEAD_MOTION=false
 # intents (joy, curious, confused, thinking, sassy, annoyed, angry, sad, startled,
 # sleepy, error) to bounded face/LED/head/arm choreography. Off by default until
 # hardware validation passes. Face rendering is delegated to the #73 FaceAnimator
-# with a static built-in-face fallback; choreography is cancellable, non-blocking,
-# safety-gated (never runs during MOVING/CHARGING/ERROR/shutdown or movement
-# preemption), and never issues drive/tread commands.
+# with a static built-in-face fallback; choreography is cancellable, non-blocking
+# and sensor rate-limited. Motor head/arm gestures are safety-gated (suppressed
+# during MOVING/CHARGING/ERROR/reboot/re-arm/recording/listening, shutdown, and
+# movement preemption); non-motor face/LED cues may still apply in those states.
+# It never issues drive/tread commands.
 USE_EMBODIED_EXPRESSIONS=false
 # Gentle move velocities for expression gestures (percent).
 EXPRESSION_HEAD_VELOCITY=40.0

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -126,3 +126,19 @@ FACE_ASSETS_SYNC_MODE=missing
 # runs during MOVING/CHARGING/ERROR/shutdown or drive commands; the head is
 # re-centered when playback ends or the state leaves PLAYING.
 USE_TALKING_HEAD_MOTION=false
+
+# Embodied Expression Coordinator (#74)
+# Enable the optional companion-side coordinator that maps constrained expression
+# intents (joy, curious, confused, thinking, sassy, annoyed, angry, sad, startled,
+# sleepy, error) to bounded face/LED/head/arm choreography. Off by default until
+# hardware validation passes. Face rendering is delegated to the #73 FaceAnimator
+# with a static built-in-face fallback; choreography is cancellable, non-blocking,
+# safety-gated (never runs during MOVING/CHARGING/ERROR/shutdown or movement
+# preemption), and never issues drive/tread commands.
+USE_EMBODIED_EXPRESSIONS=false
+# Gentle move velocities for expression gestures (percent).
+EXPRESSION_HEAD_VELOCITY=40.0
+EXPRESSION_ARM_VELOCITY=40.0
+# Minimum seconds between repeats of the same sensor-triggered expression
+# (rate-limit guard against sensor spam).
+EXPRESSION_SENSOR_MIN_INTERVAL_S=3.0

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -139,3 +139,20 @@ TALKING_HEAD_YAW_RANGE: float = 6.0        # +/- yaw wobble
 TALKING_HEAD_ROLL_RANGE: float = 3.0       # +/- roll wobble
 TALKING_HEAD_VELOCITY: float = 30.0        # gentle move velocity
 TALKING_HEAD_INTERVAL_S: float = 0.8       # seconds between micro-movements
+
+# Embodied expression coordinator (issue #74). Off by default and gated by
+# config until hardware validation passes. When enabled, an optional
+# companion-side coordinator maps constrained expression intents (joy, curious,
+# confused, thinking, sassy, annoyed, angry, sad, startled, sleepy, error) to
+# bounded face/LED/head/arm choreography. Face rendering is delegated to #73's
+# FaceAnimator with a static built-in-face fallback; choreography is cancellable,
+# non-blocking, safety-gated (never runs during MOVING/CHARGING/ERROR/shutdown or
+# movement preemption), and sensor triggers are rate-limited. It never issues
+# drive/tread commands.
+USE_EMBODIED_EXPRESSIONS: bool = False
+# Gentle move velocities for expression gestures (percent).
+EXPRESSION_HEAD_VELOCITY: float = 40.0
+EXPRESSION_ARM_VELOCITY: float = 40.0
+# Minimum seconds between repeats of the same sensor-triggered expression
+# (rate-limit guard against sensor spam from bump/ToF/hazard streams).
+EXPRESSION_SENSOR_MIN_INTERVAL_S: float = 3.0

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -146,9 +146,10 @@ TALKING_HEAD_INTERVAL_S: float = 0.8       # seconds between micro-movements
 # confused, thinking, sassy, annoyed, angry, sad, startled, sleepy, error) to
 # bounded face/LED/head/arm choreography. Face rendering is delegated to #73's
 # FaceAnimator with a static built-in-face fallback; choreography is cancellable,
-# non-blocking, safety-gated (never runs during MOVING/CHARGING/ERROR/shutdown or
-# movement preemption), and sensor triggers are rate-limited. It never issues
-# drive/tread commands.
+# non-blocking and sensor rate-limited. Motor head/arm gestures are safety-gated
+# (suppressed during MOVING/CHARGING/ERROR/reboot/re-arm/recording/listening,
+# shutdown, and movement preemption); non-motor face/LED cues may still apply in
+# those states. It never issues drive/tread commands.
 USE_EMBODIED_EXPRESSIONS: bool = False
 # Gentle move velocities for expression gestures (percent).
 EXPRESSION_HEAD_VELOCITY: float = 40.0

--- a/src/windows-orchestration/expression_coordinator.py
+++ b/src/windows-orchestration/expression_coordinator.py
@@ -286,6 +286,11 @@ class ExpressionCoordinator:
         spec = EXPRESSION_CHOREOGRAPHY[expr]
         # Newest intent wins: cancel any running gesture without re-centering.
         self._stop_thread(center=False)
+        if self.is_active:
+            logger.debug(
+                "ExpressionCoordinator: previous gesture did not stop within timeout; skipping new expression"
+            )
+            return False
         with self._lock:
             self._stop_event = threading.Event()
             self._thread = threading.Thread(

--- a/src/windows-orchestration/expression_coordinator.py
+++ b/src/windows-orchestration/expression_coordinator.py
@@ -1,0 +1,430 @@
+"""
+Embodied expression coordinator for Misty II (issue #74).
+
+Provides a self-contained ``ExpressionCoordinator`` that maps high-level
+*expression intents* (joy, curious, confused, ...) to bounded body choreography:
+face emotion, LED color, head pose, arm pose, and an optional sound cue. It is
+deliberately decoupled from the drive/locomotion safety subsystem and from face
+rendering itself:
+
+- **Face rendering is delegated**, not duplicated. The coordinator calls a
+  caller-supplied ``face_callback(emotion, static_fallback)`` which, in the live
+  system, routes through issue #73's ``FaceAnimator`` (``set_emotion`` /
+  ``show_asset``). When #73 is unavailable/disabled, the same callback can fall
+  back to a static built-in firmware face, so static face/LED behavior remains
+  the fallback path.
+- **All actuation goes through injected callables** (``set_led``,
+  ``move_head``, ``move_arms``, ``face_callback``, optional ``play_sound``).
+  This keeps the module testable without live Misty hardware.
+- **Choreography is cancellable and non-blocking.** Each intent runs on a single
+  short-lived daemon thread that checks a stop event between steps; ``cancel()``
+  halts it promptly. It never blocks audio, safety, reboot, charging, movement
+  preemption, or shutdown cleanup.
+- **Safety gating.** Before issuing head/arm gestures the coordinator consults a
+  caller-supplied ``safety_gate()`` predicate. When it returns ``False`` (e.g.
+  MOVING/CHARGING/ERROR/shutdown/movement preemption/recording) the coordinator
+  skips motor gestures. Non-motor face/LED cues are still allowed because they
+  do not move the robot.
+- **Sensor rate-limiting.** ``express_for_sensor()`` drops repeat expressions
+  that arrive faster than ``sensor_min_interval_s`` to avoid gesture spam from
+  chatty sensor streams (bump, ToF, hazard).
+- **Config-gated.** When ``enabled`` is ``False`` (default,
+  ``USE_EMBODIED_EXPRESSIONS=false``) every public method is a no-op, so body
+  behavior is identical to today.
+
+Only the constrained expression enum below can drive gestures — callers cannot
+issue arbitrary arm/head commands through this class, and drive/tread movement
+is intentionally out of scope here.
+
+Usage::
+
+    coord = ExpressionCoordinator(
+        set_led=controller.set_led,
+        move_head=controller.move_head,
+        move_arms=controller.move_arms,
+        face_callback=lambda emotion, fallback: face_animator.set_emotion(emotion),
+        safety_gate=lambda: controller.state not in UNSAFE_STATES,
+        enabled=USE_EMBODIED_EXPRESSIONS,
+    )
+    coord.express(Expression.JOY)          # direct intent
+    coord.express_for_sensor(Expression.STARTLED)  # rate-limited sensor intent
+    coord.cancel()                         # halt + re-center (safe states only)
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class Expression(str, Enum):
+    """Shared expression enum for embodied expression + face animation (#74/#73).
+
+    Kept intentionally small and constrained. The LLM/callers select from these
+    named intents only; they never issue raw arm/head commands.
+    """
+
+    JOY = "joy"
+    CURIOUS = "curious"
+    CONFUSED = "confused"
+    THINKING = "thinking"
+    SASSY = "sassy"
+    ANNOYED = "annoyed"
+    ANGRY = "angry"  # playful/sassy only, never threatening
+    SAD = "sad"
+    STARTLED = "startled"
+    SLEEPY = "sleepy"
+    ERROR = "error"
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+@dataclass(frozen=True)
+class ChoreographySpec:
+    """Bounded choreography for one expression intent.
+
+    Attributes:
+        face_emotion: Emotion passed to the face layer (#73 ``FaceAnimator``
+            supports neutral/happy/excited/sad/curious). Chosen as the closest
+            supported base face for the intent.
+        static_fallback: Built-in firmware face (``e_*.jpg``) used when the face
+            layer is unavailable/disabled. Ships with every Misty II, so it never
+            fails on a missing file.
+        led: ``(r, g, b)`` chest LED color for the intent.
+        head: Optional ``(pitch, roll, yaw)`` head pose, or ``None`` to leave the
+            head where it is. Values are clamped to the safe head envelope.
+        arms: Optional ``(left, right)`` arm pose, or ``None`` to leave the arms
+            where they are. Values are clamped to the safe arm envelope.
+        sound: Optional Misty sound-cue filename, or ``None`` for silence.
+    """
+
+    face_emotion: str
+    static_fallback: str
+    led: tuple
+    head: Optional[tuple] = None
+    arms: Optional[tuple] = None
+    sound: Optional[str] = None
+
+
+# Face emotions supported by #73's FaceAnimator. Kept in sync with
+# face_animator.VALID_EMOTIONS; expression intents map onto these base faces.
+_SUPPORTED_FACE_EMOTIONS = frozenset({"neutral", "happy", "excited", "sad", "curious"})
+
+# Neutral resting pose used to re-center head/arms after a gesture. Slight
+# up-tilt for eye contact; arms relaxed down.
+NEUTRAL_HEAD = (-10.0, 0.0, 0.0)   # (pitch, roll, yaw)
+NEUTRAL_ARMS = (80.0, 80.0)        # (left, right) — relaxed down
+
+# The choreography map. Every expression intent has a bounded spec. Head/arm
+# poses stay well inside Misty's mechanical limits (see hard clamps below).
+EXPRESSION_CHOREOGRAPHY: dict[Expression, ChoreographySpec] = {
+    Expression.JOY: ChoreographySpec(
+        face_emotion="happy", static_fallback="e_Joy.jpg",
+        led=(0, 200, 0), head=(-18.0, 0.0, 0.0), arms=(-10.0, -10.0),
+    ),
+    Expression.CURIOUS: ChoreographySpec(
+        face_emotion="curious", static_fallback="e_Surprise.jpg",
+        led=(0, 150, 200), head=(-8.0, 15.0, 20.0), arms=(60.0, 80.0),
+    ),
+    Expression.CONFUSED: ChoreographySpec(
+        face_emotion="curious", static_fallback="e_Contempt.jpg",
+        led=(180, 120, 0), head=(-5.0, 20.0, -15.0), arms=(70.0, 70.0),
+    ),
+    Expression.THINKING: ChoreographySpec(
+        face_emotion="neutral", static_fallback="e_Contempt.jpg",
+        led=(120, 0, 200), head=(5.0, 10.0, 10.0), arms=(80.0, 80.0),
+    ),
+    Expression.SASSY: ChoreographySpec(
+        face_emotion="happy", static_fallback="e_Joy2.jpg",
+        led=(220, 0, 150), head=(-10.0, -12.0, -18.0), arms=(30.0, 80.0),
+    ),
+    Expression.ANNOYED: ChoreographySpec(
+        face_emotion="sad", static_fallback="e_Contempt.jpg",
+        led=(200, 80, 0), head=(0.0, -10.0, 0.0), arms=(80.0, 80.0),
+    ),
+    Expression.ANGRY: ChoreographySpec(  # playful/sassy only, not threatening
+        face_emotion="sad", static_fallback="e_Anger.jpg",
+        led=(200, 20, 0), head=(2.0, 0.0, 0.0), arms=(50.0, 50.0),
+    ),
+    Expression.SAD: ChoreographySpec(
+        face_emotion="sad", static_fallback="e_Sadness.jpg",
+        led=(0, 0, 180), head=(20.0, 0.0, 0.0), arms=(85.0, 85.0),
+    ),
+    Expression.STARTLED: ChoreographySpec(
+        face_emotion="curious", static_fallback="e_Surprise.jpg",
+        led=(255, 255, 0), head=(-30.0, 0.0, 0.0), arms=(0.0, 0.0),
+    ),
+    Expression.SLEEPY: ChoreographySpec(
+        face_emotion="neutral", static_fallback="e_Sleepy.jpg",
+        led=(60, 40, 120), head=(20.0, 0.0, 0.0), arms=(85.0, 85.0),
+    ),
+    Expression.ERROR: ChoreographySpec(
+        face_emotion="sad", static_fallback="e_Sadness.jpg",
+        led=(200, 0, 0), head=(10.0, 0.0, 0.0), arms=(80.0, 80.0),
+    ),
+}
+
+
+def coerce_expression(value) -> Optional[Expression]:
+    """Coerce a string/enum into a known ``Expression`` or ``None``.
+
+    Returns ``None`` for unknown/empty values so callers can decide whether to
+    skip rather than raise.
+    """
+    if isinstance(value, Expression):
+        return value
+    if not isinstance(value, str):
+        return None
+    key = value.strip().lower()
+    try:
+        return Expression(key)
+    except ValueError:
+        return None
+
+
+class ExpressionCoordinator:
+    """Maps expression intents to bounded, cancellable body choreography.
+
+    Args:
+        set_led: Callable ``(r, g, b)`` to set the chest LED.
+        move_head: Callable ``(pitch, roll, yaw, velocity)`` to move the head.
+        move_arms: Callable ``(left, right, velocity)`` to move the arms.
+        face_callback: Callable ``(emotion, static_fallback)`` that renders the
+            face. In the live system this delegates to #73's ``FaceAnimator``;
+            when the face layer is unavailable it can display ``static_fallback``.
+            Optional — if ``None``, face rendering is skipped (LED/motion still
+            apply).
+        play_sound: Optional callable ``(filename)`` for a sound cue.
+        safety_gate: Optional predicate returning ``True`` when it is safe to
+            issue head/arm gestures. When it returns ``False`` motor gestures are
+            skipped; face/LED cues still apply. Defaults to always-safe.
+        enabled: If ``False`` (default), all public methods are no-ops.
+        head_velocity/arm_velocity: Gentle move velocities for gestures.
+        sensor_min_interval_s: Minimum seconds between sensor-triggered
+            expressions (rate-limit guard against sensor spam).
+        recenter: If ``True``, ``cancel()`` returns head/arms to a neutral pose
+            (only when the safety gate allows motion).
+    """
+
+    STOP_TIMEOUT_S = 2.0
+
+    # Hard safety clamps — even if a spec is misconfigured, never exceed these.
+    PITCH_MIN, PITCH_MAX = -40.0, 26.0
+    ROLL_MIN, ROLL_MAX = -40.0, 40.0
+    YAW_MIN, YAW_MAX = -81.0, 81.0
+    ARM_MIN, ARM_MAX = -29.0, 90.0
+
+    def __init__(
+        self,
+        set_led: Optional[Callable[..., None]] = None,
+        move_head: Optional[Callable[..., None]] = None,
+        move_arms: Optional[Callable[..., None]] = None,
+        face_callback: Optional[Callable[[str, str], None]] = None,
+        play_sound: Optional[Callable[[str], None]] = None,
+        safety_gate: Optional[Callable[[], bool]] = None,
+        enabled: bool = False,
+        head_velocity: float = 40.0,
+        arm_velocity: float = 40.0,
+        sensor_min_interval_s: float = 3.0,
+        recenter: bool = True,
+    ):
+        self._set_led = set_led
+        self._move_head = move_head
+        self._move_arms = move_arms
+        self._face_callback = face_callback
+        self._play_sound = play_sound
+        self._safety_gate = safety_gate
+        self._enabled = bool(enabled)
+        self._head_velocity = head_velocity
+        self._arm_velocity = arm_velocity
+        self._sensor_min_interval_s = max(0.0, sensor_min_interval_s)
+        self._recenter = bool(recenter)
+
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._last_sensor_ts: dict[Expression, float] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def is_active(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def _is_safe_to_move(self) -> bool:
+        """Whether head/arm gestures may be issued right now."""
+        if self._safety_gate is None:
+            return True
+        try:
+            return bool(self._safety_gate())
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"ExpressionCoordinator safety_gate raised: {e}")
+            return False
+
+    def express(self, expression, source: str = "direct") -> bool:
+        """Run choreography for an expression intent. No-op if disabled.
+
+        Non-blocking: choreography runs on a short-lived daemon thread. Any
+        in-flight choreography is cancelled first so the newest intent wins.
+        Returns ``True`` if a choreography was started, ``False`` otherwise
+        (disabled or unknown expression).
+        """
+        if not self._enabled:
+            return False
+        expr = coerce_expression(expression)
+        if expr is None:
+            logger.debug(f"ExpressionCoordinator: unknown expression {expression!r}; ignoring")
+            return False
+        spec = EXPRESSION_CHOREOGRAPHY[expr]
+        # Newest intent wins: cancel any running gesture without re-centering.
+        self._stop_thread(center=False)
+        with self._lock:
+            self._stop_event = threading.Event()
+            self._thread = threading.Thread(
+                target=self._run_choreography,
+                args=(expr, spec, self._stop_event),
+                name=f"ExpressionCoordinator-{expr.value}",
+                daemon=True,
+            )
+            self._thread.start()
+        logger.debug(f"ExpressionCoordinator: expressing {expr.value} (source={source})")
+        return True
+
+    def express_for_sensor(self, expression) -> bool:
+        """Rate-limited expression for sensor-triggered reactions.
+
+        Drops the intent if the same expression fired more recently than
+        ``sensor_min_interval_s`` to avoid gesture spam from chatty sensors.
+        Returns ``True`` if the expression was accepted and started.
+        """
+        if not self._enabled:
+            return False
+        expr = coerce_expression(expression)
+        if expr is None:
+            return False
+        now = time.monotonic()
+        with self._lock:
+            last = self._last_sensor_ts.get(expr)
+            if last is not None and (now - last) < self._sensor_min_interval_s:
+                logger.debug(
+                    f"ExpressionCoordinator: rate-limited sensor expression {expr.value}"
+                )
+                return False
+            self._last_sensor_ts[expr] = now
+        return self.express(expr, source="sensor")
+
+    def cancel(self) -> None:
+        """Cancel any in-flight choreography. No-op if disabled.
+
+        Bounded join; best-effort; never raises. Re-centers head/arms when
+        ``recenter`` is set and the safety gate permits motion.
+        """
+        if not self._enabled:
+            return
+        self._stop_thread(center=self._recenter)
+
+    def _stop_thread(self, center: bool) -> None:
+        with self._lock:
+            thread = self._thread
+            stop_event = self._stop_event
+            self._thread = None
+        if stop_event is not None:
+            stop_event.set()
+        if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=self.STOP_TIMEOUT_S)
+            if thread.is_alive():
+                logger.debug("ExpressionCoordinator thread did not stop within timeout")
+        if center:
+            self._recenter_body()
+
+    def _run_choreography(self, expr: Expression, spec: ChoreographySpec, stop_event: threading.Event) -> None:
+        """Apply the bounded choreography for ``expr``. Runs on its own thread.
+
+        Order: face + LED first (non-motor, always safe), then head/arm gestures
+        only when the safety gate permits. Checks ``stop_event`` between steps so
+        cancellation is prompt. Never raises out of the thread.
+        """
+        # Face (delegated to #73 / static fallback) — non-motor, always safe.
+        if not stop_event.is_set():
+            self._apply_face(spec)
+        # LED — non-motor, always safe.
+        if not stop_event.is_set():
+            self._apply_led(spec)
+        # Head/arm gestures — motor actuation, gated by safety.
+        if stop_event.is_set():
+            return
+        if not self._is_safe_to_move():
+            logger.debug(
+                f"ExpressionCoordinator: safety gate blocked motion for {expr.value}"
+            )
+            return
+        if not stop_event.is_set() and spec.head is not None:
+            self._apply_head(spec.head)
+        if not stop_event.is_set() and spec.arms is not None:
+            self._apply_arms(spec.arms)
+        # Optional sound cue last, still cancellable.
+        if not stop_event.is_set() and spec.sound and self._play_sound is not None:
+            try:
+                self._play_sound(spec.sound)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.debug(f"ExpressionCoordinator sound cue failed: {e}")
+
+    def _apply_face(self, spec: ChoreographySpec) -> None:
+        if self._face_callback is None:
+            return
+        emotion = spec.face_emotion if spec.face_emotion in _SUPPORTED_FACE_EMOTIONS else "neutral"
+        try:
+            self._face_callback(emotion, spec.static_fallback)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"ExpressionCoordinator face callback failed: {e}")
+
+    def _apply_led(self, spec: ChoreographySpec) -> None:
+        if self._set_led is None:
+            return
+        try:
+            r, g, b = spec.led
+            self._set_led(int(_clamp(r, 0, 255)), int(_clamp(g, 0, 255)), int(_clamp(b, 0, 255)))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"ExpressionCoordinator LED failed: {e}")
+
+    def _apply_head(self, head: tuple) -> None:
+        if self._move_head is None:
+            return
+        try:
+            pitch, roll, yaw = head
+            self._move_head(
+                pitch=_clamp(pitch, self.PITCH_MIN, self.PITCH_MAX),
+                roll=_clamp(roll, self.ROLL_MIN, self.ROLL_MAX),
+                yaw=_clamp(yaw, self.YAW_MIN, self.YAW_MAX),
+                velocity=self._head_velocity,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"ExpressionCoordinator head move failed: {e}")
+
+    def _apply_arms(self, arms: tuple) -> None:
+        if self._move_arms is None:
+            return
+        try:
+            left, right = arms
+            self._move_arms(
+                left=_clamp(left, self.ARM_MIN, self.ARM_MAX),
+                right=_clamp(right, self.ARM_MIN, self.ARM_MAX),
+                velocity=self._arm_velocity,
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"ExpressionCoordinator arm move failed: {e}")
+
+    def _recenter_body(self) -> None:
+        """Return head/arms to a neutral resting pose. Motor-gated, best-effort."""
+        if not self._is_safe_to_move():
+            return
+        self._apply_head(NEUTRAL_HEAD)
+        self._apply_arms(NEUTRAL_ARMS)

--- a/src/windows-orchestration/expression_coordinator.py
+++ b/src/windows-orchestration/expression_coordinator.py
@@ -338,11 +338,16 @@ class ExpressionCoordinator:
             self._thread = None
         if stop_event is not None:
             stop_event.set()
+        stopped = True
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
             thread.join(timeout=self.STOP_TIMEOUT_S)
             if thread.is_alive():
+                # Actuator call may be hung; do NOT issue a re-center from this
+                # thread while the prior choreography thread is still running, to
+                # avoid concurrent/overlapping motor commands.
+                stopped = False
                 logger.debug("ExpressionCoordinator thread did not stop within timeout")
-        if center:
+        if center and stopped:
             self._recenter_body()
 
     def _run_choreography(self, expr: Expression, spec: ChoreographySpec, stop_event: threading.Event) -> None:

--- a/src/windows-orchestration/expression_coordinator.py
+++ b/src/windows-orchestration/expression_coordinator.py
@@ -335,18 +335,20 @@ class ExpressionCoordinator:
         with self._lock:
             thread = self._thread
             stop_event = self._stop_event
-            self._thread = None
         if stop_event is not None:
             stop_event.set()
         stopped = True
         if thread is not None and thread.is_alive() and thread is not threading.current_thread():
             thread.join(timeout=self.STOP_TIMEOUT_S)
             if thread.is_alive():
-                # Actuator call may be hung; do NOT issue a re-center from this
-                # thread while the prior choreography thread is still running, to
-                # avoid concurrent/overlapping motor commands.
+                # Actuator call may be hung; keep tracking the thread so callers
+                # can observe it via is_active and avoid overlapping gestures.
                 stopped = False
                 logger.debug("ExpressionCoordinator thread did not stop within timeout")
+        if stopped:
+            with self._lock:
+                if self._thread is thread:
+                    self._thread = None
         if center and stopped:
             self._recenter_body()
 

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -114,6 +114,19 @@ USE_TALKING_HEAD_MOTION = os.getenv(
 USE_EMBODIED_EXPRESSIONS = os.getenv(
     "USE_EMBODIED_EXPRESSIONS", str(config_defaults.USE_EMBODIED_EXPRESSIONS)
 ).lower() in ("1", "true", "yes")
+# Tunable expression gesture parameters (env-overridable, defaults from config).
+EXPRESSION_HEAD_VELOCITY = float(
+    os.getenv("EXPRESSION_HEAD_VELOCITY", str(config_defaults.EXPRESSION_HEAD_VELOCITY))
+)
+EXPRESSION_ARM_VELOCITY = float(
+    os.getenv("EXPRESSION_ARM_VELOCITY", str(config_defaults.EXPRESSION_ARM_VELOCITY))
+)
+EXPRESSION_SENSOR_MIN_INTERVAL_S = float(
+    os.getenv(
+        "EXPRESSION_SENSOR_MIN_INTERVAL_S",
+        str(config_defaults.EXPRESSION_SENSOR_MIN_INTERVAL_S),
+    )
+)
 
 # Keyphrase watchdog — detects silent failures and auto-recovers
 WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", str(config_defaults.WATCHDOG_IDLE_TIMEOUT_S)))  # 90s after rearm with no wake event
@@ -364,9 +377,9 @@ class MistyController:
             ),
             safety_gate=self._expressions_safe_to_move,
             enabled=USE_EMBODIED_EXPRESSIONS,
-            head_velocity=config_defaults.EXPRESSION_HEAD_VELOCITY,
-            arm_velocity=config_defaults.EXPRESSION_ARM_VELOCITY,
-            sensor_min_interval_s=config_defaults.EXPRESSION_SENSOR_MIN_INTERVAL_S,
+            head_velocity=EXPRESSION_HEAD_VELOCITY,
+            arm_velocity=EXPRESSION_ARM_VELOCITY,
+            sensor_min_interval_s=EXPRESSION_SENSOR_MIN_INTERVAL_S,
         )
 
     # States in which expressive head/arm gestures are allowed. Motor gestures

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -107,6 +107,14 @@ USE_TALKING_HEAD_MOTION = os.getenv(
     "USE_TALKING_HEAD_MOTION", str(config_defaults.USE_TALKING_HEAD_MOTION)
 ).lower() in ("1", "true", "yes")
 
+# Embodied expression coordinator (#74) — off by default, gated here. Maps
+# constrained expression intents to bounded face/LED/head/arm choreography.
+# Cancellable, non-blocking, safety-gated (motor gestures only in safe states),
+# and sensor rate-limited; never issues drive/tread commands.
+USE_EMBODIED_EXPRESSIONS = os.getenv(
+    "USE_EMBODIED_EXPRESSIONS", str(config_defaults.USE_EMBODIED_EXPRESSIONS)
+).lower() in ("1", "true", "yes")
+
 # Keyphrase watchdog — detects silent failures and auto-recovers
 WATCHDOG_IDLE_TIMEOUT_S = float(os.getenv("WATCHDOG_IDLE_TIMEOUT_S", str(config_defaults.WATCHDOG_IDLE_TIMEOUT_S)))  # 90s after rearm with no wake event
 WATCHDOG_ESCALATE_TIMEOUT_S = float(os.getenv("WATCHDOG_ESCALATE_TIMEOUT_S", str(config_defaults.WATCHDOG_ESCALATE_TIMEOUT_S)))  # 60s after recovery attempt
@@ -339,6 +347,57 @@ class MistyController:
             interval_s=config_defaults.TALKING_HEAD_INTERVAL_S,
         )
 
+        # Embodied expression coordinator (#74) — always constructed; a no-op
+        # when disabled (USE_EMBODIED_EXPRESSIONS=false). Maps constrained
+        # expression intents to bounded face/LED/head/arm choreography. Face
+        # rendering is delegated to the FaceAnimator (with its own built-in
+        # fallback); motor gestures are gated to safe states only and drive/tread
+        # movement is never issued here.
+        from expression_coordinator import ExpressionCoordinator
+        self._expression_coordinator = ExpressionCoordinator(
+            set_led=self.set_led,
+            move_head=self.move_head,
+            move_arms=self.move_arms,
+            face_callback=lambda emotion, fallback: (
+                self._face_animator.set_emotion(emotion)
+                if self._face_animator is not None else self.show_face(fallback)
+            ),
+            safety_gate=self._expressions_safe_to_move,
+            enabled=USE_EMBODIED_EXPRESSIONS,
+            head_velocity=config_defaults.EXPRESSION_HEAD_VELOCITY,
+            arm_velocity=config_defaults.EXPRESSION_ARM_VELOCITY,
+            sensor_min_interval_s=config_defaults.EXPRESSION_SENSOR_MIN_INTERVAL_S,
+        )
+
+    # States in which expressive head/arm gestures are allowed. Motor gestures
+    # are suppressed everywhere else (movement, charging, error, reboot, re-arm,
+    # recording/listening audio capture, disconnected, and during shutdown) so
+    # gestures never interfere with safety-critical behavior or audio (#74).
+    SAFE_EXPRESSION_STATES = frozenset({State.IDLE, State.PROCESSING, State.PLAYING})
+
+    def _expressions_safe_to_move(self) -> bool:
+        """Safety gate for the ExpressionCoordinator's motor gestures (#74)."""
+        return bool(getattr(self, "running", False)) and self.state in self.SAFE_EXPRESSION_STATES
+
+    # Representative state -> expression intent mapping (#74). Only a small,
+    # unambiguous subset drives expressions from state transitions; richer
+    # trigger wiring (wake, sensors, movement outcomes) can build on this.
+    # Values are intent strings coerced by the coordinator.
+    STATE_EXPRESSION_MAP = {
+        State.PROCESSING: "thinking",
+        State.CHARGING: "sleepy",
+        State.ERROR: "error",
+    }
+
+    def _express_for_state(self, new_state: State) -> None:
+        """Drive a bounded expression for a state transition. No-op if disabled."""
+        coord = getattr(self, "_expression_coordinator", None)
+        if coord is None or not coord.enabled:
+            return
+        intent = self.STATE_EXPRESSION_MAP.get(new_state)
+        if intent:
+            coord.express(intent, source="state")
+
     # --- State transitions ---
 
     def set_state(self, new_state: State):
@@ -354,9 +413,11 @@ class MistyController:
             # reboot/re-arm or any other state (#116).
             if new_state != State.PLAYING and getattr(self, "_talking_head", None):
                 self._talking_head.stop()
+            self._express_for_state(new_state)
 
     def try_set_state(self, expected: State, new_state: State) -> bool:
         """Atomic compare-and-swap for state transitions. Returns True if successful."""
+        transitioned = False
         with self.state_lock:
             if self.state == expected:
                 old = self.state
@@ -366,8 +427,13 @@ class MistyController:
                     self._face_animator.set_state(new_state)
                 if new_state != State.PLAYING and getattr(self, "_talking_head", None):
                     self._talking_head.stop()
-                return True
-            return False
+                transitioned = True
+        if transitioned:
+            # Outside the state lock: the coordinator is non-blocking but may join
+            # a prior bounded gesture thread; keep that off the state lock.
+            self._express_for_state(new_state)
+            return True
+        return False
 
     def get_state(self) -> State:
         with self.state_lock:
@@ -1660,6 +1726,8 @@ class MistyController:
         logger.info("Shutting down...")
         self.running = False
         # Stop face animator first (§6.3 — before existing cleanup sequence)
+        if getattr(self, "_expression_coordinator", None):
+            self._expression_coordinator.cancel()  # halt any in-flight gesture (#74)
         if self._talking_head:
             self._talking_head.stop()  # halt + re-center head motion (#116)
         if self._face_animator:

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -373,7 +373,8 @@ class MistyController:
             move_arms=self.move_arms,
             face_callback=lambda emotion, fallback: (
                 self._face_animator.set_emotion(emotion)
-                if self._face_animator is not None else self.show_face(fallback)
+                if (self._face_animator is not None and self.state == State.PLAYING)
+                else self.show_face(fallback)
             ),
             safety_gate=self._expressions_safe_to_move,
             enabled=USE_EMBODIED_EXPRESSIONS,

--- a/tests/test_expression_coordinator.py
+++ b/tests/test_expression_coordinator.py
@@ -113,7 +113,7 @@ class TestCoerceExpression:
 
 class TestChoreographyMap:
     def test_every_expression_has_spec(self):
-        for expr in Expression:
+        for expr in list(Expression):
             assert expr in EXPRESSION_CHOREOGRAPHY
             assert isinstance(EXPRESSION_CHOREOGRAPHY[expr], ChoreographySpec)
 
@@ -177,7 +177,7 @@ class TestEnabledChoreography:
         assert rec.snapshot()["led"] == []
 
     def test_all_expressions_stay_within_limits(self):
-        for expr in Expression:
+        for expr in list(Expression):
             coord, rec = _make(enabled=True)
             coord.express(expr)
             _drain(coord)

--- a/tests/test_expression_coordinator.py
+++ b/tests/test_expression_coordinator.py
@@ -1,0 +1,308 @@
+"""
+Unit tests for ExpressionCoordinator (issue #74).
+
+Validates the gated, hardware-free embodied expression coordinator:
+- disabled = no-op (body behavior unchanged from baseline)
+- every expression intent maps to a bounded choreography spec
+- face rendering is delegated (callback) and LED/head/arm actuation is invoked
+- head/arm poses stay within Misty's mechanical limits (even if misconfigured)
+- choreography is cancellable
+- safety gating skips motor gestures but still allows non-motor face/LED cues
+- sensor-triggered expressions are rate-limited
+"""
+
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration"))
+
+from expression_coordinator import (  # noqa: E402
+    Expression,
+    ExpressionCoordinator,
+    ChoreographySpec,
+    EXPRESSION_CHOREOGRAPHY,
+    coerce_expression,
+    NEUTRAL_HEAD,
+    NEUTRAL_ARMS,
+    _SUPPORTED_FACE_EMOTIONS,
+)
+
+
+class _Recorder:
+    """Thread-safe recorder of actuation callbacks."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.led = []
+        self.head = []
+        self.arms = []
+        self.faces = []
+        self.sounds = []
+
+    def set_led(self, r, g, b):
+        with self._lock:
+            self.led.append((r, g, b))
+
+    def move_head(self, pitch=0, roll=0, yaw=0, velocity=50):
+        with self._lock:
+            self.head.append({"pitch": pitch, "roll": roll, "yaw": yaw, "velocity": velocity})
+
+    def move_arms(self, left=None, right=None, velocity=50):
+        with self._lock:
+            self.arms.append({"left": left, "right": right, "velocity": velocity})
+
+    def face(self, emotion, static_fallback):
+        with self._lock:
+            self.faces.append((emotion, static_fallback))
+
+    def play_sound(self, filename):
+        with self._lock:
+            self.sounds.append(filename)
+
+    def snapshot(self):
+        with self._lock:
+            return {
+                "led": list(self.led),
+                "head": list(self.head),
+                "arms": list(self.arms),
+                "faces": list(self.faces),
+                "sounds": list(self.sounds),
+            }
+
+
+def _make(enabled=True, safety_gate=None, rec=None, **kw):
+    rec = rec or _Recorder()
+    coord = ExpressionCoordinator(
+        set_led=rec.set_led,
+        move_head=rec.move_head,
+        move_arms=rec.move_arms,
+        face_callback=rec.face,
+        play_sound=rec.play_sound,
+        safety_gate=safety_gate,
+        enabled=enabled,
+        **kw,
+    )
+    return coord, rec
+
+
+def _drain(coord, timeout=1.0):
+    """Wait for the current choreography thread to finish."""
+    deadline = time.monotonic() + timeout
+    while coord.is_active and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+
+class TestCoerceExpression:
+    def test_known_string(self):
+        assert coerce_expression("joy") is Expression.JOY
+        assert coerce_expression("STARTLED") is Expression.STARTLED
+
+    def test_enum_passthrough(self):
+        assert coerce_expression(Expression.SAD) is Expression.SAD
+
+    def test_unknown_returns_none(self):
+        assert coerce_expression("furious") is None
+        assert coerce_expression("") is None
+        assert coerce_expression(None) is None
+        assert coerce_expression(123) is None
+
+
+class TestChoreographyMap:
+    def test_every_expression_has_spec(self):
+        for expr in Expression:
+            assert expr in EXPRESSION_CHOREOGRAPHY
+            assert isinstance(EXPRESSION_CHOREOGRAPHY[expr], ChoreographySpec)
+
+    def test_face_emotions_supported_by_face_layer(self):
+        for spec in EXPRESSION_CHOREOGRAPHY.values():
+            assert spec.face_emotion in _SUPPORTED_FACE_EMOTIONS
+
+    def test_static_fallback_is_builtin_face(self):
+        for spec in EXPRESSION_CHOREOGRAPHY.values():
+            assert spec.static_fallback.startswith("e_")
+            assert spec.static_fallback.endswith(".jpg")
+
+    def test_specs_within_mechanical_limits(self):
+        for spec in EXPRESSION_CHOREOGRAPHY.values():
+            if spec.head is not None:
+                pitch, roll, yaw = spec.head
+                assert ExpressionCoordinator.PITCH_MIN <= pitch <= ExpressionCoordinator.PITCH_MAX
+                assert ExpressionCoordinator.ROLL_MIN <= roll <= ExpressionCoordinator.ROLL_MAX
+                assert ExpressionCoordinator.YAW_MIN <= yaw <= ExpressionCoordinator.YAW_MAX
+            if spec.arms is not None:
+                left, right = spec.arms
+                assert ExpressionCoordinator.ARM_MIN <= left <= ExpressionCoordinator.ARM_MAX
+                assert ExpressionCoordinator.ARM_MIN <= right <= ExpressionCoordinator.ARM_MAX
+
+
+class TestDisabledIsNoOp:
+    def test_express_noop_when_disabled(self):
+        coord, rec = _make(enabled=False)
+        assert coord.express(Expression.JOY) is False
+        time.sleep(0.1)
+        assert rec.snapshot() == {"led": [], "head": [], "arms": [], "faces": [], "sounds": []}
+        assert coord.is_active is False
+
+    def test_sensor_and_cancel_noop_when_disabled(self):
+        coord, rec = _make(enabled=False)
+        assert coord.express_for_sensor(Expression.STARTLED) is False
+        coord.cancel()  # must not raise
+        assert rec.snapshot()["head"] == []
+
+    def test_enabled_property(self):
+        coord, _ = _make(enabled=False)
+        assert coord.enabled is False
+
+
+class TestEnabledChoreography:
+    def test_express_applies_face_led_head_arms(self):
+        coord, rec = _make(enabled=True)
+        assert coord.express(Expression.JOY) is True
+        _drain(coord)
+        snap = rec.snapshot()
+        spec = EXPRESSION_CHOREOGRAPHY[Expression.JOY]
+        assert snap["faces"] == [(spec.face_emotion, spec.static_fallback)]
+        assert snap["led"] == [spec.led]
+        assert len(snap["head"]) == 1
+        assert len(snap["arms"]) == 1
+
+    def test_unknown_expression_ignored(self):
+        coord, rec = _make(enabled=True)
+        assert coord.express("furious") is False
+        time.sleep(0.05)
+        assert rec.snapshot()["led"] == []
+
+    def test_all_expressions_stay_within_limits(self):
+        for expr in Expression:
+            coord, rec = _make(enabled=True)
+            coord.express(expr)
+            _drain(coord)
+            snap = rec.snapshot()
+            for h in snap["head"]:
+                assert ExpressionCoordinator.PITCH_MIN <= h["pitch"] <= ExpressionCoordinator.PITCH_MAX
+                assert ExpressionCoordinator.ROLL_MIN <= h["roll"] <= ExpressionCoordinator.ROLL_MAX
+                assert ExpressionCoordinator.YAW_MIN <= h["yaw"] <= ExpressionCoordinator.YAW_MAX
+            for a in snap["arms"]:
+                assert ExpressionCoordinator.ARM_MIN <= a["left"] <= ExpressionCoordinator.ARM_MAX
+                assert ExpressionCoordinator.ARM_MIN <= a["right"] <= ExpressionCoordinator.ARM_MAX
+
+    def test_face_callback_optional(self):
+        # No face callback -> LED/motion still applied, no crash.
+        rec = _Recorder()
+        coord = ExpressionCoordinator(
+            set_led=rec.set_led, move_head=rec.move_head, move_arms=rec.move_arms,
+            face_callback=None, enabled=True,
+        )
+        assert coord.express(Expression.SAD) is True
+        _drain(coord)
+        assert rec.snapshot()["led"] != []
+        assert rec.snapshot()["faces"] == []
+
+
+class TestSafetyGating:
+    def test_unsafe_skips_motor_but_allows_face_and_led(self):
+        coord, rec = _make(enabled=True, safety_gate=lambda: False)
+        coord.express(Expression.STARTLED)
+        _drain(coord)
+        snap = rec.snapshot()
+        # Non-motor cues still fire.
+        assert snap["faces"] != []
+        assert snap["led"] != []
+        # Motor gestures are suppressed while unsafe.
+        assert snap["head"] == []
+        assert snap["arms"] == []
+
+    def test_safe_gate_allows_motor(self):
+        coord, rec = _make(enabled=True, safety_gate=lambda: True)
+        coord.express(Expression.JOY)
+        _drain(coord)
+        assert rec.snapshot()["head"] != []
+
+    def test_raising_safety_gate_treated_as_unsafe(self):
+        def boom():
+            raise RuntimeError("state read failed")
+
+        coord, rec = _make(enabled=True, safety_gate=boom)
+        coord.express(Expression.JOY)
+        _drain(coord)
+        assert rec.snapshot()["head"] == []
+
+
+class TestCancellation:
+    def test_cancel_stops_and_recenters_when_safe(self):
+        coord, rec = _make(enabled=True, recenter=True)
+        coord.express(Expression.SAD)
+        _drain(coord)
+        rec.head.clear()
+        rec.arms.clear()
+        coord.cancel()
+        snap = rec.snapshot()
+        # Re-center pose issued.
+        assert snap["head"][-1]["pitch"] == pytest.approx(NEUTRAL_HEAD[0])
+        assert snap["arms"][-1]["left"] == pytest.approx(NEUTRAL_ARMS[0])
+        assert coord.is_active is False
+
+    def test_cancel_does_not_recenter_when_unsafe(self):
+        coord, rec = _make(enabled=True, recenter=True, safety_gate=lambda: False)
+        coord.express(Expression.SAD)
+        _drain(coord)
+        coord.cancel()
+        # No motor commands at all while unsafe.
+        assert rec.snapshot()["head"] == []
+
+    def test_cancel_without_recenter(self):
+        coord, rec = _make(enabled=True, recenter=False)
+        coord.express(Expression.JOY)
+        _drain(coord)
+        head_before = len(rec.snapshot()["head"])
+        coord.cancel()
+        assert len(rec.snapshot()["head"]) == head_before
+
+    def test_new_expression_supersedes_previous(self):
+        coord, rec = _make(enabled=True)
+        coord.express(Expression.JOY)
+        coord.express(Expression.SAD)  # supersedes
+        _drain(coord)
+        assert coord.is_active is False
+        # The most recent face should be the sad spec's emotion.
+        assert rec.snapshot()["faces"][-1][0] == EXPRESSION_CHOREOGRAPHY[Expression.SAD].face_emotion
+
+
+class TestSensorRateLimit:
+    def test_repeat_sensor_expression_is_rate_limited(self):
+        coord, rec = _make(enabled=True, sensor_min_interval_s=5.0, safety_gate=lambda: True)
+        assert coord.express_for_sensor(Expression.STARTLED) is True
+        _drain(coord)
+        # Immediate repeat is dropped.
+        assert coord.express_for_sensor(Expression.STARTLED) is False
+
+    def test_different_sensor_expressions_not_rate_limited_together(self):
+        coord, rec = _make(enabled=True, sensor_min_interval_s=5.0)
+        assert coord.express_for_sensor(Expression.STARTLED) is True
+        _drain(coord)
+        assert coord.express_for_sensor(Expression.ANNOYED) is True
+
+    def test_sensor_expression_allowed_after_interval(self):
+        coord, rec = _make(enabled=True, sensor_min_interval_s=0.2)
+        assert coord.express_for_sensor(Expression.STARTLED) is True
+        _drain(coord)
+        time.sleep(0.25)
+        assert coord.express_for_sensor(Expression.STARTLED) is True
+
+
+class TestDefensiveBehavior:
+    def test_actuator_exception_does_not_crash(self):
+        def boom(**kwargs):
+            raise RuntimeError("device unreachable")
+
+        coord = ExpressionCoordinator(
+            set_led=lambda r, g, b: (_ for _ in ()).throw(RuntimeError("led fail")),
+            move_head=boom, move_arms=boom, face_callback=None, enabled=True,
+        )
+        assert coord.express(Expression.ERROR) is True
+        _drain(coord)
+        assert coord.is_active is False


### PR DESCRIPTION
## Summary

Adds an optional, config-gated companion-side `ExpressionCoordinator` (issue #74) that maps a constrained expression enum (`joy`, `curious`, `confused`, `thinking`, `sassy`, `annoyed`, `angry`, `sad`, `startled`, `sleepy`, `error`) to bounded face/LED/head/arm choreography.

- Face rendering is **delegated** to the #73 `FaceAnimator` via an injected `face_callback(emotion, static_fallback)`, with a static built-in `e_*.jpg` firmware face as the fallback path (never duplicates face rendering).
- Choreography runs on a short-lived daemon thread: **cancellable** and **non-blocking**; never blocks audio, safety, reboot, charging, movement preemption, or shutdown.
- **Safety-gated**: head/arm gestures issue only when the injected `safety_gate()` allows; non-motor face/LED cues may still apply. Poses are hard-clamped to Misty's mechanical limits.
- **Sensor rate-limiting** via `express_for_sensor()` to avoid gesture spam.
- Gated behind `USE_EMBODIED_EXPRESSIONS=false` (default); no behavior change until enabled. Drive/tread movement stays separate.

Closes #74

## Acceptance criteria

- [x] A coordinator maps expression intents to face/head/arm/LED choreography.
- [x] The coordinator integrates with #73's face animation layer (injected `face_callback`) rather than duplicating face rendering.
- [x] Static face/LED behavior remains the fallback when animation is disabled or #73 is not available (`static_fallback` built-in face).
- [x] Choreography is cancellable and never blocks audio, safety, reboot, charging, movement preemption, or shutdown cleanup (daemon thread + stop event).
- [x] Sensor-triggered expressions are rate-limited (`EXPRESSION_SENSOR_MIN_INTERVAL_S`).
- [x] Tests cover mapping, cancellation, disabled mode, and safety gating without live hardware.
- [x] Documentation explains expression states, config flags, and hardware validation steps.

## Files changed

- `src/windows-orchestration/expression_coordinator.py` (new module)
- `src/windows-orchestration/config_defaults.py` (`USE_EMBODIED_EXPRESSIONS`, velocities, sensor interval)
- `src/windows-orchestration/.env.example` (config prose)
- `tests/test_expression_coordinator.py` (new, hardware-free)
- `docs/embodied-expression-coordinator.md` (new)

## Verification

- `python -m py_compile` on all changed Python files — OK
- `python -m pytest tests/test_expression_coordinator.py -q` — **25 passed**
- `python -m pytest tests/test_face_animator.py -q` — **36 passed** (no regression)
- `git diff --check` — clean

Motor motion cannot be validated in CI; hardware validation steps are documented in `docs/embodied-expression-coordinator.md`. The feature ships gated off (`USE_EMBODIED_EXPRESSIONS=false`) until that validation passes.
