### PR TITLE
Harden wake word and STT noise handling

### DIFF
--- a/docs/test-questions-richer-responses.md
+++ b/docs/test-questions-richer-responses.md
@@ -177,7 +177,7 @@ Tests unique to the laptop mic wake word mode:
 | Response too long/wordy | Brevity drift past 35 words | Post-truncation should catch this; check max_tokens=60 |
 | Response too short | Old behavior persisted | Verify running updated code; check system prompt |
 | Follow-up doesn't work | Silence threshold too aggressive | Check `FOLLOWUP_SILENCE_THRESHOLD` (default 1000 bytes) |
-| Laptop wake word false positives | Threshold too low | Increase threshold: `OWW_THRESHOLD=0.7` |
+| Laptop wake word false positives | Threshold too low or single-frame noise spike | Increase threshold above current value or require more sustained evidence with `OWW_TRIGGER_FRAMES=2` |
 | Laptop wake word misses | Threshold too high or mic issue | Decrease `OWW_THRESHOLD` or check `sounddevice` mic selection |
 | Self-wake (Misty triggers herself) | Pause/resume not working | Check `wake_word_listener.py` pause/resume flow in logs |
 

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -29,6 +29,8 @@ OWW_CUSTOM_MODEL_PATH=
 OWW_MODEL_NAME=hey_misty
 # Wake-word confidence threshold (0.0-1.0, default: 0.7).
 OWW_THRESHOLD=0.7
+# Consecutive above-threshold frames required before wake triggers (default: 2).
+OWW_TRIGGER_FRAMES=2
 # Optional sounddevice input device index or name for the laptop mic.
 # Leave empty to use the OS default input device.
 LAPTOP_MIC_DEVICE=

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -85,6 +85,9 @@ OWW_CUSTOM_MODEL_PATH: str = os.path.normpath(
 )
 OWW_MODEL_NAME: str = "hey_misty"
 OWW_THRESHOLD: float = 0.7
+# Require the wake model to cross threshold on consecutive audio frames before
+# firing. This suppresses single-frame background false positives.
+OWW_TRIGGER_FRAMES: int = 2
 LAPTOP_MIC_DEVICE: str = ""
 
 # Face recognition (issue #16)

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -662,13 +662,13 @@ def speech_to_text(audio_bytes: bytes, start_time: float) -> Dict[str, Any]:
             logger.debug(f"Audio stats failed: {e}")
 
         audio_io = BytesIO(audio_bytes)
-        # First try WITHOUT VAD to see if whisper can find any speech
+        # Use VAD and no prompt bias so background noise does not get coerced
+        # into plausible short phrases.
         segments, info = model.transcribe(
             audio_io,
             language="en",
             beam_size=5,
-            vad_filter=False,
-            initial_prompt="Hey Misty, tell me about science, history, math, geography, and fun facts.",
+            vad_filter=True,
         )
         segment_list = list(segments)
         text = " ".join(seg.text.strip() for seg in segment_list).strip()
@@ -688,12 +688,30 @@ def speech_to_text(audio_bytes: bytes, start_time: float) -> Dict[str, Any]:
                 )
                 return {"status": "empty", "text": "", "latency_ms": 0}
 
+        if _looks_like_repeated_short_hallucination(text):
+            logger.info("Rejecting repeated short STT hallucination: text=%r", text)
+            return {"status": "empty", "text": "", "latency_ms": 0}
+
         logger.debug(f"STT result: {text}")
         return {"status": "ok", "text": text}
 
     except Exception as e:
         logger.error(f"STT failed: {e}")
         return {"status": "error", "error": "stt_failure"}
+
+
+def _looks_like_repeated_short_hallucination(text: str) -> bool:
+    """Detect common Whisper noise artifacts such as "Wow. Wow."."""
+    chunks = [
+        re.sub(r"[^a-z0-9']+", " ", chunk.lower()).strip()
+        for chunk in re.split(r"[.!?]+", text or "")
+    ]
+    chunks = [chunk for chunk in chunks if chunk]
+    if len(chunks) < 2:
+        return False
+    if len(set(chunks)) != 1:
+        return False
+    return len(chunks[0].split()) <= 2
 
 # ============================================================================
 # STEP 2: LANGUAGE MODEL INFERENCE

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -46,6 +46,10 @@ OWW_CUSTOM_MODEL_PATH = os.getenv(
     "OWW_CUSTOM_MODEL_PATH",
     config_defaults.OWW_CUSTOM_MODEL_PATH,
 ).strip() or config_defaults.OWW_CUSTOM_MODEL_PATH
