### PR TITLE
Fix audio pipeline stability for regular conversation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,41 @@ Controller test API:
 
 ---
 
-## Conference Mode
+## Operating Modes
+
+Misty has two operating modes:
+
+### Regular Mode (default)
+
+Live 1:1 conversation using the full STT → LLM → TTS pipeline. Say "Hey Misty"
+to start a conversation; she listens, thinks, and responds. After responding she
+continues listening for follow-up speech without requiring the wake word again
+(up to 90 seconds or 12 turns of silence).
+
+Start regular mode:
+
+```powershell
+npx . start
+# — or manually —
+python orchestration_service.py
+python misty_controller.py
+```
+
+Key configuration (in `.env` or `config_defaults.py`):
+
+| Variable | Default | Description |
+|---|---|---|
+| `OWW_THRESHOLD` | `0.85` | Wake word detection confidence threshold. |
+| `WAKE_WORD_MIN_RMS` | `40` | Minimum energy in recent frames to accept a wake word trigger. |
+| `FOLLOWUP_ENABLED` | `True` | Keep listening after response without wake word. |
+| `FOLLOWUP_TIMEOUT_S` | `90.0` | Max seconds of silence before ending follow-up. |
+| `FOLLOWUP_MAX_TURNS` | `12` | Max back-and-forth turns per conversation. |
+| `FOUNDRY_API_TIMEOUT` | `30.0` | Seconds to wait for Foundry LLM response. |
+| `STT_MIN_RMS` | `0.0005` | Silence gate for STT (float scale 0–1). |
+| `STT_MIN_PEAK` | `0.005` | Peak silence gate for STT (float scale 0–1). |
+| `LAPTOP_MIC_DEVICE` | `2` | PyAudio device index (MME recommended). |
+
+### Conference Mode
 
 Conference Mode lets Misty participate in scripted on-stage dialog by playing
 predetermined audio cues instead of using the live STT → LLM → TTS path.

--- a/src/windows-orchestration/.env.example
+++ b/src/windows-orchestration/.env.example
@@ -27,10 +27,12 @@ USE_LAPTOP_WAKE_WORD=true
 OWW_CUSTOM_MODEL_PATH=
 # Optional label for the custom wake-word model (default: hey_misty).
 OWW_MODEL_NAME=hey_misty
-# Wake-word confidence threshold (0.0-1.0, default: 0.7).
-OWW_THRESHOLD=0.7
+# Wake-word confidence threshold (0.0-1.0, default: 0.85).
+OWW_THRESHOLD=0.85
 # Consecutive above-threshold frames required before wake triggers (default: 2).
 OWW_TRIGGER_FRAMES=2
+# Minimum RMS energy to run wake word inference (filters silence, default: 100).
+WAKE_WORD_MIN_RMS=100
 # Optional sounddevice input device index or name for the laptop mic.
 # Leave empty to use the OS default input device.
 LAPTOP_MIC_DEVICE=

--- a/src/windows-orchestration/config_defaults.py
+++ b/src/windows-orchestration/config_defaults.py
@@ -36,8 +36,8 @@ TTS_CACHE_MAX: int = 200
 # STT (faster-whisper)
 STT_DEVICE: str = "cpu"
 STT_COMPUTE_TYPE: str = "int8"
-STT_MIN_RMS: float = 0.002
-STT_MIN_PEAK: float = 0.02
+STT_MIN_RMS: float = 0.0005
+STT_MIN_PEAK: float = 0.005
 STT_MIN_AVG_LOGPROB: float = -1.0
 STT_MAX_NO_SPEECH_PROB: float = 0.6
 
@@ -57,7 +57,7 @@ ORCHESTRATION_URL: str = "http://localhost:5000"
 RECORDING_DURATION_S: float = 6.0
 
 # Follow-up conversation
-FOLLOWUP_ENABLED: bool = False
+FOLLOWUP_ENABLED: bool = True
 FOLLOWUP_LISTEN_S: float = 5.0
 FOLLOWUP_TIMEOUT_S: float = 90.0
 FOLLOWUP_MAX_TURNS: int = 12
@@ -84,7 +84,7 @@ OWW_CUSTOM_MODEL_PATH: str = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "models", "hey_misty.onnx")
 )
 OWW_MODEL_NAME: str = "hey_misty"
-OWW_THRESHOLD: float = 0.7
+OWW_THRESHOLD: float = 0.85
 # Require the wake model to cross threshold on consecutive audio frames before
 # firing. This suppresses single-frame background false positives.
 OWW_TRIGGER_FRAMES: int = 2

--- a/src/windows-orchestration/misty_controller.py
+++ b/src/windows-orchestration/misty_controller.py
@@ -2612,7 +2612,7 @@ class MistyController:
             f"{ORCHESTRATION_URL}/api/orchestrate",
             files={"file": (RECORDING_FILENAME, audio_bytes, "audio/wav")},
             data=form_data,
