### PR TITLE
feat: add npx conference CLI, fix self-wake and auto-advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,58 @@ Controller test API:
 
 ---
 
+## Conference Mode
+
+Conference Mode lets Misty participate in scripted on-stage dialog by playing
+predetermined audio cues instead of using the live STT → LLM → TTS path.
+The presenter speaks naturally; Misty plays the next cue once silence is
+detected, with manual override controls available at all times.
+
+```powershell
+# Preview the ordered cue plan (no hardware needed)
+npx . conference dry-run
+
+# Generate TTS audio for all cues (requires orchestration service running)
+npx . conference prepare
+
+# Verify every cue has playable audio before showtime
+npx . conference verify
+
+# Live interactive stage runner (requires Misty + orchestration service)
+npx . conference run
+
+# Manual-only mode (no auto-advance, keyboard controls only)
+npx . conference run --no-auto
+```
+
+The default talk script is `talks/20260710-2.md`. Override with `--script`:
+
+```powershell
+npx . conference dry-run --script talks/my-talk.md
+npx . conference prepare --script talks/my-talk.md
+```
+
+**Live controls** (during `run`):
+
+| Key | Action |
+|---|---|
+| `n` / Enter | Play next cue |
+| `r` | Replay current cue |
+| `p` | Go back one cue |
+| Space | Pause / resume auto-advance |
+| `a` | Start auto-advance (listen for presenter silence) |
+| `s` / `q` | Stop and return Misty to rest state |
+
+**Notes:**
+- `npx . conference run` automatically stops the main controller service to free the laptop mic.
+- Auto-advance uses the laptop mic (configured via `LAPTOP_MIC_DEVICE`) to detect when the presenter finishes speaking (default: 2 s trailing silence).
+- Generated audio and the manifest are cached in `data/conference/`. Re-running `prepare` reuses unchanged cues.
+- Set `CONFERENCE_MODE_ENABLED=true` in `.env` to enable live mode.
+
+See [`docs/conference-mode.md`](docs/conference-mode.md) for full design documentation.
+
+---
+
 ## Testing
 
 `tests/test_integration.py` includes both fast mocked tests and live-service/hardware tests.

--- a/src/windows-orchestration/conference_mode.py
+++ b/src/windows-orchestration/conference_mode.py
@@ -941,20 +941,50 @@ def _build_live_controller(args):  # pragma: no cover - requires Misty + service
 
     robot = mc.MistyController()
 
+    # Start the laptop wake word listener explicitly — normally done inside
+    # MistyController.run(), but conference mode doesn't call run().  Needed for
+    # both self-wake suppression during playback and auto-advance VAD.
+    if getattr(mc, "USE_LAPTOP_WAKE_WORD", False):
+        try:
+            robot._start_laptop_wake_word()
+            # In conference mode, suppress the normal wake-word-fires-conversation
+            # callback. The listener is only used for its speech monitor (VAD) to
+            # detect when the presenter finishes speaking for auto-advance.
+            if robot._wake_word_listener is not None:
+                robot._wake_word_listener.on_wake_word = lambda: None
+        except Exception as exc:
+            logger.warning("Could not start laptop wake word listener: %s", exc)
+
     def play_fn(asset: CueAsset):
-        with open(asset.wav_path, "rb") as fh:
-            wav_bytes = fh.read()
-        filename = asset.misty_filename or os.path.basename(asset.wav_path)
-        duration = robot.upload_and_play_audio(wav_bytes, filename)
-        time.sleep(max(0.0, float(duration or 0.0)))
-        return duration
+        # Pause wake word during playback to prevent self-wake from Misty's speaker
+        listener = getattr(robot, "_wake_word_listener", None)
+        if listener is not None:
+            listener.pause()
+        try:
+            with open(asset.wav_path, "rb") as fh:
+                wav_bytes = fh.read()
+            filename = asset.misty_filename or os.path.basename(asset.wav_path)
+            duration = robot.upload_and_play_audio(wav_bytes, filename)
+            time.sleep(max(0.0, float(duration or 0.0)))
+            return duration
+        finally:
+            if listener is not None:
+                listener.resume()
 
     tts_fallback_backend = http_tts(ORCHESTRATION_URL)
 
     def tts_fallback_fn(text: str):
-        wav_bytes = tts_fallback_backend(text)
-        duration = robot.upload_and_play_audio(wav_bytes, "conference_fallback.wav")
-        time.sleep(max(0.0, float(duration or 0.0)))
+        # Pause wake word during fallback playback to prevent self-wake
+        listener = getattr(robot, "_wake_word_listener", None)
+        if listener is not None:
+            listener.pause()
+        try:
+            wav_bytes = tts_fallback_backend(text)
+            duration = robot.upload_and_play_audio(wav_bytes, "conference_fallback.wav")
+            time.sleep(max(0.0, float(duration or 0.0)))
+        finally:
+            if listener is not None:
+                listener.resume()
 
     def _release_audio():
         # First safe-shutdown step: release the mic/audio stack so keyphrase and

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -224,7 +224,7 @@ CONFERENCE_MISTY_FILENAME_PREFIX: str = "conf_"
 # available at all times regardless of this setting.
 CONFERENCE_AUTO_ADVANCE: bool = True
 # Seconds of trailing presenter silence that mark end-of-speech for auto-advance.
-CONFERENCE_PRESENTER_SILENCE_S: float = 1.5
+CONFERENCE_PRESENTER_SILENCE_S: float = 2.0
 # Maximum seconds to wait for the presenter to finish before an auto-advance
 # attempt gives up and yields to manual control (stage-safety timeout).
 CONFERENCE_PRESENTER_MAX_WAIT_S: float = 45.0