+OWW_TRIGGER_FRAMES = max(
+    1,
+    int(os.getenv("OWW_TRIGGER_FRAMES", str(config_defaults.OWW_TRIGGER_FRAMES))),
+)
 
 # Audio capture settings (laptop mic)
 _LAPTOP_MIC_DEVICE_RAW = os.getenv("LAPTOP_MIC_DEVICE", config_defaults.LAPTOP_MIC_DEVICE).strip()
@@ -88,6 +92,7 @@ class WakeWordListener:
         self.model_name = model_name
         self.threshold = threshold
         self.custom_model_path = custom_model_path
+        self.trigger_frames = OWW_TRIGGER_FRAMES
 
         self._running = False
         self._paused = False
@@ -103,6 +108,7 @@ class WakeWordListener:
         self._last_detection_time = 0.0
         self._start_time = 0.0
         self._resume_time = 0.0  # for self-wake cooldown
+        self._detection_streaks: dict[str, int] = {}
 
         # Speech monitor state (for VAD-controlled recording)
         self._speech_monitor_active = False
@@ -160,7 +166,7 @@ class WakeWordListener:
 
             logger.info(
                 f"openWakeWord ready (models={list(self._oww_model.models.keys())}, "
-                f"threshold={self.threshold})"
+                f"threshold={self.threshold}, trigger_frames={self.trigger_frames})"
             )
             return True
         except ImportError:
@@ -258,6 +264,7 @@ class WakeWordListener:
                 self._audio_queue.get_nowait()
             except queue.Empty:
                 break
+        self._detection_streaks.clear()
         logger.debug("Wake word listener paused (self-wake prevention)")
 
     def resume(self):
@@ -265,6 +272,7 @@ class WakeWordListener:
         self._paused = False
         self._resume_time = time.time()
         self._pause_event.set()
+        self._detection_streaks.clear()
         # Reset openWakeWord state to avoid stale activations
         if self._oww_model:
             self._oww_model.reset()
@@ -400,6 +408,7 @@ class WakeWordListener:
             "uptime_s": round(uptime),
             "model": self.model_name,
             "threshold": self.threshold,
+            "trigger_frames": self.trigger_frames,
             "source": "laptop_mic",
             "custom_model_path": self.custom_model_path or None,
             "model_source": "custom" if self.custom_model_path else "missing_config",
@@ -470,22 +479,9 @@ class WakeWordListener:
                 # Run openWakeWord inference
                 if self._oww_model and not in_cooldown:
                     predictions = self._oww_model.predict(pcm)
-                    for model_name, score in predictions.items():
-                        if score >= self.threshold:
-                            self._total_detections += 1
-                            self._last_detection_time = time.time()
-                            logger.info(
-                                f"Wake word '{model_name}' detected! "
-                                f"score={score:.3f} (threshold={self.threshold})"
-                            )
-                            # Reset model to prevent repeated triggers
-                            self._oww_model.reset()
-                            # Fire callback
-                            try:
-                                self.on_wake_word()
-                            except Exception as e:
-                                logger.error(f"Wake word callback error: {e}")
-                            break
+                    self._handle_wake_predictions(predictions)
+                elif in_cooldown:
+                    self._detection_streaks.clear()
 
                 self._consecutive_errors = 0
 
@@ -504,6 +500,41 @@ class WakeWordListener:
                     self._consecutive_errors = 0
 
         logger.info("Wake word processing loop ended")
+
+    def _handle_wake_predictions(self, predictions: dict[str, float]) -> bool:
+        """Handle openWakeWord scores and fire only after sustained evidence."""
+        for model_name, score in predictions.items():
+            if score < self.threshold:
+                self._detection_streaks[model_name] = 0
+                continue
+
+            streak = self._detection_streaks.get(model_name, 0) + 1
+            self._detection_streaks[model_name] = streak
+            if streak < self.trigger_frames:
+                logger.debug(
+                    f"Wake word '{model_name}' candidate score={score:.3f} "
+                    f"({streak}/{self.trigger_frames} frames)"
+                )
+                continue
+
+            self._total_detections += 1
+            self._last_detection_time = time.time()
+            logger.info(
+                f"Wake word '{model_name}' detected! score={score:.3f} "
+                f"(threshold={self.threshold}, frames={streak}/{self.trigger_frames})"
+            )
+            self._detection_streaks.clear()
+            # Reset model to prevent repeated triggers
+            if self._oww_model:
+                self._oww_model.reset()
+            # Fire callback
+            try:
+                self.on_wake_word()
+            except Exception as e:
+                logger.error(f"Wake word callback error: {e}")
+            return True
+
+        return False
 
     # --- Speech monitor helpers ---
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,6 +86,26 @@ class TestOrchestrationSttConfidence(unittest.TestCase):
         self.assertEqual(result["status"], "empty")
         self.assertEqual(result["text"], "")
 