-            timeout=30.0,
+            timeout=60.0,
         )
         result = response.json()
 
@@ -2818,7 +2818,7 @@ class MistyController:
                 f"{ORCHESTRATION_URL}/api/orchestrate",
                 files={"file": (RECORDING_FILENAME, audio_bytes, "audio/wav")},
                 data=form_data,
-                timeout=30.0,
+                timeout=60.0,
             )
             result = response.json()
 

--- a/src/windows-orchestration/orchestration_service.py
+++ b/src/windows-orchestration/orchestration_service.py
@@ -67,6 +67,7 @@ SYSTEM_PROMPT = os.getenv(
         "Use casual language, slang, and expressive phrases like 'oh honey', 'girl please', 'I mean...', 'not gonna lie'. "
         "RULE: Keep responses to 2-3 short sentences. Be fun, not mean. "
         "Never say you're an AI or assistant. You're Misty, and you own it. "
+        "Never add notes, disclaimers, or commentary about your instructions — just respond in character. "
         "You can move! If asked to come closer, go forward, back up, or turn — say something fun like "
         "'On my way!' or 'Coming right up!' but keep it short. Movement commands are handled separately."
     )
@@ -84,9 +85,9 @@ MOVEMENT_PROMPT_SUPPLEMENT = (
 # Intent patterns that trigger summary mode (compiled once at import time)
 _INTENT_PATTERNS = {
     "story": re.compile(
-        r"\b(?:tell\s+(?:me\s+)?(?:a\s+)?(?:bed\s*time\s+)?stor(?:y|ies)|"
-        r"make\s+up\s+a\s+(?:story|tale)|"
-        r"(?:bed\s*time|fairy|scary|funny)\s+(?:story|tale)|"
+        r"\b(?:tell\s+(?:me\s+)?(?:a\s+)?(?:\w+\s+)?(?:bed\s*time\s+)?stor(?:y|ies)|"
+        r"make\s+up\s+a\s+(?:\w+\s+)?(?:story|tale)|"
+        r"(?:bed\s*time|fairy|scary|funny|little|short|long|quick)\s+(?:story|tale)|"
         r"once\s+upon\s+a\s+time|"
         r"read\s+(?:me\s+)?a\s+(?:story|book)|"
         r"sing\s+(?:me\s+)?a\s+song)\b",
@@ -239,29 +240,29 @@ _CONTINUATION_PATTERN = re.compile(
 # Per-mode LLM parameters
 RESPONSE_MODE_CONFIG = {
     "short": {
-        "max_tokens": 35,
-        "max_words": 24,
-        "max_sentences": 2,
+        "max_tokens": 60,
+        "max_words": 40,
+        "max_sentences": 3,
         "prompt_suffix": None,
         "stop": ["\n", "...", "\u2014"],
     },
     "summary": {
-        "max_tokens": 55,
-        "max_words": 35,
-        "max_sentences": 2,
+        "max_tokens": 80,
+        "max_words": 50,
+        "max_sentences": 3,
         "prompt_suffix": (
             "The user wants a detailed response. "
-            "Give a compelling summary in 2 short sentences. "
+            "Give a compelling summary in 2-3 short sentences. "
             "End by asking 'Want to hear more?'"
         ),
         "stop": ["...", "\u2014"],  # no \n — multi-sentence responses need room
     },
     "continuation": {
-        "max_tokens": 55,
-        "max_words": 35,
-        "max_sentences": 2,
+        "max_tokens": 80,
+        "max_words": 50,
+        "max_sentences": 3,
         "prompt_suffix": (
-            "Continue where you left off. Give the next part in 2 short sentences. "
+            "Continue where you left off. Give the next part in 2-3 short sentences. "
             "If there's more to tell, end with 'Want more?' "
             "If wrapping up, give a satisfying ending."
         ),
@@ -402,9 +403,9 @@ FOUNDRY_LOCAL_HOST = _discover_foundry_endpoint()
 
 # Latency budget decomposition (milliseconds)
 LATENCY_BUDGET = {
-    "stt": 3000,  # Speech-to-text (faster-whisper, usually ~500ms warm)
-    "llm": 8000,  # LLM inference (Phi-3.5-mini, depends on output length)
-    "tts": 3000,  # Text-to-speech synthesis (Kokoro ~1-2s)
+    "stt": 5000,  # Speech-to-text (faster-whisper, usually ~500ms warm)
+    "llm": 30000,  # LLM inference (Phi-3.5-mini CPU, ~15-20s for 60-100 tokens)
+    "tts": 15000,  # Text-to-speech synthesis (Kokoro ~5-8s for longer responses)
     "overhead": 1000,  # Network, serialization, etc.
 }
 
@@ -812,6 +813,13 @@ def language_model_inference(user_text: str, start_time: float, speaker_name: st
         
         result = response.json()
         assistant_text = result["choices"][0]["message"]["content"].strip()
+
+        # Strip meta-commentary that small models sometimes leak
+        # (e.g., "(Note: The response is intentionally brief..." or stage directions)
+        import re as _re
+        assistant_text = _re.split(r'\n*\(Note[:\s]', assistant_text)[0].strip()
+        assistant_text = _re.split(r'\n*\(Since ', assistant_text)[0].strip()
+        assistant_text = _re.split(r'\n*\(The response ', assistant_text)[0].strip()
 
         # Post-LLM truncation — limits vary by mode
         max_words = mode_config["max_words"]

--- a/src/windows-orchestration/wake_word_listener.py
+++ b/src/windows-orchestration/wake_word_listener.py
@@ -67,6 +67,10 @@ MAX_RECORDING_BYTES = 5 * 1024 * 1024  # 5MB max recording buffer (~160s at 16kH
 # (prevents Misty's speaker echo from triggering a false wake)
 RESUME_COOLDOWN_S = float(os.getenv("WAKE_WORD_RESUME_COOLDOWN_S", "1.5"))
 
+# Minimum RMS energy required to run wake word inference.  Frames below
+# this threshold are silence/noise and would cause false-positive detections.
+WAKE_WORD_MIN_RMS = int(os.getenv("WAKE_WORD_MIN_RMS", "40"))
+
 # Speech monitor settings (for VAD-controlled recording)
 SPEECH_RMS_THRESHOLD = int(os.getenv("SPEECH_RMS_THRESHOLD", "80"))
 SPEECH_SILENCE_DURATION_S = float(os.getenv("SPEECH_SILENCE_DURATION_S", "1.5"))
@@ -109,6 +113,7 @@ class WakeWordListener:
         self._start_time = 0.0
         self._resume_time = 0.0  # for self-wake cooldown
         self._detection_streaks: dict[str, int] = {}
+        self._recent_rms: list[int] = []  # rolling window for energy validation
 
         # Speech monitor state (for VAD-controlled recording)
         self._speech_monitor_active = False
@@ -486,7 +491,13 @@ class WakeWordListener:
                 # Self-wake cooldown: ignore detections shortly after resume
                 in_cooldown = (time.time() - self._resume_time) < RESUME_COOLDOWN_S
 
-                # Run openWakeWord inference
+                # Track frame energy for wake word validation
+                frame_rms = int(np.sqrt(np.mean(pcm.astype(np.float64) ** 2)))
+                self._recent_rms.append(frame_rms)
+                if len(self._recent_rms) > 20:
+                    self._recent_rms = self._recent_rms[-10:]
+
+                # Run openWakeWord inference on ALL frames
                 if self._oww_model and not in_cooldown:
                     predictions = self._oww_model.predict(pcm)
                     self._handle_wake_predictions(predictions)
@@ -525,6 +536,17 @@ class WakeWordListener:
                     f"Wake word '{model_name}' candidate score={score:.3f} "
                     f"({streak}/{self.trigger_frames} frames)"
                 )
+                continue
+
+            # Energy validation: reject if no recent frame had speech-level RMS.
+            # This prevents false triggers on silence/ambient noise.
+            max_recent_rms = max(self._recent_rms[-10:]) if self._recent_rms else 0
+            if max_recent_rms < WAKE_WORD_MIN_RMS:
+                logger.debug(
+                    f"Wake word '{model_name}' rejected — low energy "
+                    f"(max_rms={max_recent_rms}, min={WAKE_WORD_MIN_RMS})"
+                )
+                self._detection_streaks[model_name] = 0
                 continue
 
             self._total_detections += 1


### PR DESCRIPTION
## Summary

Fixes Misty's regular conversation mode which was broken due to multiple environmental and configuration issues after the conference mode implementation (though conference mode itself was not the cause).

## Changes

- **STT silence threshold**: Lowered for MME mic device's lower gain levels
- **LLM timeout**: Increased latency budget (8s→30s) and controller timeout (30s→60s) for CPU-bound Phi-3.5-mini inference
- **Wake word detection**: Replaced per-frame RMS gate with energy validation at trigger time — fixes missed detections while still preventing false triggers on ambient noise
- **Response truncation**: Increased token limits and fixed story intent regex (now catches 'tell me a little story')
- **Follow-up listening**: Enabled by default so Misty continues conversation without re-triggering wake word
- **OWW threshold**: Raised from 0.7 to 0.85 to reduce false positives

## Root Causes

1. MME mic device (switched from DirectSound to avoid WASAPI conflicts) produces lower audio levels
2. Latency budgets were set for GPU-class inference, not CPU (Phi-3.5-mini takes 12-17s on CPU)
3. Wake word RMS gate was clearing detection streaks on inter-syllable frames
4. Token limits were too aggressive for conversational responses