--- a/tests/test_conference_mode.py
+++ b/tests/test_conference_mode.py
@@ -569,6 +569,12 @@ def test_live_controller_wires_tts_fallback_flag_and_releases_listener(tmp_path,
         def stop(self):
             self.stopped = True
 
+        def pause(self):
+            pass
+
+        def resume(self):
+            pass
+
     class FakeRobot:
         def __init__(self):
             self.played = []

--- a/tools/misty-services.mjs
+++ b/tools/misty-services.mjs
@@ -40,6 +40,9 @@ Commands:
   stop      Gracefully stop the controller, orchestration service, and Foundry Local
   restart   Stop then start all services
   status    Show service status
+  conference <subcommand> [opts]
+            Run Conference Mode (scripted stage dialog).
+            Subcommands: dry-run, prepare, verify, run
 
 Options:
   --skip-foundry          Do not start or stop Foundry Local
@@ -54,6 +57,12 @@ Options:
   --yes                   Assume yes for install prompts
   --no-install            Do not prompt to install missing prerequisites
   -h, --help              Show this help
+
+Conference Mode (npx . conference <subcommand>):
+  dry-run [--script <path>]       Preview the ordered cue plan (no hardware)
+  prepare [--script <path>]       Generate/import/reuse cue audio + manifest
+  verify                          Confirm every cue has playable audio
+  run [--auto|--no-auto]          Live interactive stage runner (requires Misty)
 `);
 }
 
@@ -72,6 +81,11 @@ function parseArgs(argv) {
   };
   if (options.command === "-h" || options.command === "--help") {
     options.command = "help";
+  }
+
+  // Conference passes all remaining args through to conference_mode.py.
+  if (options.command === "conference") {
+    return options;
   }
 
   for (let index = 3; index < argv.length; index += 1) {
@@ -1161,6 +1175,53 @@ async function status(options) {
   console.log(`Misty controller: ${controller}${state.controller?.pid ? ` (PID ${state.controller.pid})` : ""}`);
 }
 
+async function conference(options) {
+  // Conference Mode delegates to conference_mode.py with the remaining argv.
+  // Usage: npx . conference <subcommand> [opts]
+  // e.g.:  npx . conference dry-run --script ../../talks/20260710-2.md
+  const subArgs = process.argv.slice(3); // everything after "conference"
+  if (subArgs.length === 0 || subArgs[0] === "--help" || subArgs[0] === "-h") {
+    console.log(`Usage: npx . conference <subcommand> [options]
+
+Subcommands:
+  dry-run [--script <path>]       Preview the ordered cue plan (no hardware)
+  prepare [--script <path>]       Generate/import/reuse cue audio + manifest
+  verify                          Confirm every cue has playable audio
+  run [--auto|--no-auto]          Live interactive stage runner (requires Misty)
+
+Options are passed directly to conference_mode.py.
+`);
+    return;
+  }
+
+  // For "run", stop the main controller service if it's running — it holds the
+  // laptop mic wake word listener and will conflict with conference mode.
+  const subcommand = subArgs[0];
+  if (subcommand === "run") {
+    const state = readState();
+    if (state.controller?.pid && isPidRunning(state.controller.pid)) {
+      console.log(`Stopping main controller (PID ${state.controller.pid}) to free laptop mic...`);
+      await stopPid("Misty controller", state.controller.pid, "SIGTERM");
+      delete state.controller;
+      writeState(state);
+    }
+  }
+
+  selectCompatiblePython(options);
+  const python = options.python;
+  const script = path.join(ORCH_DIR, "conference_mode.py");
+
+  if (!fs.existsSync(script)) {
+    throw new Error(`Conference Mode module not found: ${script}`);
+  }
+
+  console.log(`Running: ${python} conference_mode.py ${subArgs.join(" ")}`);
+  const result = runInherited(python, [script, ...subArgs], { cwd: ORCH_DIR });
+  if (result.status !== 0) {
+    process.exitCode = result.status ?? 1;
+  }
+}
+
 async function main() {
   const options = parseArgs(process.argv);
   switch (options.command) {
@@ -1176,6 +1237,9 @@ async function main() {
       break;
     case "status":
       await status(options);
+      break;
+    case "conference":
+      await conference(options);
       break;
     case "help":
       usage();


### PR DESCRIPTION
## Summary

Adds `npx . conference` CLI subcommand and fixes several issues discovered during live conference mode testing.

## Changes

### CLI (`tools/misty-services.mjs`)
- New `conference` subcommand with `dry-run`, `prepare`, `verify`, `run` passthrough to `conference_mode.py`
- Skips arg parsing for conference (passes all args through to Python)
- Auto-stops the main controller on `conference run` to free the laptop mic

### Self-wake prevention (`conference_mode.py`)
- Pause wake word listener during cue playback (both `play_fn` and `tts_fallback_fn`)
- Suppress wake word callback with no-op lambda in conference mode (listener only used for VAD)
- Explicitly start laptop wake word listener on controller construction (normally only done in `run()`)

### Auto-advance fix
- Start `_start_laptop_wake_word()` so the speech monitor is available for presenter VAD
- Bump `CONFERENCE_PRESENTER_SILENCE_S` from 1.5s → 2.0s to reduce early interruptions

### Documentation
- Add Conference Mode section to README with all commands, controls, and configuration notes

## Testing

- All 43 `tests/test_conference_mode.py` tests pass
- Verified live on-stage with Misty hardware (9 cues, auto-advance working)

## Related

- Partial close of #128
- Follow-up: #130 (expressions/movements)