+    def test_repeated_short_noise_phrase_is_treated_as_empty_stt(self):
+        """Common Whisper noise loops such as 'Wow. Wow.' should not reach the LLM."""
+        model = unittest.mock.MagicMock()
+        model.transcribe.return_value = (
+            [
+                SimpleNamespace(
+                    text="Wow. Wow.",
+                    avg_logprob=-0.25,
+                    no_speech_prob=0.01,
+                )
+            ],
+            SimpleNamespace(),
+        )
+
+        with unittest.mock.patch.object(self._svc, "_get_whisper_model", return_value=model):
+            result = self._svc.speech_to_text(b"not-a-real-wav", time.time())
+
+        self.assertEqual(result["status"], "empty")
+        self.assertEqual(result["text"], "")
+
 
 class TestLaptopMistyRecordingConfig(unittest.TestCase):
     """Unit tests for laptop-mode Misty recording configuration (#66)."""
@@ -305,6 +325,27 @@ class TestWakeWordConfiguration(unittest.TestCase):
 
         self.assertEqual(ctrl._wake_word_source, "error")
         self.assertIn("unsupported", ctrl._wake_word_config_error)
+
+    def test_wake_word_requires_consecutive_above_threshold_frames(self):
+        """Single-frame OpenWakeWord spikes should not trigger a conversation."""
+        if self._listener_module is None:
+            self.skipTest("wake_word_listener could not be imported")
+
+        callback = unittest.mock.MagicMock()
+        listener = self._listener_module.WakeWordListener(
+            on_wake_word=callback,
+            threshold=0.7,
+            custom_model_path=__file__,
+        )
+        listener.trigger_frames = 2
+        listener._oww_model = unittest.mock.MagicMock()
+
+        self.assertFalse(listener._handle_wake_predictions({"hey_misty": 0.82}))
+        callback.assert_not_called()
+
+        self.assertTrue(listener._handle_wake_predictions({"hey_misty": 0.81}))
+        callback.assert_called_once()
+        listener._oww_model.reset.assert_called_once()
 
 
 class TestLaptopFastRearm(unittest.TestCase):
@@ -2843,7 +2884,8 @@ class TestCanonicalDefaults(unittest.TestCase):
             "FOLLOWUP_MAX_TURNS", "WATCHDOG_IDLE_TIMEOUT_S", "WATCHDOG_ESCALATE_TIMEOUT_S",
             "IDLE_TIMEOUT_S", "PROACTIVE_REBOOT_AFTER_CYCLES",
             "PROACTIVE_REBOOT_AFTER_RECORDINGS", "LAPTOP_MISTY_RECORDING_MODE",
-            "LAPTOP_MISTY_TALLY_RECORDING_S", "FACE_RECOGNITION_TIMEOUT_S",
+            "LAPTOP_MISTY_TALLY_RECORDING_S", "OWW_TRIGGER_FRAMES",
+            "FACE_RECOGNITION_TIMEOUT_S",
         ):
             self.assertTrue(hasattr(self._cfg, attr), f"config_defaults missing: {attr}")
 


### PR DESCRIPTION
## Summary
- require consecutive above-threshold OpenWakeWord frames before triggering
- remove STT prompt bias and use VAD for transcription
- reject repeated short Whisper noise artifacts

## Validation
- python -m py_compile src\windows-orchestration\orchestration_service.py src\windows-orchestration\wake_word_listener.py src\windows-orchestration\config_defaults.py
- python -m pytest tests\test_integration.py::TestOrchestrationSttConfidence::test_repeated_short_noise_phrase_is_treated_as_empty_stt tests\test_integration.py::TestWakeWordConfiguration::test_wake_word_requires_consecutive_above_threshold_frames tests\test_integration.py::TestCanonicalDefaults -q