### PR TITLE
Add tools/train_face.py face-training CLI (part of #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,30 @@ If `LAPTOP_MISTY_RECORDING_MODE` is `tally` or `off` and laptop mic capture retu
 
 For live visual/body testing, enable only the modes you want to validate. `USE_TALKING_HEAD_MOTION=true` adds small head movements during spoken responses. `USE_EMBODIED_EXPRESSIONS=true` allows safe expression choreography such as joy/happy arm raises; motor gestures are suppressed during unsafe states like recording, moving, charging, rebooting, and shutdown. To replace Misty's custom face assets, put the required files in `FACE_ASSETS_DIR`, start once with `FACE_ASSETS_SYNC_MODE=overwrite`, then return to `missing` for normal startup.
 
+### Face recognition training (`tools/train_face.py`)
+
+`USE_FACE_RECOGNITION=true` lets the controller identify the speaker during a
+conversation and personalize LLM responses, but it only helps once at least one
+face is trained on the robot. Use the standalone CLI to manage Misty's on-robot
+face catalog over REST (requires Misty on the network; no orchestration service):
+
+```powershell
+# List currently trained faces
+python tools/train_face.py --list
+
+# Train a face (stand in front of Misty and slowly turn your head)
+python tools/train_face.py --name Tammy
+
+# Train, then run a quick recognition verify
+python tools/train_face.py --name Tammy --verify
+```
+
+The tool reads `MISTY_IP` from the environment (override with `--misty-ip`) and
+uses the same `/api/faces` endpoints as the controller, so trained labels match
+what the live pipeline recognizes. Run `python tools/train_face.py --help` for
+all options. Misty's built-in face recognition works only with human faces and
+its reliability depends on lighting and camera quality.
+
 ---
 
 ## Orchestration API

--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ For live visual/body testing, enable only the modes you want to validate. `USE_T
 `USE_FACE_RECOGNITION=true` lets the controller identify the speaker during a
 conversation and personalize LLM responses, but it only helps once at least one
 face is trained on the robot. Use the standalone CLI to manage Misty's on-robot
-face catalog over REST (requires Misty on the network; no orchestration service):
+face catalog over REST (requires Misty on the network; no orchestration service).
+Run these from the repository root:
 
 ```powershell
 # List currently trained faces
@@ -271,11 +272,20 @@ python tools/train_face.py --name Tammy
 python tools/train_face.py --name Tammy --verify
 ```
 
-The tool reads `MISTY_IP` from the environment (override with `--misty-ip`) and
-uses the same `/api/faces` endpoints as the controller, so trained labels match
-what the live pipeline recognizes. Run `python tools/train_face.py --help` for
-all options. Misty's built-in face recognition works only with human faces and
-its reliability depends on lighting and camera quality.
+The tool reads `MISTY_IP` from the environment (override with `--misty-ip`, which
+is required if `MISTY_IP` is unset) and uses the same `/api/faces` endpoints as
+the controller, so trained labels match what the live pipeline recognizes. Run
+`python tools/train_face.py --help` for all options. Misty's built-in face
+recognition works only with human faces and its reliability depends on lighting
+and camera quality.
+
+> **Hardware caveat:** [`docs/lessons-learned.md`](docs/lessons-learned.md)
+> documents that on this Misty unit the on-chip face detection/training pipeline
+> is effectively non-functional — `training/start` returns `Success` but the
+> face is never stored and `FaceRecognition` events never fire (a Snapdragon 410
+> limitation). This tool exercises the documented REST API and helps re-verify
+> that behavior, but the durable path is laptop-side recognition. Do not expect
+> on-robot training to persist until this is re-validated on hardware.
 
 ---
 

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -91,7 +91,7 @@ MAX_CONTEXT_CHARS=5000
 # Face Recognition (#16)
 # Enable face recognition during conversations (requires trained faces on Misty).
 # When enabled, Misty's camera identifies the speaker and personalizes LLM responses.
-# Train a face first with: python tools/train_face.py --name Tammy  (see #112)
+# Train a face first (run from the repo root): python tools/train_face.py --name Tammy  (see #112)
 USE_FACE_RECOGNITION=false
 # Timeout in seconds for face recognition attempt during each conversation turn.
 FACE_RECOGNITION_TIMEOUT_S=3.0

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -91,6 +91,7 @@ MAX_CONTEXT_CHARS=5000
 # Face Recognition (#16)
 # Enable face recognition during conversations (requires trained faces on Misty).
 # When enabled, Misty's camera identifies the speaker and personalizes LLM responses.
+# Train a face first with: python tools/train_face.py --name Tammy  (see #112)
 USE_FACE_RECOGNITION=false
 # Timeout in seconds for face recognition attempt during each conversation turn.
 FACE_RECOGNITION_TIMEOUT_S=3.0

--- a/tests/test_train_face.py
+++ b/tests/test_train_face.py
@@ -190,12 +190,52 @@ def test_recognize_once_ignores_unknown_person(monkeypatch):
     mod = load_train_face_module()
     trainer = mod.MistyFaceTrainer("127.0.0.1")
     monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    # Guarantee exactly one polling iteration: deadline uses the first value (0),
+    # first while-check (1.0) is < deadline (5.0) so the body runs once, second
+    # check (100.0) exits the loop.
+    monotonic_values = iter([0.0, 1.0, 100.0])
+    monkeypatch.setattr(mod.time, "monotonic", lambda: next(monotonic_values))
     monkeypatch.setattr(trainer, "_post", lambda ep, body=None: {"status": "Success"})
-    monkeypatch.setattr(
-        trainer, "_get", lambda ep: {"result": {"label": mod.UNKNOWN_LABEL}}
-    )
-    # Only unknown_person seen before timeout → no recognized label.
-    assert trainer.recognize_once(timeout_s=0.0) == ""
+    seen = {"gets": 0}
+
+    def only_unknown(ep):
+        seen["gets"] += 1
+        return {"result": {"label": mod.UNKNOWN_LABEL}}
+
+    monkeypatch.setattr(trainer, "_get", only_unknown)
+    assert trainer.recognize_once(timeout_s=5.0) == ""
+    assert seen["gets"] == 1  # the ignore-logic branch actually executed
+
+
+def test_wait_type_rejects_nonfinite():
+    mod = load_train_face_module()
+    parser = mod.build_parser()
+    for bad in ("nan", "inf", "-inf"):
+        try:
+            parser.parse_args(
+                ["--name", "Tammy", "--misty-ip", "127.0.0.1", "--wait", bad]
+            )
+            assert False, f"expected SystemExit for --wait {bad}"
+        except SystemExit as exc:
+            assert exc.code != 0
+
+
+def test_main_rejects_list_and_name_together(monkeypatch):
+    mod = load_train_face_module()
+    try:
+        mod.main(["--list", "--name", "Tammy", "--misty-ip", "127.0.0.1"])
+        assert False, "expected SystemExit for mutually exclusive actions"
+    except SystemExit as exc:
+        assert exc.code != 0
+
+
+def test_main_rejects_verify_without_name(monkeypatch):
+    mod = load_train_face_module()
+    try:
+        mod.main(["--list", "--verify", "--misty-ip", "127.0.0.1"])
+        assert False, "expected SystemExit for --verify without --name"
+    except SystemExit as exc:
+        assert exc.code != 0
 
 
 def test_main_returns_one_when_unreachable(monkeypatch):

--- a/tests/test_train_face.py
+++ b/tests/test_train_face.py
@@ -123,9 +123,79 @@ def test_main_requires_name_or_list():
 
 def test_main_list_uses_env_default_ip(monkeypatch):
     mod = load_train_face_module()
+    # No --misty-ip passed: the CLI must fall back to the MISTY_IP env var.
+    monkeypatch.setenv("MISTY_IP", "10.9.9.9")
+    captured = {}
+
+    def fake_init(self, misty_ip, timeout=10.0):
+        captured["ip"] = misty_ip
+        self.misty_ip = misty_ip
+        self.base_url = f"http://{misty_ip}/api"
+        self.timeout = timeout
+
+    monkeypatch.setattr(mod.MistyFaceTrainer, "__init__", fake_init)
     monkeypatch.setattr(mod.MistyFaceTrainer, "check_connectivity", lambda self: True)
     monkeypatch.setattr(mod.MistyFaceTrainer, "list_faces", lambda self: ["Tammy"])
-    assert mod.main(["--list", "--misty-ip", "127.0.0.1"]) == 0
+    assert mod.main(["--list"]) == 0
+    assert captured["ip"] == "10.9.9.9"
+
+
+def test_main_errors_when_no_ip_available(monkeypatch):
+    mod = load_train_face_module()
+    monkeypatch.delenv("MISTY_IP", raising=False)
+    try:
+        mod.main(["--list"])
+        assert False, "expected SystemExit when no IP is available"
+    except SystemExit as exc:
+        assert exc.code != 0
+
+
+def test_wait_type_rejects_negative():
+    mod = load_train_face_module()
+    parser = mod.build_parser()
+    try:
+        parser.parse_args(["--name", "Tammy", "--misty-ip", "127.0.0.1", "--wait", "-1"])
+        assert False, "expected SystemExit for negative --wait"
+    except SystemExit as exc:
+        assert exc.code != 0
+
+
+def test_recognize_once_extracts_label(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(trainer, "_post", lambda ep, body=None: {"status": "Success"})
+    monkeypatch.setattr(
+        trainer, "_get", lambda ep: {"result": {"label": "Tammy"}}
+    )
+    assert trainer.recognize_once(timeout_s=5.0) == "Tammy"
+
+
+def test_recognize_once_unsupported_get_returns_empty(monkeypatch, capsys):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(trainer, "_post", lambda ep, body=None: {"status": "Success"})
+
+    def unsupported(ep):
+        raise RuntimeError("404 Not Found")
+
+    monkeypatch.setattr(trainer, "_get", unsupported)
+    assert trainer.recognize_once(timeout_s=5.0) == ""
+    out = capsys.readouterr().out
+    assert "not available" in out
+
+
+def test_recognize_once_ignores_unknown_person(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(trainer, "_post", lambda ep, body=None: {"status": "Success"})
+    monkeypatch.setattr(
+        trainer, "_get", lambda ep: {"result": {"label": mod.UNKNOWN_LABEL}}
+    )
+    # Only unknown_person seen before timeout → no recognized label.
+    assert trainer.recognize_once(timeout_s=0.0) == ""
 
 
 def test_main_returns_one_when_unreachable(monkeypatch):

--- a/tests/test_train_face.py
+++ b/tests/test_train_face.py
@@ -1,0 +1,134 @@
+"""Cloud-safe unit tests for tools/train_face.py (#112).
+
+These tests mock all Misty REST calls, so they run without hardware.
+"""
+
+import importlib.util
+import os
+
+
+def load_train_face_module():
+    module_path = os.path.join(
+        os.path.dirname(__file__), "..", "tools", "train_face.py"
+    )
+    spec = importlib.util.spec_from_file_location("train_face", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_list_faces_parses_success_payload(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(
+        trainer, "_get", lambda ep: {"status": "Success", "result": ["Tammy", "Alex"]}
+    )
+    assert trainer.list_faces() == ["Tammy", "Alex"]
+
+
+def test_list_faces_returns_empty_on_error(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+
+    def boom(ep):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(trainer, "_get", boom)
+    assert trainer.list_faces() == []
+
+
+def test_start_training_rejects_empty_name():
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    assert trainer.start_training("") is False
+
+
+def test_start_training_rejects_overlong_name():
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    too_long = "x" * (mod.MAX_FACE_ID_LEN + 1)
+    assert trainer.start_training(too_long) is False
+
+
+def test_start_training_success(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    calls = {}
+
+    def fake_post(ep, body=None):
+        calls["ep"] = ep
+        calls["body"] = body
+        return {"status": "Success"}
+
+    monkeypatch.setattr(trainer, "_post", fake_post)
+    assert trainer.start_training("Tammy") is True
+    assert calls["ep"] == "/faces/training/start"
+    assert calls["body"] == {"FaceId": "Tammy"}
+
+
+def test_start_training_reports_rejection(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(trainer, "_post", lambda ep, body=None: {"status": "Failed"})
+    assert trainer.start_training("Tammy") is False
+
+
+def test_run_training_returns_zero_when_face_present(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    # empty before, trained after
+    face_lists = iter([[], ["Tammy"]])
+    monkeypatch.setattr(trainer, "list_faces", lambda: next(face_lists))
+    monkeypatch.setattr(trainer, "start_training", lambda name: True)
+    assert mod.run_training(trainer, "Tammy", wait_s=0.0, verify=False) == 0
+
+
+def test_run_training_returns_one_when_face_missing(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(mod.time, "sleep", lambda s: None)
+    monkeypatch.setattr(trainer, "list_faces", lambda: [])
+    monkeypatch.setattr(trainer, "start_training", lambda name: True)
+    assert mod.run_training(trainer, "Tammy", wait_s=0.0, verify=False) == 1
+
+
+def test_run_training_returns_one_when_start_fails(monkeypatch):
+    mod = load_train_face_module()
+    trainer = mod.MistyFaceTrainer("127.0.0.1")
+    monkeypatch.setattr(trainer, "list_faces", lambda: [])
+    monkeypatch.setattr(trainer, "start_training", lambda name: False)
+    assert mod.run_training(trainer, "Tammy", wait_s=0.0, verify=False) == 1
+
+
+def test_main_requires_name_or_list():
+    mod = load_train_face_module()
+    try:
+        mod.main(["--misty-ip", "127.0.0.1"])
+        assert False, "expected SystemExit from argparse error"
+    except SystemExit as exc:
+        assert exc.code != 0
+
+
+def test_main_list_uses_env_default_ip(monkeypatch):
+    mod = load_train_face_module()
+    monkeypatch.setattr(mod.MistyFaceTrainer, "check_connectivity", lambda self: True)
+    monkeypatch.setattr(mod.MistyFaceTrainer, "list_faces", lambda self: ["Tammy"])
+    assert mod.main(["--list", "--misty-ip", "127.0.0.1"]) == 0
+
+
+def test_main_returns_one_when_unreachable(monkeypatch):
+    mod = load_train_face_module()
+    monkeypatch.setattr(mod.MistyFaceTrainer, "check_connectivity", lambda self: False)
+    assert mod.main(["--list", "--misty-ip", "127.0.0.1"]) == 1

--- a/tools/train_face.py
+++ b/tools/train_face.py
@@ -23,7 +23,8 @@ Usage:
     # Train and then run a quick recognition verify afterwards
     python tools/train_face.py --name Tammy --verify
 
-    # Point at a specific robot (otherwise MISTY_IP env, then default)
+    # Point at a specific robot (otherwise uses the MISTY_IP env var;
+    # required if MISTY_IP is unset — there is no hard-coded default)
     python tools/train_face.py --name Tammy --misty-ip 10.0.0.44
 
 Exit codes:
@@ -34,7 +35,8 @@ Note:
     Misty's built-in face recognition only works with human faces and its
     reliability depends on lighting and camera quality. This tool drives the
     on-robot pipeline; end-to-end conversational recognition additionally
-    requires ``USE_FACE_RECOGNITION=true`` in the orchestration ``.env``.
+    requires ``USE_FACE_RECOGNITION=true`` in the controller's
+    ``src/windows-orchestration/.env`` (read by ``misty_controller.py``).
 
 Important hardware caveat:
     ``docs/lessons-learned.md`` records that on this unit Misty's on-chip face

--- a/tools/train_face.py
+++ b/tools/train_face.py
@@ -163,6 +163,9 @@ class MistyFaceTrainer:
             try:
                 self._post("/faces/recognition/stop")
             except Exception:
+                # Best-effort cleanup: recognition may already be stopped or
+                # Misty may be unreachable. Nothing actionable to do here, so
+                # suppress rather than mask the primary result/return path.
                 pass
         return recognized
 

--- a/tools/train_face.py
+++ b/tools/train_face.py
@@ -1,0 +1,282 @@
+"""
+Face training / management CLI for Misty II (#112).
+
+Standalone companion-laptop utility that manages Misty's on-robot face
+recognition catalog over the REST API. It reuses the same endpoints proven in
+``src/windows-orchestration/misty_controller.py`` (``/api/faces``,
+``/api/faces/training/start``, ``/api/faces/training/cancel``) so training a
+face here produces exactly the labels the live pipeline recognizes.
+
+No dependency on the controller or orchestration service — only Misty on the
+network is required.
+
+Prerequisites:
+    pip install requests
+
+Usage:
+    # List currently trained faces
+    python tools/train_face.py --list
+
+    # Train a new face (stand in front of Misty during training)
+    python tools/train_face.py --name Tammy
+
+    # Train and then run a quick recognition verify afterwards
+    python tools/train_face.py --name Tammy --verify
+
+    # Point at a specific robot (otherwise MISTY_IP env, then default)
+    python tools/train_face.py --name Tammy --misty-ip 10.0.0.44
+
+Exit codes:
+    0  success (requested action completed)
+    1  action failed (Misty unreachable, training/verify failed, bad args)
+
+Note:
+    Misty's built-in face recognition only works with human faces and its
+    reliability depends on lighting and camera quality. This tool drives the
+    on-robot pipeline; end-to-end conversational recognition additionally
+    requires ``USE_FACE_RECOGNITION=true`` in the orchestration ``.env``.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - trivial import guard
+    sys.exit("ERROR: 'requests' package required. Install with: pip install requests")
+
+
+# Misty caps face labels at 50 characters; mirror the controller's guard.
+MAX_FACE_ID_LEN = 50
+
+# Misty's on-robot training routine takes roughly 15 seconds to capture a face.
+DEFAULT_TRAINING_WAIT_S = 20.0
+
+# Label Misty reports for a detected-but-unknown face.
+UNKNOWN_LABEL = "unknown_person"
+
+
+class MistyFaceTrainer:
+    """Drives Misty's face training / recognition REST endpoints."""
+
+    def __init__(self, misty_ip: str, timeout: float = 10.0):
+        self.misty_ip = misty_ip
+        self.base_url = f"http://{misty_ip}/api"
+        self.timeout = timeout
+
+    # --- Low-level REST helpers -------------------------------------------
+    def _get(self, endpoint: str):
+        resp = requests.get(f"{self.base_url}{endpoint}", timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    def _post(self, endpoint: str, body: dict = None):
+        resp = requests.post(f"{self.base_url}{endpoint}", json=body, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    # --- Connectivity ------------------------------------------------------
+    def check_connectivity(self) -> bool:
+        """Return True if Misty is reachable on the network."""
+        try:
+            self._get("/device")
+            return True
+        except Exception as exc:
+            print(f"  ERROR: Cannot reach Misty at {self.misty_ip}: {exc}")
+            return False
+
+    # --- Face catalog ------------------------------------------------------
+    def list_faces(self) -> list:
+        """Return the list of trained face IDs, or [] on failure."""
+        try:
+            result = self._get("/faces")
+        except Exception as exc:
+            print(f"  ERROR: GET /faces failed: {exc}")
+            return []
+        if result and result.get("status") == "Success":
+            return result.get("result", []) or []
+        print(f"  ERROR: GET /faces returned unexpected payload: {result}")
+        return []
+
+    def start_training(self, face_id: str) -> bool:
+        """Start on-robot training for ``face_id``. Returns True on success."""
+        if not face_id or len(face_id) > MAX_FACE_ID_LEN:
+            print(
+                f"  ERROR: Invalid face id '{face_id}' "
+                f"(must be 1-{MAX_FACE_ID_LEN} characters)."
+            )
+            return False
+        try:
+            result = self._post("/faces/training/start", {"FaceId": face_id})
+        except Exception as exc:
+            print(f"  ERROR: POST /faces/training/start failed: {exc}")
+            return False
+        if result and result.get("status") == "Success":
+            return True
+        print(f"  ERROR: Training start rejected by Misty: {result}")
+        return False
+
+    def cancel_training(self) -> bool:
+        """Cancel an in-progress training session (best effort)."""
+        try:
+            self._post("/faces/training/cancel")
+            return True
+        except Exception as exc:
+            print(f"  WARNING: cancel training failed: {exc}")
+            return False
+
+    def recognize_once(self, timeout_s: float = 5.0) -> str:
+        """Run recognition briefly; return a recognized label or ``""``.
+
+        Uses REST polling of ``/faces/recognition`` events surfaced through
+        ``GET /faces`` is not sufficient, so this polls the recognition start
+        endpoint and reads back detected faces. Recognition events normally
+        arrive over WebSocket in the live pipeline; for a simple CLI verify we
+        start recognition and poll for a known label.
+        """
+        try:
+            self._post("/faces/recognition/start")
+        except Exception as exc:
+            print(f"  WARNING: could not start recognition: {exc}")
+            return ""
+        recognized = ""
+        deadline = time.monotonic() + timeout_s
+        try:
+            while time.monotonic() < deadline:
+                try:
+                    result = self._get("/faces/recognition")
+                except Exception:
+                    # Not all firmware exposes a GET; fall back to catalog check.
+                    break
+                label = ""
+                if isinstance(result, dict):
+                    payload = result.get("result") or {}
+                    if isinstance(payload, dict):
+                        label = payload.get("label") or payload.get("Label") or ""
+                if label and label != UNKNOWN_LABEL:
+                    recognized = label
+                    break
+                time.sleep(0.5)
+        finally:
+            try:
+                self._post("/faces/recognition/stop")
+            except Exception:
+                pass
+        return recognized
+
+
+def _print_faces(faces: list) -> None:
+    if faces:
+        print(f"  Trained faces ({len(faces)}):")
+        for face in faces:
+            print(f"    - {face}")
+    else:
+        print("  Trained faces: (none)")
+
+
+def run_training(trainer: MistyFaceTrainer, name: str, wait_s: float, verify: bool) -> int:
+    """Train ``name`` and optionally verify. Returns a process exit code."""
+    existing = trainer.list_faces()
+    _print_faces(existing)
+    if name in existing:
+        print(f"  NOTE: '{name}' is already trained; re-training will refresh it.")
+
+    print(f"\n  Starting face training for '{name}'...")
+    print("  >>> Stand ~0.5-1 m in front of Misty, face the camera, and slowly")
+    print("  >>> turn your head left and right. Keep your face well lit.")
+    if not trainer.start_training(name):
+        return 1
+
+    print(f"  Training in progress (~15s). Waiting up to {wait_s:.0f}s...")
+    time.sleep(wait_s)
+
+    faces_after = trainer.list_faces()
+    if name in faces_after:
+        print(f"\n  SUCCESS: '{name}' is now a trained face.")
+    else:
+        print(
+            f"\n  WARNING: '{name}' not yet present in the trained-face list. "
+            "Training may still be finalizing, or lighting/camera prevented a "
+            "clean capture. Re-run with better lighting if recognition fails."
+        )
+        _print_faces(faces_after)
+
+    if verify:
+        print("\n  Verifying recognition (look at Misty)...")
+        label = trainer.recognize_once()
+        if label == name:
+            print(f"  VERIFY OK: Misty recognized '{label}'.")
+        elif label:
+            print(f"  VERIFY: Misty recognized '{label}' (expected '{name}').")
+        else:
+            print("  VERIFY: no known face recognized within the timeout.")
+
+    return 0 if name in faces_after else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Train and manage Misty II face recognition (#112). "
+            "Reuses the same /api/faces endpoints as the live controller."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python tools/train_face.py --list\n"
+            "  python tools/train_face.py --name Tammy\n"
+            "  python tools/train_face.py --name Tammy --verify\n"
+        ),
+    )
+    parser.add_argument(
+        "--name",
+        help="Face label to train (e.g. Tammy). Omit with --list to only list.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List currently trained faces and exit.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="After training, run a quick recognition check.",
+    )
+    parser.add_argument(
+        "--misty-ip",
+        default=os.environ.get("MISTY_IP", "10.0.0.44"),
+        help="Misty robot IP address (default: MISTY_IP env or 10.0.0.44).",
+    )
+    parser.add_argument(
+        "--wait",
+        type=float,
+        default=DEFAULT_TRAINING_WAIT_S,
+        help=f"Seconds to wait for training to complete (default: {DEFAULT_TRAINING_WAIT_S:.0f}).",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.list and not args.name:
+        parser.error("provide --name NAME to train, or --list to list faces")
+
+    trainer = MistyFaceTrainer(args.misty_ip)
+    print(f"  Misty target: {args.misty_ip}")
+    if not trainer.check_connectivity():
+        return 1
+
+    if args.name:
+        return run_training(trainer, args.name, args.wait, args.verify)
+
+    # --list only
+    _print_faces(trainer.list_faces())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/train_face.py
+++ b/tools/train_face.py
@@ -35,6 +35,15 @@ Note:
     reliability depends on lighting and camera quality. This tool drives the
     on-robot pipeline; end-to-end conversational recognition additionally
     requires ``USE_FACE_RECOGNITION=true`` in the orchestration ``.env``.
+
+Important hardware caveat:
+    ``docs/lessons-learned.md`` records that on this unit Misty's on-chip face
+    detection/training is effectively non-functional — ``training/start``
+    returns "Success" but the face is never stored and ``FaceRecognition``
+    events never fire. This tool exercises the documented REST API and is
+    useful for (re)verifying that behavior, but if training does not persist,
+    that is the known Snapdragon 410 limitation, not a bug in this CLI. The
+    durable path is laptop-side recognition (see lessons-learned).
 """
 
 import argparse
@@ -130,11 +139,15 @@ class MistyFaceTrainer:
     def recognize_once(self, timeout_s: float = 5.0) -> str:
         """Run recognition briefly; return a recognized label or ``""``.
 
-        Uses REST polling of ``/faces/recognition`` events surfaced through
-        ``GET /faces`` is not sufficient, so this polls the recognition start
-        endpoint and reads back detected faces. Recognition events normally
-        arrive over WebSocket in the live pipeline; for a simple CLI verify we
-        start recognition and poll for a known label.
+        Starts recognition, then polls ``GET /faces/recognition`` for a known
+        (non-``unknown_person``) label until ``timeout_s`` elapses. Recognition
+        events normally arrive over WebSocket in the live pipeline; this CLI
+        uses simple REST polling instead.
+
+        If the firmware does not expose ``GET /faces/recognition``, this method
+        prints a clear warning and returns ``""`` (it cannot poll for a label).
+        Callers should treat an empty result as "no known face recognized OR
+        polling unavailable", not as a definitive absence of a face.
         """
         try:
             self._post("/faces/recognition/start")
@@ -147,8 +160,17 @@ class MistyFaceTrainer:
             while time.monotonic() < deadline:
                 try:
                     result = self._get("/faces/recognition")
-                except Exception:
-                    # Not all firmware exposes a GET; fall back to catalog check.
+                except Exception as exc:
+                    # Not all firmware exposes GET /faces/recognition. Warn so
+                    # the operator can distinguish "unsupported endpoint" from
+                    # "no face recognized" rather than silently reporting the
+                    # latter.
+                    print(
+                        "  WARNING: GET /faces/recognition not available on this "
+                        f"firmware ({exc}); cannot poll for a recognized label. "
+                        "Recognition events fire over WebSocket in the live "
+                        "pipeline, not this CLI verify."
+                    )
                     break
                 label = ""
                 if isinstance(result, dict):
@@ -219,6 +241,14 @@ def run_training(trainer: MistyFaceTrainer, name: str, wait_s: float, verify: bo
     return 0 if name in faces_after else 1
 
 
+def _nonneg_float(value: str) -> float:
+    """argparse type: reject negative --wait values (would crash time.sleep)."""
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -227,7 +257,7 @@ def build_parser() -> argparse.ArgumentParser:
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Examples:\n"
+            "Examples (run from the repository root):\n"
             "  python tools/train_face.py --list\n"
             "  python tools/train_face.py --name Tammy\n"
             "  python tools/train_face.py --name Tammy --verify\n"
@@ -249,12 +279,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--misty-ip",
-        default=os.environ.get("MISTY_IP", "10.0.0.44"),
-        help="Misty robot IP address (default: MISTY_IP env or 10.0.0.44).",
+        default=os.environ.get("MISTY_IP"),
+        help=(
+            "Misty robot IP address. Defaults to the MISTY_IP environment "
+            "variable; required if MISTY_IP is unset (no hard-coded fallback, "
+            "to avoid commanding the wrong robot on a shared network)."
+        ),
     )
     parser.add_argument(
         "--wait",
-        type=float,
+        type=_nonneg_float,
         default=DEFAULT_TRAINING_WAIT_S,
         help=f"Seconds to wait for training to complete (default: {DEFAULT_TRAINING_WAIT_S:.0f}).",
     )
@@ -267,6 +301,12 @@ def main(argv=None) -> int:
 
     if not args.list and not args.name:
         parser.error("provide --name NAME to train, or --list to list faces")
+
+    if not args.misty_ip:
+        parser.error(
+            "no Misty IP available: pass --misty-ip ADDRESS or set the MISTY_IP "
+            "environment variable"
+        )
 
     trainer = MistyFaceTrainer(args.misty_ip)
     print(f"  Misty target: {args.misty_ip}")

--- a/tools/train_face.py
+++ b/tools/train_face.py
@@ -47,6 +47,7 @@ Important hardware caveat:
 """
 
 import argparse
+import math
 import os
 import sys
 import time
@@ -242,8 +243,10 @@ def run_training(trainer: MistyFaceTrainer, name: str, wait_s: float, verify: bo
 
 
 def _nonneg_float(value: str) -> float:
-    """argparse type: reject negative --wait values (would crash time.sleep)."""
+    """argparse type: reject negative/non-finite --wait (would crash time.sleep)."""
     parsed = float(value)
+    if not math.isfinite(parsed):
+        raise argparse.ArgumentTypeError("must be a finite number")
     if parsed < 0:
         raise argparse.ArgumentTypeError("must be >= 0")
     return parsed
@@ -301,6 +304,12 @@ def main(argv=None) -> int:
 
     if not args.list and not args.name:
         parser.error("provide --name NAME to train, or --list to list faces")
+
+    if args.list and args.name:
+        parser.error("--list and --name are mutually exclusive; choose one action")
+
+    if args.verify and not args.name:
+        parser.error("--verify only applies when training with --name")
 
     if not args.misty_ip:
         parser.error(


### PR DESCRIPTION
## Summary

Partial, cloud-safe implementation for **#112** (activate facial recognition). Adds a standalone `tools/train_face.py` CLI to manage Misty's on-robot face catalog over REST, reusing the same `/api/faces` endpoints proven in `misty_controller.py` so trained labels match what the live pipeline recognizes.

> **Part of #112 — intentionally does NOT close the issue.** Three acceptance criteria require live Misty hardware and one requires a gitignored local runtime toggle, none of which are verifiable in this environment. Those are off-ramped for manual completion (see the issue off-ramp comment).

## Acceptance criteria coverage

| # | Criterion | Status |
|---|---|---|
| 1 | `tools/train_face.py` exists (train/list/verify via REST) | ✅ Delivered |
| 6 | Training script documented (README + `--help`) | ✅ Delivered |
| 2 | `USE_FACE_RECOGNITION=true` in `.env` | ⛔ Off-ramp — `.env` is gitignored + live runtime toggle |
| 3 | Misty has ≥1 trained face ("Tammy") | ⛔ Off-ramp — requires Misty hardware |
| 4 | Live conversation recognizes Tammy, LLM uses name | ⛔ Off-ramp — requires Misty + Foundry Local + audio |
| 5 | Unrecognized faces fall back gracefully (live) | ⛔ Off-ramp — live E2E requires hardware |

## Changes

- `tools/train_face.py` — `--list` / `--name` / `--verify` / `--misty-ip` / `--wait`; input validation (≤50 char labels), connectivity preflight, structured output, exit codes.
- `tests/test_train_face.py` — 12 mocked unit tests (no hardware).
- `README.md` — "Face recognition training" usage subsection.
- `.env.example` — pointer to the tool next to `USE_FACE_RECOGNITION`.

## Verification (cloud-safe)

- `git diff --check` → clean
- `python -m py_compile tools/train_face.py tests/test_train_face.py` → exit 0
- `python tools/train_face.py --help` → renders options + examples
- `python -m pytest tests/test_train_face.py -q` → **12 passed**
- Full non-live suite: 328 passed; **5 pre-existing failures** in `TestPromptLimiting`/`TestLatencyConfig` (orchestration `max_tokens` config drift) confirmed present on `main` with these changes stashed — **unrelated to this PR**.

## Notes / follow-up

- README currently states Misty's on-chip face recognition is "effectively non-functional"; live reliability of criteria #3–#5 should be re-validated on hardware and reconciled with that note before enabling `USE_FACE_RECOGNITION`.
- Remaining hardware criteria tracked in #112 (kept open).
