### PR TITLE
Implement laptop-side face enrollment and recognition for Tammy (#125)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 # Exception: trained wake word model (small, ~14KB)
 !models/hey_misty.onnx
 
+# Local face profiles — biometric embeddings, never commit (#125)
+data/face_profiles/*.npz
+data/face_profiles/*.npy
+
 # Logs
 *.log
 logs/services/

--- a/README.md
+++ b/README.md
@@ -290,11 +290,12 @@ and camera quality.
 ### Laptop-side face recognition (`tools/enroll_face.py`, `tools/recognize_face.py`) — #125
 
 Because Misty's on-chip `/api/faces` pipeline is effectively dead on this unit,
-the **durable, default** path for identifying a speaker is laptop-side
-recognition. It captures frames from Misty's RGB camera or the laptop webcam,
-computes face embeddings on the companion laptop (OpenCV + ONNX Runtime), and
-feeds the existing `speaker_name` orchestration path. The deprecated Misty-native
-`USE_FACE_RECOGNITION` (#16) path should stay disabled.
+the **durable, recommended** path for identifying a speaker is laptop-side
+recognition. It is opt-in (off by default; enable with
+`USE_LAPTOP_FACE_RECOGNITION=true`). It captures frames from Misty's RGB camera
+or the laptop webcam, computes face embeddings on the companion laptop (OpenCV +
+ONNX Runtime), and feeds the existing `speaker_name` orchestration path. The
+deprecated Misty-native `USE_FACE_RECOGNITION` (#16) path should stay disabled.
 
 **Enroll a person** (embeddings + metadata are stored locally, never photos):
 
@@ -342,7 +343,7 @@ Key settings (`config_defaults.py` is the single source of truth):
 |---|---|---|
 | `USE_LAPTOP_FACE_RECOGNITION` | `false` | Enable laptop-side recognition (replaces #16). |
 | `FACE_PROFILE_DIR` | `data/face_profiles` | Local, gitignored profile storage. |
-| `FACE_RECOGNITION_SOURCE` | `misty_camera` | `misty_camera` \| `webcam` \| `image_file`. |
+| `FACE_RECOGNITION_SOURCE` | `misty_camera` | Conversation-time frame source: `misty_camera` \| `webcam`. (The CLIs also support an `image` source for offline testing.) |
 | `FACE_RECOGNITION_THRESHOLD` | `0.4` | Cosine-distance match threshold (lower = stricter). |
 | `FACE_RECOGNITION_MIN_CONSISTENT_FRAMES` | `2` | Frames that must agree before a name is used. |
 | `FACE_RECOGNITION_MIN_SAMPLES` | `5` | Minimum valid samples to enroll a profile. |

--- a/README.md
+++ b/README.md
@@ -284,8 +284,76 @@ and camera quality.
 > is effectively non-functional — `training/start` returns `Success` but the
 > face is never stored and `FaceRecognition` events never fire (a Snapdragon 410
 > limitation). This tool exercises the documented REST API and helps re-verify
-> that behavior, but the durable path is laptop-side recognition. Do not expect
-> on-robot training to persist until this is re-validated on hardware.
+> that behavior, but the durable path is laptop-side recognition (below). Do not
+> expect on-robot training to persist until this is re-validated on hardware.
+
+### Laptop-side face recognition (`tools/enroll_face.py`, `tools/recognize_face.py`) — #125
+
+Because Misty's on-chip `/api/faces` pipeline is effectively dead on this unit,
+the **durable, default** path for identifying a speaker is laptop-side
+recognition. It captures frames from Misty's RGB camera or the laptop webcam,
+computes face embeddings on the companion laptop (OpenCV + ONNX Runtime), and
+feeds the existing `speaker_name` orchestration path. The deprecated Misty-native
+`USE_FACE_RECOGNITION` (#16) path should stay disabled.
+
+**Enroll a person** (embeddings + metadata are stored locally, never photos):
+
+```powershell
+# From Misty's camera
+python tools\enroll_face.py --name Tammy --source misty --misty-ip 10.0.0.15 --samples 10
+
+# Or from the laptop webcam
+python tools\enroll_face.py --name Tammy --source webcam --samples 10
+
+# Manage profiles
+python tools\enroll_face.py --list
+python tools\enroll_face.py --delete Tammy
+```
+
+**Test recognition** (non-zero exit code when no known face is recognized):
+
+```powershell
+python tools\recognize_face.py --source misty --misty-ip 10.0.0.15
+python tools\recognize_face.py --source webcam
+```
+
+**Enable it in conversations** by setting `USE_LAPTOP_FACE_RECOGNITION=true` in
+`src/windows-orchestration/.env` and configuring the detector/embedder model
+paths. When enabled, the controller runs recognition concurrently with recording
+at the start of a turn; a confident match sets `speaker_name` (persisted through
+follow-up turns). If recognition fails, times out, or no profile exists, the
+controller logs the reason and continues without a name (**fail-open**).
+
+**Models:** the OpenCV/ONNX detector and embedding models are **not bundled**
+(`*.onnx` is gitignored). Point `FACE_DETECTOR_MODEL_PATH` (e.g. YuNet) and
+`FACE_EMBEDDER_MODEL_PATH` (e.g. SFace/ArcFace) at locally downloaded model files.
+Until these are set, laptop recognition reports a clear "model unavailable" error
+and stays idle rather than crashing.
+
+**Privacy:** enrolled profiles live in `data/face_profiles/` and contain only
+numeric embeddings and metadata (name, timestamp, model name/version, sample
+count, embedding dimensions). Face embeddings are **biometric data**, kept local
+only and **gitignored**. User-supplied names are validated so they cannot escape
+the profile directory. See [`data/face_profiles/README.md`](data/face_profiles/README.md).
+
+Key settings (`config_defaults.py` is the single source of truth):
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `USE_LAPTOP_FACE_RECOGNITION` | `false` | Enable laptop-side recognition (replaces #16). |
+| `FACE_PROFILE_DIR` | `data/face_profiles` | Local, gitignored profile storage. |
+| `FACE_RECOGNITION_SOURCE` | `misty_camera` | `misty_camera` \| `webcam` \| `image_file`. |
+| `FACE_RECOGNITION_THRESHOLD` | `0.4` | Cosine-distance match threshold (lower = stricter). |
+| `FACE_RECOGNITION_MIN_CONSISTENT_FRAMES` | `2` | Frames that must agree before a name is used. |
+| `FACE_RECOGNITION_MIN_SAMPLES` | `5` | Minimum valid samples to enroll a profile. |
+| `FACE_DETECTOR_MODEL_PATH` / `FACE_EMBEDDER_MODEL_PATH` | *(empty)* | OpenCV/ONNX model file paths (not bundled). |
+
+**Live validation checklist** (requires hardware/camera; not run in CI):
+
+1. `python tools\enroll_face.py --name Tammy --source misty --misty-ip <MISTY_IP> --samples 10`
+2. `python tools\recognize_face.py --source misty --misty-ip <MISTY_IP>` → prints `RECOGNIZED: Tammy` with distance below threshold.
+3. Set `USE_LAPTOP_FACE_RECOGNITION=true`, start the services, and confirm Misty naturally uses Tammy's name in conversation.
+4. Confirm an unknown face falls back gracefully (no name injected, conversation continues).
 
 ---
 

--- a/data/face_profiles/README.md
+++ b/data/face_profiles/README.md
@@ -1,0 +1,30 @@
+# Local face profiles (#125)
+
+This directory holds **laptop-side** enrolled face profiles created by
+`tools/enroll_face.py`. It replaces Misty's unreliable on-chip `/api/faces`
+pipeline (see `docs/lessons-learned.md`).
+
+## Privacy and git policy
+
+- Profiles are stored as `<Name>.npz` files containing **only numeric face
+  embeddings and metadata** (name, created timestamp, model name/version,
+  sample count, embedding dimensions). **No source photos are ever stored.**
+- Face embeddings are **biometric data**. They are kept **local only** and are
+  **gitignored** (`data/face_profiles/*.npz`, `*.npy`). Do not commit them.
+- This `README.md` is the only file in this directory that is tracked by git,
+  so the directory exists on a fresh clone.
+
+## Usage
+
+```powershell
+# Enroll (from the repo root)
+python tools\enroll_face.py --name Tammy --source misty --misty-ip 10.0.0.15 --samples 10
+python tools\enroll_face.py --name Tammy --source webcam --samples 10
+
+# List / delete
+python tools\enroll_face.py --list
+python tools\enroll_face.py --delete Tammy
+
+# Recognize (smoke test)
+python tools\recognize_face.py --source webcam
+```

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -54,6 +54,8 @@ The **face detection ML pipeline** on the Snapdragon 410 sensory processor is no
 
 Move face recognition to the companion laptop (same pattern as wake word → openWakeWord, same pattern as STT → faster-whisper). Use OpenCV + ONNX Runtime for detection and embeddings via the laptop webcam. The `speaker_name` pipeline (PR #64) is camera-agnostic — only the source of the name changes.
 
+> **Implemented (#125).** `src/windows-orchestration/face_recognition_service.py` provides a laptop-side `FaceRecognizer` (enroll/recognize with local, gitignored embedding profiles) fronted by `tools/enroll_face.py` and `tools/recognize_face.py`, and wired into `misty_controller.py` behind `USE_LAPTOP_FACE_RECOGNITION`. It captures from Misty's RGB camera or the laptop webcam, requires multi-frame agreement to avoid false positives, and fails open (no name) when a face is unknown or the model/camera is unavailable. The deprecated Misty-native `USE_FACE_RECOGNITION` (#16) path is kept disabled. See the README "Laptop-side face recognition" section for enrollment, testing, enabling, privacy behavior, and the live validation checklist.
+
 ### Broader Lesson
 
 **Every ML-dependent feature on the Snapdragon 410 should be assumed fragile.** The chip's ML capabilities are degrading:

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -96,6 +96,31 @@ USE_FACE_RECOGNITION=false
 # Timeout in seconds for face recognition attempt during each conversation turn.
 FACE_RECOGNITION_TIMEOUT_S=3.0
 
+# Laptop-side Face Recognition (#125)
+# Replaces Misty's unreliable on-chip /api/faces pipeline with a laptop-side
+# recognizer that identifies enrolled people and feeds the existing speaker_name
+# path. Enable this INSTEAD of USE_FACE_RECOGNITION above. Enroll a profile
+# first (run from the repo root):
+#   python tools\enroll_face.py --name Tammy --source misty --misty-ip <MISTY_IP> --samples 10
+#   python tools\recognize_face.py --source webcam
+USE_LAPTOP_FACE_RECOGNITION=false
+# Directory holding enrolled face profiles (embeddings + metadata only; never
+# photos). Gitignored. Defaults to the repo-level data/face_profiles directory.
+# FACE_PROFILE_DIR=./data/face_profiles
+# Frame source used during conversations: misty_camera | webcam | image_file.
+FACE_RECOGNITION_SOURCE=misty_camera
+# Cosine-distance match threshold (lower = stricter; conservative to avoid
+# false positives — a wrong name is worse than no name).
+FACE_RECOGNITION_THRESHOLD=0.4
+# Frames that must agree on the same name before it is used (false-positive guard).
+FACE_RECOGNITION_MIN_CONSISTENT_FRAMES=2
+# Minimum valid face samples required to enroll a profile.
+FACE_RECOGNITION_MIN_SAMPLES=5
+# OpenCV/ONNX detector + embedding model paths (not bundled; *.onnx is gitignored).
+# Required for live laptop recognition; see README for how to obtain them.
+FACE_DETECTOR_MODEL_PATH=
+FACE_EMBEDDER_MODEL_PATH=
+
 # Face Animation (#73)
 # Enable the continuous animation frame-loop for face expressions. This flag now
 # scopes ONLY the frame-loop thread: even when false, Misty still shows her custom

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -107,7 +107,8 @@ USE_LAPTOP_FACE_RECOGNITION=false
 # Directory holding enrolled face profiles (embeddings + metadata only; never
 # photos). Gitignored. Defaults to the repo-level data/face_profiles directory.
 # FACE_PROFILE_DIR=./data/face_profiles
-# Frame source used during conversations: misty_camera | webcam | image_file.
+# Frame source used during conversations: misty_camera | webcam.
+# (The CLIs additionally support an "image" source for offline testing.)
 FACE_RECOGNITION_SOURCE=misty_camera
 # Cosine-distance match threshold (lower = stricter; conservative to avoid
 # false positives — a wrong name is worse than no name).

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -108,8 +108,9 @@ USE_LAPTOP_FACE_RECOGNITION: bool = False
 FACE_PROFILE_DIR: str = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "data", "face_profiles")
 )
-# Frame source used for recognition during conversations: "misty_camera",
-# "webcam", or "image_file".
+# Frame source used for recognition during conversations: "misty_camera" or
+# "webcam". (The enrollment/recognition CLIs additionally support an "image"
+# source for offline use; the live controller uses the robot camera or webcam.)
 FACE_RECOGNITION_SOURCE: str = "misty_camera"
 # Cosine-distance match threshold (lower = stricter). A probe matches a profile
 # only when its distance to the profile centroid is <= this value. Conservative

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -93,6 +93,40 @@ LAPTOP_MIC_DEVICE: str = ""
 # Face recognition (issue #16)
 FACE_RECOGNITION_TIMEOUT_S: float = 3.0
 
+# Laptop-side face recognition (issue #125).
+# Replaces Misty's unreliable on-chip /api/faces pipeline (documented as
+# effectively non-functional on this Snapdragon 410 unit in
+# docs/lessons-learned.md) with a laptop-side recognizer that produces a
+# speaker_name for the existing orchestration path. Off by default; enable only
+# after enrolling a profile (see tools/enroll_face.py). Keep the deprecated
+# USE_FACE_RECOGNITION (#16) path disabled when this is enabled.
+USE_LAPTOP_FACE_RECOGNITION: bool = False
+# Directory holding enrolled face profiles (embeddings + metadata only, never
+# photos). Gitignored. Defaults to the repo-level data/face_profiles directory
+# (config_defaults.py lives in src/windows-orchestration/, so ../../data/... is
+# the repo root).
+FACE_PROFILE_DIR: str = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "data", "face_profiles")
+)
+# Frame source used for recognition during conversations: "misty_camera",
+# "webcam", or "image_file".
+FACE_RECOGNITION_SOURCE: str = "misty_camera"
+# Cosine-distance match threshold (lower = stricter). A probe matches a profile
+# only when its distance to the profile centroid is <= this value. Conservative
+# defaults reduce false positives (a wrong name is worse than no name).
+FACE_RECOGNITION_THRESHOLD: float = 0.4
+# Minimum number of frames that must agree on the same name before recognition
+# returns it (single-frame false-positive guard).
+FACE_RECOGNITION_MIN_CONSISTENT_FRAMES: int = 2
+# Minimum number of valid face samples required to enroll a profile.
+FACE_RECOGNITION_MIN_SAMPLES: int = 5
+# Optional paths to the OpenCV/ONNX face detector and embedding models used by
+# OnnxFaceEmbedder. Empty by default; laptop recognition raises a clear
+# FaceModelUnavailable error until these are set. Models are not bundled in git
+# (*.onnx is gitignored) — see the README for how to obtain them.
+FACE_DETECTOR_MODEL_PATH: str = os.environ.get("FACE_DETECTOR_MODEL_PATH", "")
+FACE_EMBEDDER_MODEL_PATH: str = os.environ.get("FACE_EMBEDDER_MODEL_PATH", "")
+
 # Face animation (issue #73, Phase 2)
 USE_FACE_ANIMATION: bool = False
 FACE_ANIMATION_MAX_FPS: float = 4.0

--- a/src/windows-orchestration/face_recognition_service.py
+++ b/src/windows-orchestration/face_recognition_service.py
@@ -38,7 +38,6 @@ Public API
 
 from __future__ import annotations
 
-import io
 import os
 import re
 import time

--- a/src/windows-orchestration/face_recognition_service.py
+++ b/src/windows-orchestration/face_recognition_service.py
@@ -1,0 +1,704 @@
+"""Laptop-side face enrollment and recognition service (#125).
+
+This module replaces Misty's unreliable on-chip face-recognition pipeline
+(``/api/faces`` training + ``FaceRecognition`` events, documented as
+effectively non-functional on this Snapdragon 410 unit in
+``docs/lessons-learned.md``) with a *laptop-side* recognizer that runs on the
+companion Windows/x64 machine and produces a ``speaker_name`` for the existing
+orchestration path.
+
+Design goals
+------------
+- **No Misty face firmware dependency.** Recognition happens entirely on the
+  laptop from captured frames (Misty RGB camera, laptop webcam, or image file).
+- **Cloud-safe / testable without hardware.** Heavy, optional dependencies
+  (``cv2``, ``onnxruntime``) are imported lazily so unit tests can inject a
+  deterministic fake embedder and static frame sources. No live camera, model
+  download, or robot is required for the automated test suite.
+- **Fail open.** Every public entry point raises a typed, catchable error so the
+  controller can log a clear reason and continue the conversation without a
+  ``speaker_name`` rather than crashing.
+- **Privacy first.** Only numeric face embeddings and metadata are persisted,
+  never source photos. Profile files live in a gitignored local directory and
+  user-supplied names cannot escape that directory.
+
+Public API
+----------
+``FaceRecognizer``
+    ``enroll(name, frames) -> FaceProfile``
+    ``recognize(frame) -> RecognitionResult | None``
+    ``recognize_consistent(frames) -> RecognitionResult | None``
+    ``load_profiles()`` / ``save_profile(profile)``
+``FaceProfileStore``
+    Path-traversal-safe ``.npz`` profile storage.
+``FrameSource`` implementations
+    ``MistyCameraFrameSource`` / ``WebcamFrameSource`` / ``ImageFileFrameSource``
+``recognize_speaker`` helper used by ``misty_controller.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class FaceRecognitionError(Exception):
+    """Base class for all recoverable face-recognition failures."""
+
+
+class NoFaceDetected(FaceRecognitionError):
+    """No face was found in the supplied frame."""
+
+
+class MultipleFacesDetected(FaceRecognitionError):
+    """More than one face was found where exactly one was required."""
+
+
+class LowConfidence(FaceRecognitionError):
+    """A face was found but no profile matched above the confidence threshold."""
+
+
+class FaceModelUnavailable(FaceRecognitionError):
+    """The face detection/embedding model or its dependencies are unavailable."""
+
+
+class FrameSourceError(FaceRecognitionError):
+    """A frame source could not produce a usable frame."""
+
+
+class ProfileNameError(FaceRecognitionError, ValueError):
+    """A profile name is empty, too long, or contains unsafe characters."""
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+# A frame is a HxWx3 uint8 BGR image (OpenCV convention) as a numpy array.
+Frame = np.ndarray
+
+# Profile names: letters, digits, spaces, underscores and hyphens only. This
+# both prevents path traversal and keeps file names portable across OSes.
+_VALID_NAME_RE = re.compile(r"^[A-Za-z0-9 _-]{1,64}$")
+MAX_PROFILE_NAME_LEN = 64
+
+MODEL_NAME = "laptop-face-embedder"
+MODEL_VERSION = "1"
+
+
+def validate_profile_name(name: str) -> str:
+    """Return a normalized, safe profile name or raise ``ProfileNameError``.
+
+    Rejects empty names, names longer than :data:`MAX_PROFILE_NAME_LEN`, path
+    separators, ``..`` traversal, and any character outside
+    ``[A-Za-z0-9 _-]``. The returned name is stripped of surrounding
+    whitespace and is safe to use as a single-path-segment file stem.
+    """
+    if not isinstance(name, str):
+        raise ProfileNameError("profile name must be a string")
+    stripped = name.strip()
+    if not stripped:
+        raise ProfileNameError("profile name must not be empty")
+    if len(stripped) > MAX_PROFILE_NAME_LEN:
+        raise ProfileNameError(
+            f"profile name too long (max {MAX_PROFILE_NAME_LEN} characters)"
+        )
+    if os.sep in stripped or (os.altsep and os.altsep in stripped):
+        raise ProfileNameError("profile name must not contain path separators")
+    if ".." in stripped:
+        raise ProfileNameError("profile name must not contain '..'")
+    if not _VALID_NAME_RE.match(stripped):
+        raise ProfileNameError(
+            "profile name may only contain letters, digits, spaces, '_' and '-'"
+        )
+    return stripped
+
+
+@dataclass
+class FaceProfile:
+    """An enrolled identity: its embeddings plus provenance metadata.
+
+    Only numeric embeddings and metadata are stored — never source imagery.
+    """
+
+    name: str
+    embeddings: np.ndarray  # shape (num_samples, embedding_dim), float32, L2-normalized
+    model_name: str = MODEL_NAME
+    model_version: str = MODEL_VERSION
+    created_at: str = ""
+    sample_count: int = 0
+    embedding_dim: int = 0
+
+    def __post_init__(self):
+        self.embeddings = np.asarray(self.embeddings, dtype=np.float32)
+        if self.embeddings.ndim != 2 or self.embeddings.shape[0] == 0:
+            raise FaceRecognitionError(
+                "profile embeddings must be a non-empty 2D array"
+            )
+        self.sample_count = int(self.embeddings.shape[0])
+        self.embedding_dim = int(self.embeddings.shape[1])
+        if not self.created_at:
+            self.created_at = datetime.now(timezone.utc).isoformat()
+
+    @property
+    def mean_embedding(self) -> np.ndarray:
+        """L2-normalized mean of the enrolled embeddings (the match centroid)."""
+        mean = self.embeddings.mean(axis=0)
+        return _l2_normalize(mean)
+
+
+@dataclass
+class RecognitionResult:
+    """Outcome of a successful recognition."""
+
+    name: str
+    distance: float  # cosine distance in [0, 2]; lower is a better match
+    threshold: float
+    source: str = "unknown"
+    confidence: float = field(default=0.0)
+
+    def __post_init__(self):
+        # Map cosine distance to a bounded, monotonic confidence for logging.
+        self.confidence = max(0.0, 1.0 - (self.distance / max(self.threshold, 1e-6)))
+
+
+# ---------------------------------------------------------------------------
+# Math helpers
+# ---------------------------------------------------------------------------
+
+
+def _l2_normalize(vec: np.ndarray) -> np.ndarray:
+    vec = np.asarray(vec, dtype=np.float32)
+    norm = float(np.linalg.norm(vec))
+    if norm < 1e-12:
+        return vec
+    return vec / norm
+
+
+def cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine distance (1 - cosine similarity) between two vectors, in [0, 2]."""
+    a = _l2_normalize(a)
+    b = _l2_normalize(b)
+    return float(1.0 - np.dot(a, b))
+
+
+# ---------------------------------------------------------------------------
+# Embedder abstraction
+# ---------------------------------------------------------------------------
+
+
+class FaceEmbedder:
+    """Interface for a face detector + embedding backend.
+
+    Implementations must return one embedding vector *per detected face* for a
+    frame. The :class:`FaceRecognizer` enforces the "exactly one face" policy so
+    embedders stay simple and testable.
+    """
+
+    def extract_embeddings(self, frame: Frame) -> List[np.ndarray]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OnnxFaceEmbedder(FaceEmbedder):
+    """Default OpenCV + ONNX Runtime face detector/embedder.
+
+    Both ``cv2`` and ``onnxruntime`` and the model files are loaded lazily on
+    first use. If any dependency or model file is missing, a
+    :class:`FaceModelUnavailable` error is raised with actionable guidance
+    instead of failing at import time. This keeps the module importable (and the
+    rest of the pipeline testable) on machines that do not have the models.
+
+    Model files are supplied via env/config paths and are intentionally *not*
+    bundled in git (``*.onnx`` is gitignored). See the README for how to obtain
+    a detector (e.g. YuNet) and an embedding model (e.g. SFace/ArcFace) for live
+    laptop recognition.
+    """
+
+    def __init__(
+        self,
+        detector_model_path: str,
+        embedder_model_path: str,
+        detector_score_threshold: float = 0.6,
+    ):
+        self.detector_model_path = detector_model_path
+        self.embedder_model_path = embedder_model_path
+        self.detector_score_threshold = detector_score_threshold
+        self._detector = None
+        self._recognizer = None
+
+    def _ensure_loaded(self):
+        if self._detector is not None and self._recognizer is not None:
+            return
+        try:
+            import cv2  # noqa: F401  (lazy, optional dependency)
+        except Exception as exc:  # pragma: no cover - depends on host env
+            raise FaceModelUnavailable(
+                "OpenCV (cv2) is required for laptop face recognition; install "
+                "opencv-python. Original error: " + str(exc)
+            )
+        for path, label in (
+            (self.detector_model_path, "detector"),
+            (self.embedder_model_path, "embedding"),
+        ):
+            if not path or not os.path.isfile(path):
+                raise FaceModelUnavailable(
+                    f"Face {label} model file not found: {path!r}. Set the model "
+                    "path via config/env and download the model (see README)."
+                )
+        try:
+            self._detector = cv2.FaceDetectorYN_create(
+                self.detector_model_path, "", (320, 320),
+                self.detector_score_threshold,
+            )
+            self._recognizer = cv2.FaceRecognizerSF_create(
+                self.embedder_model_path, ""
+            )
+        except Exception as exc:  # pragma: no cover - depends on host env
+            raise FaceModelUnavailable(
+                "Failed to initialize OpenCV face models: " + str(exc)
+            )
+
+    def extract_embeddings(self, frame: Frame) -> List[np.ndarray]:  # pragma: no cover - needs cv2/models
+        self._ensure_loaded()
+        import cv2
+
+        if frame is None or getattr(frame, "size", 0) == 0:
+            raise FrameSourceError("empty frame supplied to embedder")
+        h, w = frame.shape[:2]
+        self._detector.setInputSize((w, h))
+        _, faces = self._detector.detect(frame)
+        if faces is None:
+            return []
+        embeddings: List[np.ndarray] = []
+        for face in faces:
+            aligned = self._recognizer.alignCrop(frame, face)
+            feature = self._recognizer.feature(aligned)
+            embeddings.append(_l2_normalize(np.asarray(feature, dtype=np.float32).ravel()))
+        return embeddings
+
+
+# ---------------------------------------------------------------------------
+# Profile storage
+# ---------------------------------------------------------------------------
+
+
+class FaceProfileStore:
+    """Stores :class:`FaceProfile` objects as ``.npz`` files in one directory.
+
+    Names are validated with :func:`validate_profile_name` and every resolved
+    path is confirmed to stay inside the profile directory, preventing path
+    traversal from a hostile ``--name``.
+    """
+
+    SUFFIX = ".npz"
+
+    def __init__(self, directory: str):
+        self.directory = os.path.abspath(directory)
+
+    def _safe_path(self, name: str) -> str:
+        safe = validate_profile_name(name)
+        path = os.path.abspath(os.path.join(self.directory, safe + self.SUFFIX))
+        # Defense in depth: ensure the resolved path is inside the directory.
+        base = self.directory + os.sep
+        if not (path + "").startswith(base) and os.path.dirname(path) != self.directory:
+            raise ProfileNameError("resolved profile path escapes profile directory")
+        return path
+
+    def path_for(self, name: str) -> str:
+        """Return the (validated) on-disk path for ``name`` without touching disk."""
+        return self._safe_path(name)
+
+    def ensure_dir(self):
+        os.makedirs(self.directory, exist_ok=True)
+
+    def save(self, profile: FaceProfile) -> str:
+        """Persist ``profile`` and return the file path."""
+        self.ensure_dir()
+        path = self._safe_path(profile.name)
+        np.savez(
+            path,
+            name=profile.name,
+            embeddings=profile.embeddings,
+            model_name=profile.model_name,
+            model_version=profile.model_version,
+            created_at=profile.created_at,
+            sample_count=profile.sample_count,
+            embedding_dim=profile.embedding_dim,
+        )
+        # numpy appends .npz automatically only when missing; normalize.
+        if not os.path.isfile(path) and os.path.isfile(path + self.SUFFIX):
+            os.replace(path + self.SUFFIX, path)
+        return path
+
+    def load(self, name: str) -> FaceProfile:
+        path = self._safe_path(name)
+        if not os.path.isfile(path):
+            raise FaceRecognitionError(f"no enrolled profile named {name!r}")
+        with np.load(path, allow_pickle=False) as data:
+            return FaceProfile(
+                name=str(data["name"]),
+                embeddings=np.asarray(data["embeddings"], dtype=np.float32),
+                model_name=str(data["model_name"]),
+                model_version=str(data["model_version"]),
+                created_at=str(data["created_at"]),
+            )
+
+    def list_names(self) -> List[str]:
+        if not os.path.isdir(self.directory):
+            return []
+        names = []
+        for entry in sorted(os.listdir(self.directory)):
+            if entry.endswith(self.SUFFIX):
+                names.append(entry[: -len(self.SUFFIX)])
+        return names
+
+    def load_all(self) -> List[FaceProfile]:
+        profiles = []
+        for name in self.list_names():
+            try:
+                profiles.append(self.load(name))
+            except Exception:
+                # Skip corrupt/foreign files rather than crash the recognizer.
+                continue
+        return profiles
+
+    def delete(self, name: str) -> bool:
+        path = self._safe_path(name)
+        if os.path.isfile(path):
+            os.remove(path)
+            return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Recognizer
+# ---------------------------------------------------------------------------
+
+
+class FaceRecognizer:
+    """Enrolls and recognizes named local face profiles.
+
+    The recognizer is deliberately agnostic to how frames were produced and how
+    embeddings are computed: it composes a :class:`FaceProfileStore` and a
+    :class:`FaceEmbedder`. Tests inject a deterministic fake embedder; production
+    uses :class:`OnnxFaceEmbedder`.
+    """
+
+    def __init__(
+        self,
+        store: FaceProfileStore,
+        embedder: FaceEmbedder,
+        threshold: float = 0.4,
+        min_samples: int = 5,
+        min_consistent_frames: int = 2,
+    ):
+        if threshold <= 0:
+            raise ValueError("threshold must be > 0")
+        if min_samples < 1:
+            raise ValueError("min_samples must be >= 1")
+        if min_consistent_frames < 1:
+            raise ValueError("min_consistent_frames must be >= 1")
+        self.store = store
+        self.embedder = embedder
+        self.threshold = float(threshold)
+        self.min_samples = int(min_samples)
+        self.min_consistent_frames = int(min_consistent_frames)
+        self._profiles: Optional[List[FaceProfile]] = None
+
+    # --- profile access ---------------------------------------------------
+    def load_profiles(self, force: bool = False) -> List[FaceProfile]:
+        if self._profiles is None or force:
+            self._profiles = self.store.load_all()
+        return self._profiles
+
+    def save_profile(self, profile: FaceProfile) -> str:
+        path = self.store.save(profile)
+        self._profiles = None  # invalidate cache
+        return path
+
+    # --- embedding --------------------------------------------------------
+    def _single_face_embedding(self, frame: Frame) -> np.ndarray:
+        """Return exactly one embedding for ``frame`` or raise a typed error."""
+        embeddings = self.embedder.extract_embeddings(frame)
+        if not embeddings:
+            raise NoFaceDetected("no face detected in frame")
+        if len(embeddings) > 1:
+            raise MultipleFacesDetected(
+                f"{len(embeddings)} faces detected; exactly one is required"
+            )
+        return _l2_normalize(np.asarray(embeddings[0], dtype=np.float32).ravel())
+
+    # --- enrollment -------------------------------------------------------
+    def enroll(self, name: str, frames: Sequence[Frame]) -> FaceProfile:
+        """Enroll ``name`` from ``frames``.
+
+        Each frame must contain exactly one detectable face. Frames with no
+        face, multiple faces, or embedding errors are skipped; if fewer than
+        :attr:`min_samples` valid embeddings remain, enrollment fails with a
+        :class:`FaceRecognitionError`.
+        """
+        safe_name = validate_profile_name(name)
+        valid: List[np.ndarray] = []
+        rejected = 0
+        for frame in frames:
+            try:
+                valid.append(self._single_face_embedding(frame))
+            except FaceRecognitionError:
+                rejected += 1
+        if len(valid) < self.min_samples:
+            raise FaceRecognitionError(
+                f"only {len(valid)} valid face sample(s) captured for {safe_name!r}; "
+                f"need at least {self.min_samples} (rejected {rejected})"
+            )
+        profile = FaceProfile(name=safe_name, embeddings=np.vstack(valid))
+        self.save_profile(profile)
+        return profile
+
+    # --- recognition ------------------------------------------------------
+    def recognize(self, frame: Frame, source: str = "unknown") -> Optional[RecognitionResult]:
+        """Recognize a single frame.
+
+        Returns a :class:`RecognitionResult` when the best profile match is at
+        or below :attr:`threshold`, otherwise ``None`` (unknown / low
+        confidence). Raises :class:`NoFaceDetected` / :class:`MultipleFacesDetected`
+        for framing problems so callers can distinguish "no face" from "unknown
+        face".
+        """
+        probe = self._single_face_embedding(frame)
+        profiles = self.load_profiles()
+        best_name: Optional[str] = None
+        best_dist = float("inf")
+        for profile in profiles:
+            dist = cosine_distance(probe, profile.mean_embedding)
+            if dist < best_dist:
+                best_dist = dist
+                best_name = profile.name
+        if best_name is None or best_dist > self.threshold:
+            return None
+        return RecognitionResult(
+            name=best_name, distance=best_dist, threshold=self.threshold, source=source
+        )
+
+    def recognize_consistent(
+        self, frames: Sequence[Frame], source: str = "unknown"
+    ) -> Optional[RecognitionResult]:
+        """Require the same name across at least ``min_consistent_frames`` frames.
+
+        This guards against single-frame false positives. Frames that fail to
+        produce a face are ignored. Returns the best-scoring result for the
+        winning name, or ``None`` if no name reaches the consistency threshold.
+        """
+        counts: dict[str, int] = {}
+        best_by_name: dict[str, RecognitionResult] = {}
+        for frame in frames:
+            try:
+                result = self.recognize(frame, source=source)
+            except FaceRecognitionError:
+                continue
+            if result is None:
+                continue
+            counts[result.name] = counts.get(result.name, 0) + 1
+            prev = best_by_name.get(result.name)
+            if prev is None or result.distance < prev.distance:
+                best_by_name[result.name] = result
+        for name, count in counts.items():
+            if count >= self.min_consistent_frames:
+                return best_by_name[name]
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Frame sources
+# ---------------------------------------------------------------------------
+
+
+class FrameSource:
+    """Interface for producing frames the recognizer can consume."""
+
+    name = "unknown"
+
+    def capture(self) -> Frame:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def capture_many(self, count: int, interval_s: float = 0.2) -> List[Frame]:
+        frames: List[Frame] = []
+        for i in range(max(1, count)):
+            frames.append(self.capture())
+            if interval_s > 0 and i < count - 1:
+                time.sleep(interval_s)
+        return frames
+
+    def close(self):  # pragma: no cover - default no-op
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+class ImageFileFrameSource(FrameSource):
+    """Frame source backed by image files. Primary source for tests/offline use.
+
+    ``reader`` is an injectable callable ``path -> Frame`` (default: cv2.imread),
+    which lets unit tests supply static numpy arrays without OpenCV installed.
+    """
+
+    name = "image_file"
+
+    def __init__(self, paths: Sequence[str], reader: Optional[Callable[[str], Frame]] = None):
+        self._paths = list(paths)
+        if not self._paths:
+            raise FrameSourceError("ImageFileFrameSource requires at least one path")
+        self._reader = reader or self._default_reader
+        self._index = 0
+
+    @staticmethod
+    def _default_reader(path: str) -> Frame:  # pragma: no cover - needs cv2
+        try:
+            import cv2
+        except Exception as exc:
+            raise FaceModelUnavailable(
+                "OpenCV (cv2) is required to read image files; install opencv-python. "
+                + str(exc)
+            )
+        img = cv2.imread(path)
+        if img is None:
+            raise FrameSourceError(f"could not read image file: {path!r}")
+        return img
+
+    def capture(self) -> Frame:
+        path = self._paths[self._index % len(self._paths)]
+        self._index += 1
+        return self._reader(path)
+
+
+class WebcamFrameSource(FrameSource):  # pragma: no cover - needs a camera
+    """Frame source backed by a laptop webcam via OpenCV ``VideoCapture``."""
+
+    name = "webcam"
+
+    def __init__(self, device_index: int = 0, warmup_frames: int = 3):
+        self.device_index = device_index
+        self.warmup_frames = warmup_frames
+        self._cap = None
+
+    def _ensure_open(self):
+        if self._cap is not None:
+            return
+        try:
+            import cv2
+        except Exception as exc:
+            raise FaceModelUnavailable(
+                "OpenCV (cv2) is required for webcam capture; install opencv-python. "
+                + str(exc)
+            )
+        cap = cv2.VideoCapture(self.device_index)
+        if not cap.isOpened():
+            raise FrameSourceError(f"could not open webcam device {self.device_index}")
+        for _ in range(self.warmup_frames):
+            cap.read()
+        self._cap = cap
+
+    def capture(self) -> Frame:
+        self._ensure_open()
+        ok, frame = self._cap.read()
+        if not ok or frame is None:
+            raise FrameSourceError("failed to read frame from webcam")
+        return frame
+
+    def close(self):
+        if self._cap is not None:
+            self._cap.release()
+            self._cap = None
+
+
+class MistyCameraFrameSource(FrameSource):  # pragma: no cover - needs Misty + cv2
+    """Frame source backed by Misty's RGB camera (``GET /api/cameras/rgb``).
+
+    Fetches a JPEG from the robot and decodes it with OpenCV. Timeouts and
+    malformed responses raise :class:`FrameSourceError` with a clear message so
+    the caller can fall back to a webcam or continue without a name.
+    """
+
+    name = "misty_camera"
+
+    def __init__(self, misty_ip: str, timeout_s: float = 5.0):
+        if not misty_ip:
+            raise FrameSourceError("MistyCameraFrameSource requires a misty_ip")
+        self.misty_ip = misty_ip
+        self.timeout_s = timeout_s
+        self.url = f"http://{misty_ip}/api/cameras/rgb"
+
+    def capture(self) -> Frame:
+        try:
+            import requests
+        except Exception as exc:
+            raise FrameSourceError("requests is required for Misty camera capture: " + str(exc))
+        try:
+            import cv2
+        except Exception as exc:
+            raise FaceModelUnavailable(
+                "OpenCV (cv2) is required to decode Misty camera frames; install "
+                "opencv-python. " + str(exc)
+            )
+        try:
+            resp = requests.get(self.url, params={"base64": "false"}, timeout=self.timeout_s)
+            resp.raise_for_status()
+        except Exception as exc:
+            raise FrameSourceError(f"Misty camera request failed: {exc}")
+        buffer = np.frombuffer(resp.content, dtype=np.uint8)
+        frame = cv2.imdecode(buffer, cv2.IMREAD_COLOR)
+        if frame is None:
+            raise FrameSourceError("Misty camera returned a non-image / malformed response")
+        return frame
+
+
+# ---------------------------------------------------------------------------
+# Controller integration helper
+# ---------------------------------------------------------------------------
+
+
+def recognize_speaker(
+    recognizer: FaceRecognizer,
+    source: FrameSource,
+    frame_count: Optional[int] = None,
+    interval_s: float = 0.15,
+) -> Optional[str]:
+    """Capture frames and return a recognized speaker name, or ``None``.
+
+    This is the single entry point ``misty_controller.py`` uses. It is
+    deliberately *fail-open*: any :class:`FaceRecognitionError` (no face,
+    unknown face, unavailable model, camera/frame failure) results in ``None``
+    so the conversation continues without a name. It never raises.
+
+    ``frame_count`` defaults to the recognizer's ``min_consistent_frames`` so a
+    match must be confirmed across multiple frames before a name is returned.
+    """
+    if frame_count is None:
+        frame_count = recognizer.min_consistent_frames
+    try:
+        frames = source.capture_many(frame_count, interval_s=interval_s)
+    except FaceRecognitionError:
+        return None
+    except Exception:
+        return None
+    try:
+        result = recognizer.recognize_consistent(frames, source=getattr(source, "name", "unknown"))
+    except FaceRecognitionError:
+        return None
+    except Exception:
+        return None
+    return result.name if result is not None else None

--- a/src/windows-orchestration/face_recognition_service.py
+++ b/src/windows-orchestration/face_recognition_service.py
@@ -168,8 +168,11 @@ class RecognitionResult:
     confidence: float = field(default=0.0)
 
     def __post_init__(self):
-        # Map cosine distance to a bounded, monotonic confidence for logging.
-        self.confidence = max(0.0, 1.0 - (self.distance / max(self.threshold, 1e-6)))
+        # Map cosine distance to a bounded [0, 1] confidence for logging. Clamp
+        # both ends so floating-point error (or distance > threshold) cannot
+        # produce a value outside [0, 1].
+        raw = 1.0 - (self.distance / max(self.threshold, 1e-6))
+        self.confidence = min(1.0, max(0.0, raw))
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +247,7 @@ class OnnxFaceEmbedder(FaceEmbedder):
         except Exception as exc:  # pragma: no cover - depends on host env
             raise FaceModelUnavailable(
                 "OpenCV (cv2) is required for laptop face recognition; install "
-                "opencv-python. Original error: " + str(exc)
+                "opencv-python-headless (or opencv-python). Original error: " + str(exc)
             )
         for path, label in (
             (self.detector_model_path, "detector"),
@@ -308,9 +311,9 @@ class FaceProfileStore:
     def _safe_path(self, name: str) -> str:
         safe = validate_profile_name(name)
         path = os.path.abspath(os.path.join(self.directory, safe + self.SUFFIX))
-        # Defense in depth: ensure the resolved path is inside the directory.
-        base = self.directory + os.sep
-        if not (path + "").startswith(base) and os.path.dirname(path) != self.directory:
+        # Defense in depth: the resolved path must live directly inside the
+        # profile directory (single path segment, no traversal).
+        if os.path.dirname(path) != self.directory:
             raise ProfileNameError("resolved profile path escapes profile directory")
         return path
 
@@ -325,6 +328,8 @@ class FaceProfileStore:
         """Persist ``profile`` and return the file path."""
         self.ensure_dir()
         path = self._safe_path(profile.name)
+        # ``path`` already ends with ``.npz``, so np.savez writes exactly this
+        # file (it only appends the suffix when missing).
         np.savez(
             path,
             name=profile.name,
@@ -335,9 +340,6 @@ class FaceProfileStore:
             sample_count=profile.sample_count,
             embedding_dim=profile.embedding_dim,
         )
-        # numpy appends .npz automatically only when missing; normalize.
-        if not os.path.isfile(path) and os.path.isfile(path + self.SUFFIX):
-            os.replace(path + self.SUFFIX, path)
         return path
 
     def load(self, name: str) -> FaceProfile:
@@ -574,7 +576,7 @@ class ImageFileFrameSource(FrameSource):
             import cv2
         except Exception as exc:
             raise FaceModelUnavailable(
-                "OpenCV (cv2) is required to read image files; install opencv-python. "
+                "OpenCV (cv2) is required to read image files; install opencv-python-headless (or opencv-python). "
                 + str(exc)
             )
         img = cv2.imread(path)
@@ -605,7 +607,7 @@ class WebcamFrameSource(FrameSource):  # pragma: no cover - needs a camera
             import cv2
         except Exception as exc:
             raise FaceModelUnavailable(
-                "OpenCV (cv2) is required for webcam capture; install opencv-python. "
+                "OpenCV (cv2) is required for webcam capture; install opencv-python-headless (or opencv-python). "
                 + str(exc)
             )
         cap = cv2.VideoCapture(self.device_index)
@@ -655,7 +657,7 @@ class MistyCameraFrameSource(FrameSource):  # pragma: no cover - needs Misty + c
         except Exception as exc:
             raise FaceModelUnavailable(
                 "OpenCV (cv2) is required to decode Misty camera frames; install "
-                "opencv-python. " + str(exc)
+                "opencv-python-headless (or opencv-python). " + str(exc)
             )
         try:
             resp = requests.get(self.url, params={"base64": "false"}, timeout=self.timeout_s)

--- a/src/windows-orchestration/face_recognition_service.py
+++ b/src/windows-orchestration/face_recognition_service.py
@@ -511,10 +511,14 @@ class FaceRecognizer:
             prev = best_by_name.get(result.name)
             if prev is None or result.distance < prev.distance:
                 best_by_name[result.name] = result
-        for name, count in counts.items():
-            if count >= self.min_consistent_frames:
-                return best_by_name[name]
-        return None
+        # Among identities that meet the consistency threshold, pick the
+        # strongest evidence: highest agreeing-frame count, then lowest distance.
+        # This makes the outcome independent of frame order.
+        qualified = [name for name, count in counts.items() if count >= self.min_consistent_frames]
+        if not qualified:
+            return None
+        winner = min(qualified, key=lambda n: (-counts[n], best_by_name[n].distance))
+        return best_by_name[winner]
 
 
 # ---------------------------------------------------------------------------

--- a/src/windows-orchestration/face_recognition_service.py
+++ b/src/windows-orchestration/face_recognition_service.py
@@ -429,6 +429,23 @@ class FaceRecognizer:
         return path
 
     # --- embedding --------------------------------------------------------
+    def count_valid_samples(self, frames: Sequence[Frame]) -> tuple[int, int]:
+        """Return ``(valid, rejected)`` single-face sample counts for ``frames``.
+
+        A public, side-effect-free helper for dry-run/preview flows: it does not
+        persist anything. A frame counts as valid only when exactly one face is
+        detected (no face or multiple faces are rejected).
+        """
+        valid = 0
+        rejected = 0
+        for frame in frames:
+            try:
+                self._single_face_embedding(frame)
+                valid += 1
+            except FaceRecognitionError:
+                rejected += 1
+        return valid, rejected
+
     def _single_face_embedding(self, frame: Frame) -> np.ndarray:
         """Return exactly one embedding for ``frame`` or raise a typed error."""
         embeddings = self.embedder.extract_embeddings(frame)

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -1303,8 +1303,11 @@ class MistyController:
 
         Imports the recognition module lazily so the heavy/optional face
         dependencies are only touched when USE_LAPTOP_FACE_RECOGNITION is on.
-        Caches the result; on any construction error it caches ``False`` so we
-        do not retry (and spam logs) every conversation turn. Fail-open.
+        Caches the constructed recognizer; on a genuine construction error
+        (import/params) it caches ``False`` so we do not retry (and spam logs)
+        every turn. Profile presence is intentionally NOT checked here — it is
+        re-evaluated per turn in ``recognize_face_laptop`` so a profile enrolled
+        while the controller is running is picked up without a restart. Fail-open.
         """
         if self._laptop_face_recognizer is not None:
             return self._laptop_face_recognizer or None
@@ -1323,14 +1326,6 @@ class MistyController:
                 min_samples=FACE_RECOGNITION_MIN_SAMPLES,
                 min_consistent_frames=FACE_RECOGNITION_MIN_CONSISTENT_FRAMES,
             )
-            if not recognizer.load_profiles():
-                logger.info(
-                    "[Face #125] No enrolled profiles in %s — laptop recognition idle "
-                    "(enroll with tools/enroll_face.py).",
-                    FACE_PROFILE_DIR,
-                )
-                self._laptop_face_recognizer = False
-                return None
             self._laptop_face_recognizer = recognizer
             return recognizer
         except Exception as exc:
@@ -1369,12 +1364,21 @@ class MistyController:
         recognizer = self._build_laptop_face_recognizer()
         if recognizer is None:
             return None
-        source = self._build_laptop_frame_source()
-        if source is None:
-            return None
         try:
             import face_recognition_service as frs
 
+            # Refresh profiles each turn so a profile enrolled while the
+            # controller is running is picked up without a restart.
+            if not recognizer.load_profiles(force=True):
+                logger.debug(
+                    "[Face #125] No enrolled profiles in %s — skipping (enroll with "
+                    "tools/enroll_face.py).",
+                    FACE_PROFILE_DIR,
+                )
+                return None
+            source = self._build_laptop_frame_source()
+            if source is None:
+                return None
             with source:
                 name = frs.recognize_speaker(recognizer, source)
             if name:

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -71,6 +71,19 @@ LAPTOP_MISTY_TALLY_RECORDING_S = float(os.getenv("LAPTOP_MISTY_TALLY_RECORDING_S
 USE_FACE_RECOGNITION = os.getenv("USE_FACE_RECOGNITION", "").lower() in ("1", "true", "yes")
 FACE_RECOGNITION_TIMEOUT_S = float(os.getenv("FACE_RECOGNITION_TIMEOUT_S", str(config_defaults.FACE_RECOGNITION_TIMEOUT_S)))
 
+# Laptop-side face recognition (#125) — replaces Misty's unreliable on-chip
+# /api/faces pipeline with a laptop-side recognizer that identifies enrolled
+# people and feeds the existing speaker_name path. Off by default; enable
+# INSTEAD of USE_FACE_RECOGNITION after enrolling a profile (tools/enroll_face.py).
+USE_LAPTOP_FACE_RECOGNITION = os.getenv("USE_LAPTOP_FACE_RECOGNITION", "").lower() in ("1", "true", "yes")
+FACE_PROFILE_DIR = os.getenv("FACE_PROFILE_DIR", config_defaults.FACE_PROFILE_DIR)
+FACE_RECOGNITION_SOURCE = os.getenv("FACE_RECOGNITION_SOURCE", config_defaults.FACE_RECOGNITION_SOURCE).strip().lower()
+FACE_RECOGNITION_THRESHOLD = float(os.getenv("FACE_RECOGNITION_THRESHOLD", str(config_defaults.FACE_RECOGNITION_THRESHOLD)))
+FACE_RECOGNITION_MIN_CONSISTENT_FRAMES = int(os.getenv("FACE_RECOGNITION_MIN_CONSISTENT_FRAMES", str(config_defaults.FACE_RECOGNITION_MIN_CONSISTENT_FRAMES)))
+FACE_RECOGNITION_MIN_SAMPLES = int(os.getenv("FACE_RECOGNITION_MIN_SAMPLES", str(config_defaults.FACE_RECOGNITION_MIN_SAMPLES)))
+FACE_DETECTOR_MODEL_PATH = os.getenv("FACE_DETECTOR_MODEL_PATH", config_defaults.FACE_DETECTOR_MODEL_PATH)
+FACE_EMBEDDER_MODEL_PATH = os.getenv("FACE_EMBEDDER_MODEL_PATH", config_defaults.FACE_EMBEDDER_MODEL_PATH)
+
 # Face animation (#73) — state-driven animated expressions
 USE_FACE_ANIMATION = os.getenv("USE_FACE_ANIMATION", "").lower() in ("1", "true", "yes")
 FACE_ANIMATION_MAX_FPS = float(os.getenv("FACE_ANIMATION_MAX_FPS", str(config_defaults.FACE_ANIMATION_MAX_FPS)))
@@ -327,6 +340,11 @@ class MistyController:
         self._face_recognition_event = threading.Event()  # signaled when face recognized
         self._face_event_name: str | None = None  # WebSocket event name for face recognition
         self._trained_faces: list[str] = []  # cached list of trained face IDs
+
+        # Laptop-side face recognition (#125) — lazily-built recognizer that
+        # replaces Misty's unreliable on-chip pipeline. None until first use;
+        # set to False if construction fails so we don't retry every turn.
+        self._laptop_face_recognizer = None
 
         # Face animation (#73) — state-driven animated expressions.
         # The FaceAnimator is ALWAYS constructed so custom face identity, emotion
@@ -1278,6 +1296,85 @@ class MistyController:
                 return None
         finally:
             self.stop_face_recognition()
+
+    # --- Laptop-side face recognition (#125) ------------------------------
+    def _build_laptop_face_recognizer(self):
+        """Lazily construct the laptop-side FaceRecognizer, or None on failure.
+
+        Imports the recognition module lazily so the heavy/optional face
+        dependencies are only touched when USE_LAPTOP_FACE_RECOGNITION is on.
+        Caches the result; on any construction error it caches ``False`` so we
+        do not retry (and spam logs) every conversation turn. Fail-open.
+        """
+        if self._laptop_face_recognizer is not None:
+            return self._laptop_face_recognizer or None
+        try:
+            import face_recognition_service as frs
+
+            store = frs.FaceProfileStore(FACE_PROFILE_DIR)
+            embedder = frs.OnnxFaceEmbedder(
+                detector_model_path=FACE_DETECTOR_MODEL_PATH,
+                embedder_model_path=FACE_EMBEDDER_MODEL_PATH,
+            )
+            recognizer = frs.FaceRecognizer(
+                store=store,
+                embedder=embedder,
+                threshold=FACE_RECOGNITION_THRESHOLD,
+                min_samples=FACE_RECOGNITION_MIN_SAMPLES,
+                min_consistent_frames=FACE_RECOGNITION_MIN_CONSISTENT_FRAMES,
+            )
+            if not recognizer.load_profiles():
+                logger.info(
+                    "[Face #125] No enrolled profiles in %s — laptop recognition idle "
+                    "(enroll with tools/enroll_face.py).",
+                    FACE_PROFILE_DIR,
+                )
+                self._laptop_face_recognizer = False
+                return None
+            self._laptop_face_recognizer = recognizer
+            return recognizer
+        except Exception as exc:
+            logger.warning("[Face #125] Could not initialize laptop recognizer: %s", exc)
+            self._laptop_face_recognizer = False
+            return None
+
+    def _build_laptop_frame_source(self):
+        """Build the configured frame source for laptop recognition, or None."""
+        try:
+            import face_recognition_service as frs
+
+            if FACE_RECOGNITION_SOURCE == "webcam":
+                return frs.WebcamFrameSource(device_index=0)
+            # Default to Misty's RGB camera.
+            return frs.MistyCameraFrameSource(MISTY_IP, timeout_s=FACE_RECOGNITION_TIMEOUT_S)
+        except Exception as exc:
+            logger.warning("[Face #125] Could not build frame source: %s", exc)
+            return None
+
+    def recognize_face_laptop(self) -> str | None:
+        """Return a recognized speaker name using laptop-side recognition.
+
+        Fully fail-open: any missing model, camera failure, unknown face, or
+        low-confidence match returns None so the conversation continues without
+        a name. Never raises.
+        """
+        recognizer = self._build_laptop_face_recognizer()
+        if recognizer is None:
+            return None
+        source = self._build_laptop_frame_source()
+        if source is None:
+            return None
+        try:
+            import face_recognition_service as frs
+
+            with source:
+                name = frs.recognize_speaker(recognizer, source)
+            if name:
+                logger.info("[Face #125] Laptop recognition identified: %s", name)
+            return name
+        except Exception as exc:
+            logger.debug("[Face #125] Laptop recognition failed (continuing): %s", exc)
+            return None
 
     def _handle_face_recognition_event(self, data: dict):
         """Handle a FaceRecognition WebSocket event."""
@@ -2327,9 +2424,17 @@ class MistyController:
         self.show_face("face_listening.png")  # wide-eyed, attentive
         self.move_head(pitch=-10, roll=0, yaw=0, velocity=60)  # look up slightly — eye contact
 
-        # Start face recognition concurrently with recording (#16)
+        # Start face recognition concurrently with recording.
         face_result = [None]  # mutable container for thread result
-        if USE_FACE_RECOGNITION and self._trained_faces:
+        if USE_LAPTOP_FACE_RECOGNITION:
+            # Laptop-side recognition (#125) — preferred; replaces Misty's
+            # unreliable on-chip pipeline. Fail-open inside recognize_face_laptop.
+            def _face_check():
+                face_result[0] = self.recognize_face_laptop()
+            face_thread = threading.Thread(target=_face_check, daemon=True)
+            face_thread.start()
+        elif USE_FACE_RECOGNITION and self._trained_faces:
+            # Deprecated Misty-native path (#16).
             def _face_check():
                 face_result[0] = self.recognize_face_quick()
             face_thread = threading.Thread(target=_face_check, daemon=True)

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -1345,7 +1345,15 @@ class MistyController:
 
             if FACE_RECOGNITION_SOURCE == "webcam":
                 return frs.WebcamFrameSource(device_index=0)
-            # Default to Misty's RGB camera.
+            if FACE_RECOGNITION_SOURCE != "misty_camera":
+                # Surface misconfiguration (typos, or the CLI-only "image_file")
+                # instead of silently using the wrong source.
+                logger.warning(
+                    "[Face #125] Unsupported FACE_RECOGNITION_SOURCE=%r for live "
+                    "conversation; supported values are 'misty_camera' and 'webcam'. "
+                    "Falling back to Misty's camera.",
+                    FACE_RECOGNITION_SOURCE,
+                )
             return frs.MistyCameraFrameSource(MISTY_IP, timeout_s=FACE_RECOGNITION_TIMEOUT_S)
         except Exception as exc:
             logger.warning("[Face #125] Could not build frame source: %s", exc)

--- a/src/windows-orchestration/requirements.txt
+++ b/src/windows-orchestration/requirements.txt
@@ -24,6 +24,8 @@ Pillow
 bleak
 # Laptop-side face recognition: OpenCV detector/embedder (issue #125).
 # onnxruntime (above) runs the ONNX face models; numpy (above) stores embeddings.
-# Optional at runtime — laptop recognition stays idle with a clear error if the
+# Headless build keeps CI/server installs light (no GUI libs); we only use
+# VideoCapture / imdecode / FaceDetectorYN, never cv2 highgui windows. Optional
+# at runtime — laptop recognition stays idle with a clear error if the
 # models/deps are missing; not required for the cloud-safe unit tests.
-opencv-python
+opencv-python-headless

--- a/src/windows-orchestration/requirements.txt
+++ b/src/windows-orchestration/requirements.txt
@@ -22,3 +22,8 @@ openwakeword
 Pillow
 # BLE provisioning: WiFi setup over Bluetooth (issue #111)
 bleak
+# Laptop-side face recognition: OpenCV detector/embedder (issue #125).
+# onnxruntime (above) runs the ONNX face models; numpy (above) stores embeddings.
+# Optional at runtime — laptop recognition stays idle with a clear error if the
+# models/deps are missing; not required for the cloud-safe unit tests.
+opencv-python

--- a/tests/test_laptop_face_recognition.py
+++ b/tests/test_laptop_face_recognition.py
@@ -93,7 +93,7 @@ def test_store_path_never_escapes_directory(tmp_path):
     with pytest.raises(frs.ProfileNameError):
         store.path_for("../../etc/passwd")
     good = store.path_for("Tammy")
-    assert os.path.abspath(good).startswith(os.path.abspath(str(tmp_path)))
+    assert os.path.commonpath([os.path.abspath(good), os.path.abspath(str(tmp_path))]) == os.path.abspath(str(tmp_path))
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +194,16 @@ def test_enroll_validates_name(tmp_path):
     rec = make_recognizer(tmp_path)
     with pytest.raises(frs.ProfileNameError):
         rec.enroll("../evil", [make_frame(TAMMY)] * 5)
+
+
+def test_count_valid_samples(tmp_path):
+    rec = make_recognizer(tmp_path)
+    frames = [make_frame(TAMMY), make_frame(), make_frame(TAMMY, ALEX), make_frame(ALEX)]
+    valid, rejected = rec.count_valid_samples(frames)
+    assert valid == 2  # two single-face frames
+    assert rejected == 2  # one no-face + one multi-face
+    # Pure dry run: nothing persisted.
+    assert rec.store.list_names() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_laptop_face_recognition.py
+++ b/tests/test_laptop_face_recognition.py
@@ -121,9 +121,11 @@ def test_profile_store_list_and_delete(tmp_path):
     store.save(frs.FaceProfile(name="Tammy", embeddings=np.vstack([TAMMY, TAMMY])))
     store.save(frs.FaceProfile(name="Alex", embeddings=np.vstack([ALEX, ALEX])))
     assert store.list_names() == ["Alex", "Tammy"]
-    assert store.delete("Alex") is True
+    deleted = store.delete("Alex")
+    assert deleted is True
     assert store.list_names() == ["Tammy"]
-    assert store.delete("Alex") is False
+    deleted_again = store.delete("Alex")
+    assert deleted_again is False
 
 
 def test_load_all_skips_corrupt_files(tmp_path):

--- a/tests/test_laptop_face_recognition.py
+++ b/tests/test_laptop_face_recognition.py
@@ -158,6 +158,15 @@ def test_cosine_distance_identity_and_orthogonal():
     assert frs.cosine_distance(TAMMY, ALEX) == pytest.approx(1.0, abs=1e-6)
 
 
+def test_recognition_result_confidence_is_bounded():
+    # Negative distance (fp error / cosine > 1) must not push confidence above 1.
+    over = frs.RecognitionResult(name="X", distance=-0.01, threshold=0.4)
+    assert 0.0 <= over.confidence <= 1.0
+    # Distance beyond threshold must not push confidence below 0.
+    under = frs.RecognitionResult(name="X", distance=1.0, threshold=0.4)
+    assert 0.0 <= under.confidence <= 1.0
+
+
 # ---------------------------------------------------------------------------
 # Enrollment
 # ---------------------------------------------------------------------------

--- a/tests/test_laptop_face_recognition.py
+++ b/tests/test_laptop_face_recognition.py
@@ -1,0 +1,367 @@
+"""Cloud-safe unit tests for laptop-side face recognition (#125).
+
+These tests use a deterministic fake embedder and in-memory / static frame
+sources, so they run without Misty hardware, a camera, OpenCV, or ONNX models.
+"""
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_ORCH_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+)
+if _ORCH_DIR not in sys.path:
+    sys.path.insert(0, _ORCH_DIR)
+
+import face_recognition_service as frs  # noqa: E402
+
+
+DIM = 4
+TAMMY = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+ALEX = np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32)
+STRANGER = np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32)
+
+
+def make_frame(*embeddings) -> np.ndarray:
+    """Build a fake frame whose 'faces' are the given embedding rows.
+
+    Shape (num_faces, DIM). An empty frame (num_faces == 0) means 'no face'.
+    """
+    if not embeddings:
+        return np.zeros((0, DIM), dtype=np.float32)
+    return np.vstack([np.asarray(e, dtype=np.float32) for e in embeddings])
+
+
+class FakeEmbedder(frs.FaceEmbedder):
+    """Interprets a frame as an (n_faces, DIM) array of pre-baked embeddings."""
+
+    def extract_embeddings(self, frame):
+        arr = np.asarray(frame, dtype=np.float32)
+        if arr.ndim != 2 or arr.shape[0] == 0:
+            return []
+        return [arr[i] for i in range(arr.shape[0])]
+
+
+class FakeSource(frs.FrameSource):
+    name = "fake"
+
+    def __init__(self, frames, raise_on_capture=False):
+        self._frames = list(frames)
+        self._i = 0
+        self._raise = raise_on_capture
+
+    def capture(self):
+        if self._raise:
+            raise frs.FrameSourceError("boom")
+        frame = self._frames[self._i % len(self._frames)]
+        self._i += 1
+        return frame
+
+
+def make_recognizer(tmp_path, **kwargs):
+    store = frs.FaceProfileStore(str(tmp_path))
+    defaults = dict(threshold=0.4, min_samples=3, min_consistent_frames=2)
+    defaults.update(kwargs)
+    return frs.FaceRecognizer(store=store, embedder=FakeEmbedder(), **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Name validation / path-traversal safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["Tammy", "Tammy Two", "tammy_2", "a-b-c"])
+def test_validate_profile_name_accepts_safe(name):
+    assert frs.validate_profile_name(name) == name.strip()
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "   ", "..", "../evil", "a/b", "a\\b", "x" * 65, "bad*name", "semi;colon"],
+)
+def test_validate_profile_name_rejects_unsafe(name):
+    with pytest.raises(frs.ProfileNameError):
+        frs.validate_profile_name(name)
+
+
+def test_store_path_never_escapes_directory(tmp_path):
+    store = frs.FaceProfileStore(str(tmp_path))
+    with pytest.raises(frs.ProfileNameError):
+        store.path_for("../../etc/passwd")
+    good = store.path_for("Tammy")
+    assert os.path.abspath(good).startswith(os.path.abspath(str(tmp_path)))
+
+
+# ---------------------------------------------------------------------------
+# Profile storage
+# ---------------------------------------------------------------------------
+
+
+def test_profile_store_roundtrip(tmp_path):
+    store = frs.FaceProfileStore(str(tmp_path))
+    embeddings = np.vstack([TAMMY, TAMMY, TAMMY])
+    profile = frs.FaceProfile(name="Tammy", embeddings=embeddings)
+    path = store.save(profile)
+    assert os.path.isfile(path)
+
+    loaded = store.load("Tammy")
+    assert loaded.name == "Tammy"
+    assert loaded.sample_count == 3
+    assert loaded.embedding_dim == DIM
+    assert loaded.model_name == frs.MODEL_NAME
+    np.testing.assert_allclose(loaded.embeddings, embeddings)
+
+
+def test_profile_store_list_and_delete(tmp_path):
+    store = frs.FaceProfileStore(str(tmp_path))
+    store.save(frs.FaceProfile(name="Tammy", embeddings=np.vstack([TAMMY, TAMMY])))
+    store.save(frs.FaceProfile(name="Alex", embeddings=np.vstack([ALEX, ALEX])))
+    assert store.list_names() == ["Alex", "Tammy"]
+    assert store.delete("Alex") is True
+    assert store.list_names() == ["Tammy"]
+    assert store.delete("Alex") is False
+
+
+def test_load_all_skips_corrupt_files(tmp_path):
+    store = frs.FaceProfileStore(str(tmp_path))
+    store.save(frs.FaceProfile(name="Tammy", embeddings=np.vstack([TAMMY, TAMMY])))
+    # Drop a foreign .npz that is not a valid profile.
+    with open(os.path.join(str(tmp_path), "junk.npz"), "wb") as fh:
+        fh.write(b"not a real npz")
+    profiles = store.load_all()
+    assert [p.name for p in profiles] == ["Tammy"]
+
+
+def test_profile_rejects_empty_embeddings():
+    with pytest.raises(frs.FaceRecognitionError):
+        frs.FaceProfile(name="Tammy", embeddings=np.zeros((0, DIM), dtype=np.float32))
+
+
+def test_mean_embedding_is_normalized():
+    profile = frs.FaceProfile(name="Tammy", embeddings=np.vstack([TAMMY * 3, TAMMY * 5]))
+    assert pytest.approx(np.linalg.norm(profile.mean_embedding), abs=1e-5) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Math
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_distance_identity_and_orthogonal():
+    assert frs.cosine_distance(TAMMY, TAMMY) == pytest.approx(0.0, abs=1e-6)
+    assert frs.cosine_distance(TAMMY, ALEX) == pytest.approx(1.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Enrollment
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_success(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    frames = [make_frame(TAMMY) for _ in range(4)]
+    profile = rec.enroll("Tammy", frames)
+    assert profile.name == "Tammy"
+    assert profile.sample_count == 4
+    assert "Tammy" in rec.store.list_names()
+
+
+def test_enroll_rejects_too_few_valid_samples(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=5)
+    # Only 2 usable frames; the rest have no face or multiple faces.
+    frames = [make_frame(TAMMY), make_frame(TAMMY), make_frame(), make_frame(TAMMY, ALEX)]
+    with pytest.raises(frs.FaceRecognitionError):
+        rec.enroll("Tammy", frames)
+    assert "Tammy" not in rec.store.list_names()
+
+
+def test_enroll_validates_name(tmp_path):
+    rec = make_recognizer(tmp_path)
+    with pytest.raises(frs.ProfileNameError):
+        rec.enroll("../evil", [make_frame(TAMMY)] * 5)
+
+
+# ---------------------------------------------------------------------------
+# Recognition
+# ---------------------------------------------------------------------------
+
+
+def test_recognize_known_face(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    result = rec.recognize(make_frame(TAMMY), source="test")
+    assert result is not None
+    assert result.name == "Tammy"
+    assert result.distance <= rec.threshold
+    assert result.source == "test"
+    assert 0.0 <= result.confidence <= 1.0
+
+
+def test_recognize_unknown_face_returns_none(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    assert rec.recognize(make_frame(STRANGER)) is None
+
+
+def test_recognize_no_face_raises(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    with pytest.raises(frs.NoFaceDetected):
+        rec.recognize(make_frame())
+
+
+def test_recognize_multiple_faces_raises(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    with pytest.raises(frs.MultipleFacesDetected):
+        rec.recognize(make_frame(TAMMY, ALEX))
+
+
+def test_recognize_with_no_profiles_returns_none(tmp_path):
+    rec = make_recognizer(tmp_path)
+    assert rec.recognize(make_frame(TAMMY)) is None
+
+
+def test_recognize_consistent_requires_min_frames(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3, min_consistent_frames=2)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    # Only one Tammy frame + noise → not enough agreement.
+    frames = [make_frame(TAMMY), make_frame(STRANGER), make_frame()]
+    assert rec.recognize_consistent(frames) is None
+    # Two agreeing frames → recognized.
+    frames = [make_frame(TAMMY), make_frame(TAMMY), make_frame(STRANGER)]
+    result = rec.recognize_consistent(frames)
+    assert result is not None and result.name == "Tammy"
+
+
+# ---------------------------------------------------------------------------
+# Controller integration helper (recognize_speaker)
+# ---------------------------------------------------------------------------
+
+
+def test_recognize_speaker_returns_name(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3, min_consistent_frames=2)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    source = FakeSource([make_frame(TAMMY), make_frame(TAMMY)])
+    assert frs.recognize_speaker(rec, source, frame_count=2, interval_s=0) == "Tammy"
+
+
+def test_recognize_speaker_unknown_returns_none(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3, min_consistent_frames=2)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    source = FakeSource([make_frame(STRANGER), make_frame(STRANGER)])
+    assert frs.recognize_speaker(rec, source, frame_count=2, interval_s=0) is None
+
+
+def test_recognize_speaker_is_fail_open(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    source = FakeSource([make_frame(TAMMY)], raise_on_capture=True)
+    # Capture raises → helper must swallow and return None, never raise.
+    assert frs.recognize_speaker(rec, source, frame_count=2, interval_s=0) is None
+
+
+# ---------------------------------------------------------------------------
+# Frame sources
+# ---------------------------------------------------------------------------
+
+
+def test_image_file_frame_source_uses_injected_reader():
+    calls = []
+
+    def fake_reader(path):
+        calls.append(path)
+        return make_frame(TAMMY)
+
+    src = frs.ImageFileFrameSource(["a.jpg", "b.jpg"], reader=fake_reader)
+    frames = src.capture_many(3, interval_s=0)
+    assert len(frames) == 3
+    assert calls == ["a.jpg", "b.jpg", "a.jpg"]  # cycles through paths
+
+
+def test_image_file_frame_source_requires_paths():
+    with pytest.raises(frs.FrameSourceError):
+        frs.ImageFileFrameSource([])
+
+
+def test_capture_many_count():
+    src = FakeSource([make_frame(TAMMY)])
+    assert len(src.capture_many(5, interval_s=0)) == 5
+
+
+def test_misty_source_requires_ip():
+    with pytest.raises(frs.FrameSourceError):
+        frs.MistyCameraFrameSource("")
+
+
+# ---------------------------------------------------------------------------
+# OnnxFaceEmbedder unavailability (no model files / deps)
+# ---------------------------------------------------------------------------
+
+
+def test_onnx_embedder_reports_unavailable_without_models(tmp_path):
+    embedder = frs.OnnxFaceEmbedder(
+        detector_model_path=str(tmp_path / "missing_detector.onnx"),
+        embedder_model_path=str(tmp_path / "missing_embedder.onnx"),
+    )
+    with pytest.raises(frs.FaceModelUnavailable):
+        embedder.extract_embeddings(make_frame(TAMMY))
+
+
+# ---------------------------------------------------------------------------
+# CLI argument validation (mocked/static; no models needed)
+# ---------------------------------------------------------------------------
+
+
+def _load_tool(module_name, filename):
+    path = os.path.join(os.path.dirname(__file__), "..", "tools", filename)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_enroll_cli_requires_exactly_one_action(tmp_path):
+    mod = _load_tool("enroll_face", "enroll_face.py")
+    with pytest.raises(SystemExit):
+        mod.main(["--profile-dir", str(tmp_path)])  # no action
+    with pytest.raises(SystemExit):
+        mod.main(["--list", "--delete", "X", "--profile-dir", str(tmp_path)])  # two actions
+
+
+def test_enroll_cli_list_empty_dir(tmp_path):
+    mod = _load_tool("enroll_face", "enroll_face.py")
+    assert mod.main(["--list", "--profile-dir", str(tmp_path)]) == 0
+
+
+def test_enroll_cli_delete_missing_returns_one(tmp_path):
+    mod = _load_tool("enroll_face", "enroll_face.py")
+    assert mod.main(["--delete", "Nobody", "--profile-dir", str(tmp_path)]) == 1
+
+
+def test_enroll_cli_rejects_unsafe_name(tmp_path):
+    mod = _load_tool("enroll_face", "enroll_face.py")
+    rc = mod.main(["--name", "../evil", "--source", "image", "--image", "x.jpg",
+                   "--profile-dir", str(tmp_path)])
+    assert rc == 1
+
+
+def test_enroll_cli_rejects_bad_samples(tmp_path):
+    mod = _load_tool("enroll_face", "enroll_face.py")
+    with pytest.raises(SystemExit):
+        mod.main(["--name", "Tammy", "--samples", "0", "--profile-dir", str(tmp_path)])
+
+
+def test_recognize_cli_no_profiles_returns_one(tmp_path):
+    mod = _load_tool("recognize_face", "recognize_face.py")
+    assert mod.main(["--source", "webcam", "--profile-dir", str(tmp_path)]) == 1
+
+
+def test_recognize_cli_rejects_bad_frames(tmp_path):
+    mod = _load_tool("recognize_face", "recognize_face.py")
+    with pytest.raises(SystemExit):
+        mod.main(["--frames", "-1", "--profile-dir", str(tmp_path)])

--- a/tests/test_laptop_face_recognition.py
+++ b/tests/test_laptop_face_recognition.py
@@ -240,6 +240,18 @@ def test_recognize_consistent_requires_min_frames(tmp_path):
     assert result is not None and result.name == "Tammy"
 
 
+def test_recognize_consistent_prefers_strongest_evidence(tmp_path):
+    rec = make_recognizer(tmp_path, min_samples=3, min_consistent_frames=2)
+    rec.enroll("Tammy", [make_frame(TAMMY)] * 3)
+    rec.enroll("Alex", [make_frame(ALEX)] * 3)
+    # Both clear min_consistent_frames=2; Tammy has more agreeing frames and
+    # must win regardless of frame order.
+    frames = [make_frame(ALEX), make_frame(TAMMY), make_frame(ALEX),
+              make_frame(TAMMY), make_frame(TAMMY)]
+    result = rec.recognize_consistent(frames)
+    assert result is not None and result.name == "Tammy"
+
+
 # ---------------------------------------------------------------------------
 # Controller integration helper (recognize_speaker)
 # ---------------------------------------------------------------------------

--- a/tools/enroll_face.py
+++ b/tools/enroll_face.py
@@ -1,0 +1,257 @@
+"""Laptop-side face enrollment CLI (#125).
+
+Enrolls a named local face profile from Misty's RGB camera or the laptop webcam
+and stores it in a gitignored local profile directory. This replaces Misty's
+unreliable on-chip ``/api/faces`` training (see docs/lessons-learned.md).
+
+Only numeric face embeddings and metadata are stored — never photos.
+
+Usage (run from the repository root):
+    python tools\\enroll_face.py --name Tammy --source misty --misty-ip 10.0.0.15 --samples 10
+    python tools\\enroll_face.py --name Tammy --source webcam --samples 10
+    python tools\\enroll_face.py --name Tammy --source image --image face1.jpg face2.jpg
+    python tools\\enroll_face.py --list
+    python tools\\enroll_face.py --delete Tammy
+
+Exit codes:
+    0  success (requested action completed)
+    1  failure (too few samples, unavailable model/camera, bad args)
+"""
+
+import argparse
+import os
+import sys
+
+# Make the windows-orchestration package importable.
+_ORCH_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+)
+if _ORCH_DIR not in sys.path:
+    sys.path.insert(0, _ORCH_DIR)
+
+import config_defaults  # noqa: E402
+import face_recognition_service as frs  # noqa: E402
+
+
+def build_source(args) -> frs.FrameSource:
+    """Construct the requested frame source or raise FrameSourceError."""
+    if args.source == "misty":
+        if not args.misty_ip:
+            raise frs.FrameSourceError(
+                "--source misty requires --misty-ip ADDRESS (or set MISTY_IP)"
+            )
+        return frs.MistyCameraFrameSource(args.misty_ip)
+    if args.source == "webcam":
+        return frs.WebcamFrameSource(device_index=args.webcam_index)
+    if args.source == "image":
+        if not args.image:
+            raise frs.FrameSourceError("--source image requires one or more --image paths")
+        return frs.ImageFileFrameSource(args.image)
+    raise frs.FrameSourceError(f"unknown source: {args.source!r}")
+
+
+def build_recognizer(args) -> frs.FaceRecognizer:
+    store = frs.FaceProfileStore(args.profile_dir)
+    embedder = frs.OnnxFaceEmbedder(
+        detector_model_path=config_defaults.FACE_DETECTOR_MODEL_PATH,
+        embedder_model_path=config_defaults.FACE_EMBEDDER_MODEL_PATH,
+    )
+    return frs.FaceRecognizer(
+        store=store,
+        embedder=embedder,
+        threshold=args.threshold,
+        min_samples=args.samples if args.samples else config_defaults.FACE_RECOGNITION_MIN_SAMPLES,
+        min_consistent_frames=config_defaults.FACE_RECOGNITION_MIN_CONSISTENT_FRAMES,
+    )
+
+
+def run_list(args) -> int:
+    store = frs.FaceProfileStore(args.profile_dir)
+    names = store.list_names()
+    if names:
+        print(f"  Enrolled profiles ({len(names)}) in {store.directory}:")
+        for name in names:
+            try:
+                profile = store.load(name)
+                print(
+                    f"    - {name}  (samples={profile.sample_count}, "
+                    f"dim={profile.embedding_dim}, model={profile.model_name}"
+                    f"@{profile.model_version}, created={profile.created_at})"
+                )
+            except Exception as exc:
+                print(f"    - {name}  (unreadable: {exc})")
+    else:
+        print(f"  Enrolled profiles: (none) in {store.directory}")
+    return 0
+
+
+def run_delete(args) -> int:
+    store = frs.FaceProfileStore(args.profile_dir)
+    try:
+        deleted = store.delete(args.delete)
+    except frs.ProfileNameError as exc:
+        print(f"  ERROR: {exc}")
+        return 1
+    if deleted:
+        print(f"  Deleted profile '{args.delete}'.")
+        return 0
+    print(f"  No profile named '{args.delete}' to delete.")
+    return 1
+
+
+def run_enroll(args) -> int:
+    try:
+        frs.validate_profile_name(args.name)
+    except frs.ProfileNameError as exc:
+        print(f"  ERROR: {exc}")
+        return 1
+
+    try:
+        source = build_source(args)
+    except frs.FrameSourceError as exc:
+        print(f"  ERROR: {exc}")
+        return 1
+
+    recognizer = build_recognizer(args)
+
+    print(f"  Enrolling '{args.name}' from {args.source} source.")
+    print("  >>> Face the camera in good, even lighting.")
+    print("  >>> Slowly turn your head left and right during capture.")
+    if args.preview_only:
+        print("  (--preview-only) No profile will be saved.")
+
+    try:
+        with source:
+            frames = source.capture_many(args.samples, interval_s=args.interval)
+    except frs.FaceRecognitionError as exc:
+        print(f"  ERROR: capture failed: {exc}")
+        return 1
+
+    print(f"  Captured {len(frames)} frame(s); extracting face embeddings...")
+
+    if args.preview_only:
+        # Dry run: count valid single-face frames without persisting.
+        valid = 0
+        rejected = 0
+        for frame in frames:
+            try:
+                recognizer._single_face_embedding(frame)
+                valid += 1
+            except frs.FaceRecognitionError:
+                rejected += 1
+        print(f"  PREVIEW: {valid} valid sample(s), {rejected} rejected. Nothing saved.")
+        return 0 if valid >= recognizer.min_samples else 1
+
+    try:
+        profile = recognizer.enroll(args.name, frames)
+    except frs.FaceRecognitionError as exc:
+        print(f"  ERROR: enrollment failed: {exc}")
+        return 1
+
+    path = recognizer.store.path_for(profile.name)
+    print(
+        f"\n  SUCCESS: enrolled '{profile.name}' "
+        f"({profile.sample_count} samples, dim={profile.embedding_dim})."
+    )
+    print(f"  Saved profile: {path}")
+    print("  Reminder: this file contains biometric embeddings — keep it out of git.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Enroll a laptop-side face profile (#125).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples (run from the repository root):\n"
+            "  python tools\\enroll_face.py --name Tammy --source misty --misty-ip 10.0.0.15 --samples 10\n"
+            "  python tools\\enroll_face.py --name Tammy --source webcam --samples 10\n"
+            "  python tools\\enroll_face.py --list\n"
+            "  python tools\\enroll_face.py --delete Tammy\n"
+        ),
+    )
+    parser.add_argument("--name", help="Profile name to enroll (e.g. Tammy).")
+    parser.add_argument("--list", action="store_true", help="List enrolled profiles and exit.")
+    parser.add_argument("--delete", metavar="NAME", help="Delete an enrolled profile and exit.")
+    parser.add_argument(
+        "--source",
+        choices=("misty", "webcam", "image"),
+        default="misty",
+        help="Frame source for enrollment (default: misty).",
+    )
+    parser.add_argument(
+        "--misty-ip",
+        default=os.environ.get("MISTY_IP"),
+        help="Misty robot IP (defaults to MISTY_IP env var). Required for --source misty.",
+    )
+    parser.add_argument("--webcam-index", type=int, default=0, help="Webcam device index (default: 0).")
+    parser.add_argument("--image", nargs="+", help="Image file paths for --source image.")
+    parser.add_argument(
+        "--samples",
+        type=_positive_int,
+        default=10,
+        help="Number of frames to capture (default: 10).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=_nonneg_float,
+        default=0.3,
+        help="Seconds between captured frames (default: 0.3).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=_positive_float,
+        default=config_defaults.FACE_RECOGNITION_THRESHOLD,
+        help=f"Match threshold (default: {config_defaults.FACE_RECOGNITION_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        default=config_defaults.FACE_PROFILE_DIR,
+        help="Directory to store profiles (default: repo data/face_profiles).",
+    )
+    parser.add_argument(
+        "--preview-only",
+        action="store_true",
+        help="Dry run: capture and count valid samples without saving a profile.",
+    )
+    return parser
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not (parsed > 0):
+        raise argparse.ArgumentTypeError("must be > 0")
+    return parsed
+
+
+def _nonneg_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    actions = [bool(args.list), bool(args.delete), bool(args.name)]
+    if sum(actions) != 1:
+        parser.error("choose exactly one of --name NAME, --list, or --delete NAME")
+
+    if args.list:
+        return run_list(args)
+    if args.delete:
+        return run_delete(args)
+    return run_enroll(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/enroll_face.py
+++ b/tools/enroll_face.py
@@ -60,7 +60,7 @@ def build_recognizer(args) -> frs.FaceRecognizer:
         store=store,
         embedder=embedder,
         threshold=args.threshold,
-        min_samples=args.samples if args.samples else config_defaults.FACE_RECOGNITION_MIN_SAMPLES,
+        min_samples=args.min_samples,
         min_consistent_frames=config_defaults.FACE_RECOGNITION_MIN_CONSISTENT_FRAMES,
     )
 
@@ -190,7 +190,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--samples",
         type=_positive_int,
         default=10,
-        help="Number of frames to capture (default: 10).",
+        help="Number of frames to CAPTURE (default: 10).",
+    )
+    parser.add_argument(
+        "--min-samples",
+        type=_positive_int,
+        default=config_defaults.FACE_RECOGNITION_MIN_SAMPLES,
+        help=(
+            "Minimum number of VALID single-face samples required to enroll "
+            f"(default: {config_defaults.FACE_RECOGNITION_MIN_SAMPLES}). Frames with "
+            "no face or multiple faces are skipped, so this is independent of --samples."
+        ),
     )
     parser.add_argument(
         "--interval",

--- a/tools/enroll_face.py
+++ b/tools/enroll_face.py
@@ -131,14 +131,7 @@ def run_enroll(args) -> int:
 
     if args.preview_only:
         # Dry run: count valid single-face frames without persisting.
-        valid = 0
-        rejected = 0
-        for frame in frames:
-            try:
-                recognizer._single_face_embedding(frame)
-                valid += 1
-            except frs.FaceRecognitionError:
-                rejected += 1
+        valid, rejected = recognizer.count_valid_samples(frames)
         print(f"  PREVIEW: {valid} valid sample(s), {rejected} rejected. Nothing saved.")
         return 0 if valid >= recognizer.min_samples else 1
 

--- a/tools/recognize_face.py
+++ b/tools/recognize_face.py
@@ -1,0 +1,190 @@
+"""Laptop-side face recognition CLI / smoke test (#125).
+
+Captures one or more frames from Misty's RGB camera or the laptop webcam and
+reports the recognized profile name, cosine distance, threshold, and frame
+source. Returns a non-zero exit code when no known face is recognized, so it can
+be used as a smoke test.
+
+Usage (run from the repository root):
+    python tools\\recognize_face.py --source misty --misty-ip 10.0.0.15
+    python tools\\recognize_face.py --source webcam
+    python tools\\recognize_face.py --source image --image face.jpg
+
+Exit codes:
+    0  a known face was recognized above confidence
+    1  no known face recognized / capture or model unavailable / bad args
+"""
+
+import argparse
+import os
+import sys
+
+_ORCH_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "windows-orchestration")
+)
+if _ORCH_DIR not in sys.path:
+    sys.path.insert(0, _ORCH_DIR)
+
+import config_defaults  # noqa: E402
+import face_recognition_service as frs  # noqa: E402
+
+
+def build_source(args) -> frs.FrameSource:
+    if args.source == "misty":
+        if not args.misty_ip:
+            raise frs.FrameSourceError(
+                "--source misty requires --misty-ip ADDRESS (or set MISTY_IP)"
+            )
+        return frs.MistyCameraFrameSource(args.misty_ip)
+    if args.source == "webcam":
+        return frs.WebcamFrameSource(device_index=args.webcam_index)
+    if args.source == "image":
+        if not args.image:
+            raise frs.FrameSourceError("--source image requires one or more --image paths")
+        return frs.ImageFileFrameSource(args.image)
+    raise frs.FrameSourceError(f"unknown source: {args.source!r}")
+
+
+def build_recognizer(args) -> frs.FaceRecognizer:
+    store = frs.FaceProfileStore(args.profile_dir)
+    embedder = frs.OnnxFaceEmbedder(
+        detector_model_path=config_defaults.FACE_DETECTOR_MODEL_PATH,
+        embedder_model_path=config_defaults.FACE_EMBEDDER_MODEL_PATH,
+    )
+    return frs.FaceRecognizer(
+        store=store,
+        embedder=embedder,
+        threshold=args.threshold,
+        min_samples=config_defaults.FACE_RECOGNITION_MIN_SAMPLES,
+        min_consistent_frames=args.min_frames,
+    )
+
+
+def run_recognize(args) -> int:
+    recognizer = build_recognizer(args)
+    if not recognizer.load_profiles():
+        print(
+            f"  No enrolled profiles found in {recognizer.store.directory}. "
+            "Enroll one first with tools\\enroll_face.py."
+        )
+        return 1
+
+    try:
+        source = build_source(args)
+    except frs.FrameSourceError as exc:
+        print(f"  ERROR: {exc}")
+        return 1
+
+    try:
+        with source:
+            frames = source.capture_many(args.frames, interval_s=args.interval)
+    except frs.FaceRecognitionError as exc:
+        print(f"  ERROR: capture failed: {exc}")
+        return 1
+
+    result = recognizer.recognize_consistent(frames, source=source.name)
+    if result is None:
+        print(
+            f"  No known face recognized (source={source.name}, "
+            f"frames={len(frames)}, threshold={recognizer.threshold}, "
+            f"min_consistent_frames={recognizer.min_consistent_frames})."
+        )
+        return 1
+
+    print(
+        f"  RECOGNIZED: {result.name}\n"
+        f"    distance:   {result.distance:.4f} (lower is better)\n"
+        f"    threshold:  {result.threshold:.4f}\n"
+        f"    confidence: {result.confidence:.3f}\n"
+        f"    source:     {result.source}"
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Recognize a laptop-side face profile (#125).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples (run from the repository root):\n"
+            "  python tools\\recognize_face.py --source misty --misty-ip 10.0.0.15\n"
+            "  python tools\\recognize_face.py --source webcam\n"
+        ),
+    )
+    parser.add_argument(
+        "--source",
+        choices=("misty", "webcam", "image"),
+        default="misty",
+        help="Frame source for recognition (default: misty).",
+    )
+    parser.add_argument(
+        "--misty-ip",
+        default=os.environ.get("MISTY_IP"),
+        help="Misty robot IP (defaults to MISTY_IP env var). Required for --source misty.",
+    )
+    parser.add_argument("--webcam-index", type=int, default=0, help="Webcam device index (default: 0).")
+    parser.add_argument("--image", nargs="+", help="Image file paths for --source image.")
+    parser.add_argument(
+        "--frames",
+        type=_positive_int,
+        default=5,
+        help="Number of frames to capture (default: 5).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=_nonneg_float,
+        default=0.2,
+        help="Seconds between captured frames (default: 0.2).",
+    )
+    parser.add_argument(
+        "--min-frames",
+        type=_positive_int,
+        default=config_defaults.FACE_RECOGNITION_MIN_CONSISTENT_FRAMES,
+        help=(
+            "Frames that must agree on the same name (default: "
+            f"{config_defaults.FACE_RECOGNITION_MIN_CONSISTENT_FRAMES})."
+        ),
+    )
+    parser.add_argument(
+        "--threshold",
+        type=_positive_float,
+        default=config_defaults.FACE_RECOGNITION_THRESHOLD,
+        help=f"Match threshold (default: {config_defaults.FACE_RECOGNITION_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--profile-dir",
+        default=config_defaults.FACE_PROFILE_DIR,
+        help="Directory holding profiles (default: repo data/face_profiles).",
+    )
+    return parser
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not (parsed > 0):
+        raise argparse.ArgumentTypeError("must be > 0")
+    return parsed
+
+
+def _nonneg_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return run_recognize(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #125

## Summary

Replaces Misty''s unreliable on-chip `/api/faces` face pipeline (documented as effectively non-functional on this Snapdragon 410 unit) with a **laptop-side** face enrollment/recognition service that produces `speaker_name` for the existing orchestration path. Off by default and fail-open.

## What changed

- **`src/windows-orchestration/face_recognition_service.py`** (new): `FaceRecognizer` (enroll / recognize / recognize_consistent / load/save profiles), `FaceProfile`, path-traversal-safe `FaceProfileStore` (`.npz`, embeddings + metadata only — never photos), pluggable `FaceEmbedder` with a lazy `OnnxFaceEmbedder` (OpenCV + ONNX Runtime, reports `FaceModelUnavailable` when deps/models missing), `MistyCameraFrameSource` / `WebcamFrameSource` / `ImageFileFrameSource`, and a fail-open `recognize_speaker()` helper.
- **`tools/enroll_face.py`** + **`tools/recognize_face.py`** (new): enroll/list/delete and recognition CLIs with argument validation and exit codes.
- **`misty_controller.py`**: feature flag `USE_LAPTOP_FACE_RECOGNITION` runs laptop recognition concurrently with recording, sets `speaker_name`, persists it across follow-up turns, and fails open (logs + continues) on any error. Deprecated `USE_FACE_RECOGNITION` (#16) path kept disabled.
- **`config_defaults.py`** + **`.env.example`**: centralized defaults (source, threshold, min consistent frames, min samples, profile dir, model paths).
- **`.gitignore`**: `data/face_profiles/*.npz|*.npy` (biometric data stays local). `data/face_profiles/README.md` documents privacy.
- **Docs**: README "Laptop-side face recognition" section (enroll/test/enable/privacy/live checklist) + `docs/lessons-learned.md` marked implemented.
- **`requirements.txt`**: `opencv-python` (optional at runtime; not needed for tests).

## Acceptance criteria

- [x] Laptop-side module enrolls/recognizes a named local profile without Misty''s `/api/faces` or `FaceRecognition` events.
- [x] CLI enrolls from Misty camera or webcam into a **gitignored** local profile dir.
- [x] CLI runs recognition and reports name, distance, threshold, and clear failure reasons (non-zero exit when unrecognized).
- [x] `misty_controller.py` can pass `speaker_name=Tammy` into the existing orchestration request.
- [x] Unknown/low-confidence faces fall back gracefully (no crash, no name).
- [x] Profile path handling prevents traversal and keeps biometric data out of git.
- [x] Defaults centralized in `config_defaults.py`, documented in `.env.example`.
- [x] README documents enrollment, testing, enabling, privacy, and native-path deprecation.
- [x] Automated tests cover storage, threshold, no-face/unknown fallback, controller-integration helper, and CLI validation with mocked/static frame sources.
- [x] Live validation checklist documented (hardware-only; not run in CI).

## Verification

```
python -m py_compile src\windows-orchestration\face_recognition_service.py config_defaults.py misty_controller.py tools\enroll_face.py tools\recognize_face.py   # rc=0
python -m pytest tests\test_laptop_face_recognition.py -q      # 44 passed
python -m pytest tests\test_train_face.py -q                   # passed (no regression)
python -m pytest tests\test_integration.py -m "not live" -q    # 215 passed, 5 pre-existing failures unrelated to #125
git diff --check                                               # clean
```

The 5 `test_integration.py` failures (`TestPromptLimiting` / `TestLatencyConfig` `max_tokens`) are **pre-existing on `main`** and touch `orchestration_service.py`, which this PR does not modify (verified by checking them out on `main`).

Live camera/robot validation cannot run in CI and is captured as a manual checklist in the README.